### PR TITLE
Fix stale E2E navigation after Automation tab

### DIFF
--- a/frontend/e2e/export-approval-gate.spec.js
+++ b/frontend/e2e/export-approval-gate.spec.js
@@ -98,6 +98,8 @@ test.describe("Export approval gate", () => {
 		await page.getByRole("button", { name: /generate from \d+ approved/i }).click();
 		await expect(page.getByText(/Needs additional negative coverage/i)).toBeVisible();
 		await page.getByRole("button", { name: /^Next$/ }).click();
+		await expect(page.getByRole("heading", { name: /^Automation$/i })).toBeVisible();
+		await page.getByRole("button", { name: /^Next$/ }).click();
 
 		const jsonButton = page.getByRole("button", { name: /json/i }).first();
 		await expect(page.getByText(/Export locked by review gate/i)).toBeVisible();

--- a/frontend/e2e/jira-workflow.spec.js
+++ b/frontend/e2e/jira-workflow.spec.js
@@ -271,18 +271,22 @@ test.describe("JIRA requirements workflow", () => {
 		await page.getByRole("button", { name: /close settings dialog/i }).click();
 		await expect(page.getByRole("dialog", { name: /^settings$/i })).toBeHidden();
 
-		await page.getByRole("button", { name: /jira cloud/i }).click();
+		await page.getByRole("radio", { name: /jira cloud/i }).check();
+		await expect(page.getByRole("heading", { name: /import from jira/i })).toBeVisible();
 		const projectSelect = page.locator(".jira-search-grid select").first();
 		await expect(projectSelect).toContainText("PROJ — Platform Finance");
 		await expect(projectSelect).toHaveValue("PROJ");
 
 		await page.getByRole("button", { name: /^Search$/ }).click();
-		await expect(page.locator(".jira-issue-card")).toContainText(["PROJ-101"]);
-		await page.locator(".jira-issue-card", { hasText: "PROJ-101" }).click();
+		const jiraIssueOption = page.getByRole("radio", { name: /select jira issue proj-101/i });
+		await expect(jiraIssueOption).toBeVisible();
+		await jiraIssueOption.check();
 		await page.getByRole("button", { name: /Import PROJ-101/i }).click();
 
-		await expect(page.locator(".requirements-list li")).toHaveCount(2);
-		await expect(page.getByText("JIRA PROJ-101")).toHaveCount(2);
+		const requirementRows = page.locator(".requirement-review-table tbody tr");
+		await expect(requirementRows).toHaveCount(2);
+		await expect(requirementRows.nth(0)).toContainText("REQ-101");
+		await expect(requirementRows.nth(1)).toContainText("REQ-102");
 		await expect(page.getByRole("heading", { name: /jira sync preview/i })).toBeVisible();
 
 		await page.getByPlaceholder(/Enter your feedback here/i).fill("Make the approval notifications explicit and tighten the language.");
@@ -290,7 +294,9 @@ test.describe("JIRA requirements workflow", () => {
 
 		await expect(page.getByText(/duplicate checks/i)).toBeVisible();
 		await expect(page.getByText(/notification recipients/i)).toBeVisible();
-		await expect(page.getByText("JIRA PROJ-101")).toHaveCount(2);
+		await expect(requirementRows).toHaveCount(2);
+		await expect(requirementRows.nth(0)).toContainText("PROJ-101");
+		await expect(requirementRows.nth(1)).toContainText("PROJ-101");
 
 		await page.getByRole("button", { name: /preview jira update/i }).click();
 		await expect(page.getByText(/Ready 1/)).toBeVisible();

--- a/frontend/e2e/workflow.spec.js
+++ b/frontend/e2e/workflow.spec.js
@@ -93,6 +93,8 @@ test.describe("Agentic Test Case Generator E2E", () => {
 		await generatedTestCasesTab.click();
 
 		await page.getByRole("button", { name: /^Next$/ }).click();
+		await expect(page.getByRole("heading", { name: /^Automation$/i })).toBeVisible();
+		await page.getByRole("button", { name: /^Next$/ }).click();
 		const draftExportToggle = page.getByLabel(/export draft anyway/i);
 		if (await draftExportToggle.isVisible().catch(() => false)) {
 			await draftExportToggle.check();


### PR DESCRIPTION
## Summary
- Update export E2E flows to navigate through Automation before asserting Export controls.
- Update JIRA workflow E2E to use current radio/table controls instead of stale button/card/list selectors.

Closes #32

## Validation
- `npm run test:e2e -- jira-workflow.spec.js` passed: 1 test.
- `npm run test:e2e -- export-approval-gate.spec.js jira-workflow.spec.js` passed: 2 tests.
- `npm run test:e2e -- workflow.spec.js` passed: 3 tests.
- `npm run test:e2e` passed: 4 tests.
- `npm run build` passed.

## Observations
- The initial authenticated E2E failure was caused by a local test launch mismatch: Python backend loads `.env` with override, while the Node E2E helper honored the command-line `JWT_SECRET_KEY`. Running with the repo-local `.env` aligned auth successfully.
- The model-backed generation path remains slow and can produce draft-quality output; the E2E flow now correctly proceeds through the draft override path when needed.