### PR TITLE
Add codebase docs and concern backlog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,26 @@ use the `type:epic` label and link child stories/tasks from the epic body.
 10. Comment on the issue with the implementation summary, validation results,
     and any follow-up work.
 
+## Branch Protection
+
+The GitHub `main` branch is protected. Do not push directly to `main`.
+
+Required merge path:
+
+- Work on an issue-scoped branch, normally
+  `codex/issue-<number>-<short-slug>`.
+- Open a pull request linked to the issue.
+- Keep the branch up to date with `main` before merge.
+- Resolve all pull request conversations before merge.
+- Required approvals: 0. This repository is currently solo-maintained, so a PR
+  is still required for traceability and CI, but approving reviews are not.
+- Required status checks:
+  - `Backend tests and offline benchmarks`
+  - `Frontend build and focused E2E`
+
+Force pushes and deletion of `main` are blocked. Admin enforcement is enabled,
+so the protected-branch workflow applies to maintainers too.
+
 ## Local Environment
 
 Use the repo-local Python virtual environment for backend work. Do not rely on
@@ -172,4 +192,3 @@ A change is complete only when:
 - Documentation is updated for changed workflow, API, configuration, or behavior.
 - The pull request is linked to the issue and clearly summarizes what changed.
 - Follow-up work is captured as linked issues instead of hidden TODOs.
-

--- a/README.md
+++ b/README.md
@@ -13,6 +13,16 @@ Web-based, human-in-the-loop workflow for parsing requirements (Word/Markdown/Ex
 - Preview generated test cases for browser automation readiness and run approved executable candidates with Playwright
 - No document retention (in-memory processing only)
 
+## Documentation Map
+
+- `docs/codebase/STACK.md` describes runtimes, dependencies, commands, and environment configuration.
+- `docs/codebase/STRUCTURE.md` maps source directories, entry points, and module boundaries.
+- `docs/codebase/ARCHITECTURE.md` explains the backend, frontend, agent, integration, and execution-runtime flow.
+- `docs/codebase/CONVENTIONS.md` captures naming, routing, error handling, logging, and testing conventions.
+- `docs/codebase/INTEGRATIONS.md` inventories Firebase, Gemini/ADK, Firestore, JIRA, Azure DevOps, Playwright, and observability integrations.
+- `docs/codebase/TESTING.md` lists validation gates and folds in the reproducible Playwright documentation E2E workflow for the next version.
+- `docs/codebase/CONCERNS.md` records high-churn areas, technical debt, security/scaling concerns, and open architecture questions.
+
 ## Setup
 
 ### 1) Configure environment

--- a/docs/codebase/ARCHITECTURE.md
+++ b/docs/codebase/ARCHITECTURE.md
@@ -1,0 +1,188 @@
+# Architecture
+
+## 1) Architectural Style
+
+Primary style: modular monolith with a layered backend, a React single-page
+frontend, and an isolated Playwright execution runtime.
+
+Why this classification:
+
+- `backend/app/main.py` creates one FastAPI application and registers feature
+  routers from `backend/app/routers/`.
+- Routers delegate domain behavior to service modules, agent modules, adapters,
+  and Pydantic contracts in `backend/app/models.py`.
+- The frontend is one Vite React app with `App.jsx` as top-level workflow
+  orchestration and focused components under `frontend/src/components/`.
+- Browser execution is split into a backend Python conversion/service path and
+  a Node Playwright runtime under `backend/execution_runtime/`.
+
+Primary constraints:
+
+- User-facing workflow is human-in-the-loop: requirements are parsed/reviewed,
+  context can be enriched, test cases are generated/reviewed, exports are gated,
+  and execution candidates are previewed before running.
+- Agent output must be resilient: parsers, deterministic fallbacks, retry
+  diagnostics, and heuristic quality gates protect the workflow from malformed
+  model output.
+- Source artifacts and credentials must not be retained in git. Generated
+  execution artifacts, screenshots, exports, and client briefs are ignored.
+
+## 2) Visual Architecture
+
+```mermaid
+flowchart LR
+    user["Signed-in user"]
+    browser["React/Vite frontend\nfrontend/src/App.jsx\nfrontend/src/components"]
+    apiClient["API helper\nfrontend/src/services/apiClient.js"]
+
+    app["FastAPI app\nbackend/app/main.py"]
+    middleware["Request middleware\nrequest_id, trace_id,\nlogging, metrics"]
+    routers["Feature routers\nrequirements, testcases,\nautomation, export,\nintegrations, billing, reports"]
+    auth["Auth layer\nFirebase ID token\nlegacy JWT\nGoogle credential login"]
+    models["Pydantic contracts\nbackend/app/models.py"]
+
+    agents["Agent workflows\nADK/Gemini\nrequirements, analysis,\ntest generation, automation"]
+    services["Domain services\naudit, billing, versioning,\ngrounding, execution, reporting"]
+    adapters["Provider adapters\nJIRA Cloud\nAzure DevOps"]
+    petf["Plain-English test framework\nspec parser -> IR ->\nPlaywright generator"]
+    runtime["Execution runtime\nbackend/execution_runtime\nnpx playwright test"]
+
+    gemini["Gemini API"]
+    firebase["Firebase Auth\nFirestore"]
+    jira["JIRA Cloud API"]
+    ado["Azure DevOps API"]
+    artifacts["Local generated artifacts\n.execution_artifacts\n/tmp/pw_workflow_out"]
+    metrics["/metrics\nPrometheus format"]
+
+    user --> browser
+    browser --> apiClient
+    apiClient --> app
+    app --> middleware
+    middleware --> routers
+    routers --> auth
+    routers --> models
+    routers --> agents
+    routers --> services
+    services --> adapters
+    services --> petf
+    petf --> runtime
+
+    agents --> gemini
+    auth --> firebase
+    services --> firebase
+    adapters --> jira
+    adapters --> ado
+    runtime --> artifacts
+    services --> artifacts
+    middleware --> metrics
+
+    routers --> browser
+```
+
+The diagram shows the main request path and the two important side paths:
+agent-backed generation through Gemini, and executable browser automation
+through the plain-English framework plus the isolated Playwright runtime.
+
+## 3) System Flow
+
+```text
+React UI -> FastAPI router -> billing/audit guard -> agent/service/adapters -> Firestore/external API/local artifacts -> Pydantic response -> React UI
+```
+
+Typical generate flow:
+
+1. The frontend sends authenticated API requests through helpers in
+   `frontend/src/services/apiClient.js` and auth/session orchestration in
+   `frontend/src/App.jsx`.
+2. FastAPI middleware in `backend/app/main.py` attaches `X-Request-ID`, optional
+   trace context, structured request logging, and HTTP metrics.
+3. A router in `backend/app/routers/` resolves `AuthUser`, starts an audit
+   workflow, checks billing where relevant, validates Pydantic request models,
+   and delegates work.
+4. Agent modules such as `backend/app/adk_client.py`,
+   `backend/app/agents/analysis_agent.py`, and
+   `backend/app/agents/test_case_agent.py` orchestrate model calls, parsing,
+   review loops, metrics, and deterministic fallback output.
+5. Service modules persist audit/version/billing/integration metadata through
+   Firestore helpers where configured, or return warnings/fallback behavior
+   where the code explicitly supports missing Firestore.
+6. The router completes audit and billing records, then returns Pydantic
+   response models for the frontend to render diagnostics, coverage,
+   traceability, exports, or execution results.
+
+Next-version execution flow:
+
+```text
+Generated TestCase -> /automation/execution/preview -> executable candidates
+selected candidates -> YAML spec -> IR JSON -> Playwright TS spec -> npx playwright test -> report artifacts
+```
+
+The conversion and run path is implemented by
+`backend/app/services/execution_service.py` and
+`backend/plain_english_test_framework/`, with Node runtime configuration in
+`backend/execution_runtime/playwright.config.ts`.
+
+## 4) Layer/Module Responsibilities
+
+| Layer or module | Owns | Must not own | Evidence |
+|-----------------|------|--------------|----------|
+| FastAPI app | App construction, middleware, CORS, router registration, health, metrics | Feature endpoint logic beyond global middleware | `backend/app/main.py` |
+| Routers | HTTP contracts, auth dependencies, audit lifecycle calls, billing access calls, endpoint-level errors | Provider HTTP implementation or model prompt design | `backend/app/routers/*.py` |
+| Models | Pydantic request/response/data contracts | Runtime business behavior | `backend/app/models.py` |
+| Agents | Requirement extraction, analysis, test-case generation, review/refinement loops, deterministic fallback generation, automation POM generation | HTTP transport and UI rendering | `backend/app/adk_client.py`, `backend/app/agents/*.py` |
+| Services | Billing, audit, versioning, reporting, Firestore-backed persistence, execution conversion/run, context grounding | Route decorators or React state | `backend/app/services/*.py` |
+| Adapters | JIRA and Azure DevOps remote API calls and provider-specific normalization | Cross-provider workflow policy | `backend/app/adapters/*.py` |
+| Auth | Firebase token verification, legacy JWT decoding, Google credential login, role/admin checks | Billing, generation, or integration sync logic | `backend/app/auth/*.py` |
+| Observability | JSON logging, request context, metrics rendering, optional tracing | Business decisions | `backend/app/observability/*.py` |
+| Plain-English framework | Spec parsing, secret detection, environment/data resolution, schema-valid IR generation, Playwright spec generation, local runner | User auth, billing, external integrations | `backend/plain_english_test_framework/*.py` |
+| React app | User workflow state, auth session, component composition, API actions | Backend persistence or agent logic | `frontend/src/App.jsx`, `frontend/src/components/` |
+
+## 5) Reused Patterns
+
+| Pattern | Where found | Why it exists |
+|---------|-------------|---------------|
+| FastAPI dependency auth | `Depends(get_current_user)` in routers | Keeps protected endpoint identity resolution consistent |
+| Pydantic boundary models | `backend/app/models.py` | Keeps backend API, integration, billing, execution, and export payloads explicit |
+| Workflow audit lifecycle | `start_workflow_run()`, `complete_workflow_run()`, `record_usage_event()` | Links operations to request IDs, users, billing, reports, and trace metadata |
+| Deterministic fallback | Requirement/test-case agents and automation agent | Keeps workflow usable when model output is malformed, unavailable, or incomplete |
+| Safe artifact fetch | `artifact_fetcher.py` plus `context_grounding.py` | Blocks unsafe URLs and returns partial enrichment instead of crashing |
+| Provider adapter plus service | JIRA and Azure DevOps adapter/service pairs | Separates remote API mechanics from import/sync workflow policy |
+| Local fake/patch tests | `backend/tests/test_*` | Keeps tests independent from real Firestore, JIRA, Azure DevOps, Firebase, and model calls |
+| Generated artifact isolation | `.execution_artifacts/`, `client_submission/`, runtime artifact directories | Prevents local outputs, traces, screenshots, and exports from becoming source |
+
+## 6) Known Architectural Risks
+
+- `backend/app/agents/test_case_agent.py`, `frontend/src/App.jsx`, and
+  `frontend/src/App.css` remain large, high-churn files. They mix multiple
+  responsibilities and require focused, well-tested slices for future changes.
+- `backend/app/models.py` contains many product domains in one file. This keeps
+  contracts discoverable but increases merge and review risk as the API grows.
+- Current auth supports Firebase ID tokens and legacy/backend JWT tokens. This
+  helps local/E2E workflows, but it can confuse production auth policy unless
+  the intended long-term mode remains documented.
+- Firestore is the current durable service path for audit, versioning, billing,
+  integration mappings, and reports, while older architecture docs recommend
+  Postgres as a target. The target persistence architecture needs explicit
+  product/operational confirmation.
+- The execution runtime shells out to `npx playwright test`. The artifact root,
+  runtime cwd, browser channel, and generated paths need careful configuration
+  in every deployment environment.
+
+## 7) Evidence
+
+- `backend/app/main.py`
+- `backend/app/models.py`
+- `backend/app/routers/requirements.py`
+- `backend/app/routers/testcases.py`
+- `backend/app/routers/automation.py`
+- `backend/app/services/execution_service.py`
+- `backend/plain_english_test_framework/compiler.py`
+- `backend/plain_english_test_framework/local_runner.py`
+- `backend/app/services/artifact_fetcher.py`
+- `backend/app/services/context_grounding.py`
+- `backend/app/services/audit_service.py`
+- `backend/app/services/billing_service.py`
+- `frontend/src/App.jsx`
+- `frontend/src/components/`
+- `frontend/src/services/apiClient.js`
+- `backend/execution_runtime/playwright.config.ts`

--- a/docs/codebase/CONCERNS.md
+++ b/docs/codebase/CONCERNS.md
@@ -1,0 +1,83 @@
+# Codebase Concerns
+
+This document records risks visible from the current tracked source, docs, and
+git/history checks. It is not a full bug backlog.
+
+## 1) Top Risks
+
+| Severity | Concern | Evidence | Impact | Suggested action |
+|----------|---------|----------|--------|------------------|
+| High | Large, high-churn orchestration files remain central to the app | `frontend/src/App.jsx`, `frontend/src/App.css`, `backend/app/agents/test_case_agent.py`, `backend/app/models.py`, recent git history | Higher regression and merge risk for UI workflow and generation behavior | Continue behavior-preserving extraction under issue-scoped frontend and agent refactor tasks |
+| High | Persistence target is not fully settled in docs versus code | `docs/firebase-auth-audit-architecture.md`, `backend/app/services/firebase_admin.py`, `backend/app/services/billing_repository.py` | Architecture decisions can drift between Firestore current state and Postgres target recommendations | Decide whether Firestore remains the near-term durable store or whether Postgres migration is active |
+| Medium | Dual auth support can blur production policy | `backend/app/auth/jwt_auth.py`, `backend/app/auth/firebase_auth.py`, `backend/app/routers/auth.py`, `frontend/src/App.jsx` | Local/E2E JWT compatibility is useful, but production paths need clear accepted-token policy | Document deployment auth mode and eventually remove or isolate legacy JWT if no longer needed |
+| Medium | `.env.example` duplicates execution settings | `.env.example` lines 34-50 | Increases setup confusion and risk of stale values | Deduplicate the repeated execution block in a focused docs/config cleanup issue |
+| Medium | Generated artifacts can dominate local scans | `.gitignore`, `.execution_artifacts/`, `client_submission/` ignore rules | Repository analysis can report generated traces/reports instead of source complexity | Keep ignored artifact cleanup in local workflow and tune future scan scripts to exclude ignored directories |
+| Medium | No enforced formatter/linter configuration is tracked | `frontend/package.json`, `backend/requirements.txt`, `.github/workflows/ci.yml` | Style drift and avoidable review noise | Add formatter/linter tooling under a dedicated issue |
+| Medium | Metrics endpoint exposure depends on deployment perimeter | `backend/app/main.py`, `backend/app/observability/metrics.py` | `/metrics` may expose operational metadata if public deployments do not protect it | Decide deployment access policy for `/metrics` |
+
+## 2) Technical Debt
+
+| Debt item | Why it exists | Where | Risk if ignored | Suggested fix |
+|-----------|---------------|-------|-----------------|---------------|
+| Monolithic frontend orchestration | `App.jsx` still owns most workflow state and API actions after component extraction | `frontend/src/App.jsx` | Harder UI changes and fragile E2E updates | Extract workflow state into hooks/reducers in small issue-scoped slices |
+| Large global stylesheet | Many feature styles still live in one CSS file | `frontend/src/App.css` | Dead styles and visual regressions become harder to audit | Split CSS by foundation and feature ownership |
+| Large generation agent | Test-case generation, review, metrics, fallback, normalization, and prompting still share one module | `backend/app/agents/test_case_agent.py` | Agent behavior changes are difficult to isolate | Split orchestration, normalization, coverage metrics, fallback, and prompt helpers gradually |
+| Broad model module | Many product domains share one Pydantic file | `backend/app/models.py` | Contract merge conflicts and long review cycles | Split model modules only after router/service ownership boundaries are stable |
+| Older roadmap/doc drift | Some docs describe work as future that is partly implemented now | `docs/implementation-plan.md`, `docs/frontend-refactor-github-issues.md` | Contributors may follow stale sequencing | Add "current state" notes or close superseded plan sections during planning updates |
+| No generated frontend API types | Frontend manually consumes backend response shapes | `frontend/src/App.jsx`, `scripts/export_openapi.py` | Response-shape drift can escape until runtime/E2E | Generate frontend types from OpenAPI in a dedicated contract issue |
+
+## 3) Security Concerns
+
+| Risk | OWASP category | Evidence | Current mitigation | Gap |
+|------|----------------|----------|--------------------|-----|
+| Stored integration credentials | A02 Cryptographic Failures | `jira_connection_service.py`, `azure_devops_connection_service.py` | Fernet encryption using dedicated secret or JWT secret fallback; token hints only | Rotation and secret lifecycle are not documented |
+| SSRF through artifact URLs | A10 Server-Side Request Forgery | `artifact_fetcher.py` | Blocks local/private/non-routable hosts, unsafe schemes, and redirect abuse | Continued hardening needed before broad production use with authenticated/internal artifacts |
+| Browser token storage | A07 Identification and Authentication Failures | `frontend/src/App.jsx`, `README.md` | Firebase token verification and backend auth checks | `localStorage` token storage remains MVP-level risk |
+| Metrics endpoint exposure | A05 Security Misconfiguration | `backend/app/main.py` | Endpoint is schema-hidden and contains operational metrics rather than secrets | Deployment access control is not documented |
+| Generated artifacts may contain sensitive content if real data is used | A01 Broken Access Control / data exposure | `.gitignore`, `docs/client-submission-workflow.md`, `execution_service.py` | Generated directories are ignored; docs warn against committing client data | Local retention and cleanup policy is not formalized |
+
+## 4) Performance and Scaling Concerns
+
+| Concern | Evidence | Current symptom | Scaling risk | Suggested improvement |
+|---------|----------|-----------------|-------------|-----------------------|
+| Long-running agent workflows | `adk_client.py`, `test_case_agent.py`, `scripts/e2e_playwright_workflow.py` | E2E script sets a 600 second timeout | Request/response flows can tie up workers under load | Consider background jobs or async workflow state once product usage grows |
+| In-process execution subprocesses | `execution_service.py`, `local_runner.py` | Backend shells out to `npx playwright test` | CPU/browser resource contention in multi-user deployments | Add queueing, concurrency limits, and artifact retention policy |
+| Firestore reads for reporting/billing | `reporting_service.py`, `billing_repository.py` | Tests cover fallback/warning behavior | Large usage-event history may become expensive or slow | Add rollups or a relational analytics store if usage grows |
+| Large frontend state tree | `frontend/src/App.jsx` | Many workflow states in one component | Re-renders and maintenance overhead | Move domain state into hooks/reducers and memoize expensive derived views if needed |
+| Local artifact growth | `.execution_artifacts/`, `client_submission/` | Generated outputs are ignored but not auto-pruned | Disk growth and noisy local scans | Add cleanup command or retention guidance |
+
+## 5) Fragile/High-Churn Areas
+
+| Area | Why fragile | Churn signal | Safe change strategy |
+|------|-------------|--------------|----------------------|
+| `frontend/src/App.jsx` | Owns auth, workflow state, API actions, derived metrics, and layout orchestration | Highest recent git churn among tracked source hotspots; 3013 lines | Keep changes focused and cover with frontend build/E2E |
+| `frontend/src/App.css` | Large global stylesheet with feature-specific selectors | High churn and 3478 lines | Move styles by feature only with visual checks |
+| `backend/app/agents/test_case_agent.py` | Central generation/review/coverage/fallback pipeline | High churn and 3245 lines | Add focused tests for every behavior slice before refactor |
+| `backend/app/models.py` | Shared API contracts for many domains | High churn and 1047 lines | Treat changes as contract changes; run OpenAPI export |
+| Integration sync routers/services | JIRA and Azure DevOps have parallel flows with provider-specific edge cases | Recent traceability and test isolation work | Change one provider at a time or keep explicit parity tests |
+| Execution runtime | Converts natural language cases into runnable browser specs | New next-version E2E capability | Run execution preview and runtime checks for every change |
+
+## 6) `[ASK USER]` Questions
+
+1. [ASK USER] Should Firestore remain the durable store for the next release, or is the Postgres target in `docs/firebase-auth-audit-architecture.md` an active migration requirement?
+2. [ASK USER] Should backend-issued JWT support stay as a supported local/E2E compatibility mode after Firebase Auth becomes the default production identity path?
+3. [ASK USER] What retention window should apply to `.execution_artifacts/` and `/tmp/pw_workflow_out` outputs when real client data is used locally?
+4. [ASK USER] Should `/metrics` be publicly reachable in deployed environments, or should it require network/auth protection?
+
+## 7) Evidence
+
+- `docs/firebase-auth-audit-architecture.md`
+- `docs/implementation-plan.md`
+- `docs/frontend-refactor-github-issues.md`
+- `.env.example`
+- `.gitignore`
+- `backend/app/auth/jwt_auth.py`
+- `backend/app/auth/firebase_auth.py`
+- `backend/app/services/artifact_fetcher.py`
+- `backend/app/services/execution_service.py`
+- `backend/app/services/billing_repository.py`
+- `backend/app/services/reporting_service.py`
+- `frontend/src/App.jsx`
+- `frontend/src/App.css`
+- `backend/app/agents/test_case_agent.py`
+- `backend/app/models.py`

--- a/docs/codebase/CONVENTIONS.md
+++ b/docs/codebase/CONVENTIONS.md
@@ -1,0 +1,138 @@
+# Coding Conventions
+
+This reference describes conventions visible in the tracked source. It does not
+invent rules that are not enforced by configuration.
+
+## 1) Naming Rules
+
+| Item | Rule | Example | Evidence |
+|------|------|---------|----------|
+| Backend Python files | snake_case, usually by feature or service role | `test_case_agent.py`, `artifact_fetcher.py`, `azure_devops_sync_service.py` | `backend/app/agents/`, `backend/app/services/` |
+| Backend test files | `test_*.py` in `backend/tests/` | `test_execution_service.py` | `backend/tests/` |
+| Python functions | snake_case; internal helpers commonly start with `_` | `_normalize_base_url`, `preview_execution` | `backend/app/services/execution_service.py` |
+| Python classes/models | PascalCase | `GenerateTestCasesResponse`, `BillingAccount` | `backend/app/models.py` |
+| Constants/env vars | uppercase snake_case | `DEFAULT_MODEL_NAME`, `EXECUTION_MAX_CASES_PER_REQUEST` | `backend/app/config.py`, `.env.example` |
+| Frontend components | PascalCase file and function names | `AutomationPanel.jsx`, `GeneratedTestCasesView.jsx` | `frontend/src/components/` |
+| Frontend hooks | `use*` camelCase | `useBillingStatus.js`, `useEscapeToClose.js` | `frontend/src/hooks/` |
+| Frontend helpers | camelCase exports in domain helper files | `createRequestId`, `downloadResponseBlob` | `frontend/src/services/apiClient.js` |
+
+## 2) Formatting and Linting
+
+- Formatter: [TODO] no tracked formatter config was found.
+- Linter: [TODO] no tracked linter config was found.
+- Type checking: [TODO] no tracked Python type checker or TypeScript config was
+  found for application code.
+- Enforced formatting command: [TODO] none in package manifests or CI.
+- Practical rule: match the surrounding file style, run focused tests, and run
+  `git diff --check` before committing if possible.
+
+Current validation commands:
+
+```bash
+python -m unittest discover -s backend/tests -p 'test_*.py'
+python scripts/evaluate_requirements.py --offline --strict
+python scripts/evaluate_generation.py --offline --strict
+python scripts/export_openapi.py --output /tmp/agentic-tcg-openapi.json --indent 0
+
+cd frontend
+npm run build
+npm run test:e2e -- e2e/export-approval-gate.spec.js
+
+cd backend/execution_runtime
+npm run test:playwright -- --list
+```
+
+## 3) Import and Module Conventions
+
+- Backend application imports use relative imports inside `backend/app`, for
+  example `from ..models import AuthUser` in routers.
+- Backend tests import application modules through `app.*` when run with
+  `backend` on the Python import path.
+- Frontend modules use relative imports. No path alias is configured.
+- Router modules expose a module-level `router = APIRouter()`.
+- Service modules mostly expose functions rather than classes; provider-specific
+  remote behavior lives in adapter modules.
+- There are no barrel exports or generated frontend API clients today.
+
+## 4) Error and Logging Conventions
+
+Backend error strategy:
+
+- Auth helpers raise `HTTPException` for missing, expired, revoked, or invalid
+  bearer tokens.
+- Routers raise `HTTPException` for endpoint-level validation and provider
+  workflow failures.
+- Service functions return typed response models or raise domain/runtime errors
+  that routers translate to HTTP responses.
+- Agent workflows prefer diagnostics, warnings, parser failure metadata, and
+  deterministic fallback output when model output is malformed or incomplete.
+
+Logging strategy:
+
+- `backend/app/main.py` configures structured request logging through
+  `backend/app/observability/logging.py`.
+- Request middleware binds `request_id`, optional `trace_id`, method, and path
+  into log context.
+- Workflow agents add `request_id`, `workflow_run_id`, `actor_user_id`, and
+  operation context to workflow logs.
+- Audit writes are retried and dead-letter summaries are sanitized before
+  storage in memory.
+
+Sensitive-data rules visible in code:
+
+- Connection secrets are excluded from Pydantic reprs with `Field(repr=False)`.
+- JIRA tokens and Azure DevOps PATs are encrypted before Firestore storage.
+- Token hints are displayed instead of full credentials.
+- The plain-English framework scans generated specs for secret-like values.
+- README and `.env.example` warn not to commit PATs, API keys, credentials, or
+  generated client data.
+
+## 5) Testing Conventions
+
+- Backend tests live in `backend/tests/` and are discovered with
+  `python -m unittest discover -s backend/tests -p 'test_*.py'`.
+- Tests use `unittest`, `fastapi.testclient.TestClient`, `unittest.mock.patch`,
+  and local fake clients instead of real remote services.
+- Integration tests for JIRA/Azure DevOps patch service and adapter boundaries.
+- Firestore-dependent tests patch `get_firestore_client` or use fake clients to
+  isolate behavior.
+- Frontend E2E specs live in `frontend/e2e/`.
+- Execution runtime smoke checks use `npm run test:playwright -- --list` under
+  `backend/execution_runtime`.
+
+## 6) Branching, Issue, and Change Scope
+
+The repository-level `AGENTS.md` makes GitHub issues or issue-ready proposals
+the unit of work. Use `codex/issue-<number>-<short-slug>` when working from a
+GitHub issue. If no issue exists, create one or add an issue-ready proposal
+before changing code or docs.
+
+The GitHub `main` branch is protected. Changes must merge through a pull
+request linked to the issue. The solo-maintainer setup requires 0 approving
+reviews, but still requires the branch to be up to date, all conversations to be
+resolved, and these checks to pass:
+
+- `Backend tests and offline benchmarks`
+- `Frontend build and focused E2E`
+
+Direct pushes, force pushes, and deletion of `main` are blocked. Admin
+enforcement is enabled.
+
+Keep implementations scoped to acceptance criteria, update traceability docs
+when validation evidence changes, and avoid unrelated cleanup in issue-scoped
+work.
+
+## 7) Evidence
+
+- `AGENTS.md`
+- `backend/app/main.py`
+- `backend/app/auth/jwt_auth.py`
+- `backend/app/auth/firebase_auth.py`
+- `backend/app/services/jira_connection_service.py`
+- `backend/app/services/azure_devops_connection_service.py`
+- `backend/app/observability/logging.py`
+- `backend/plain_english_test_framework/validation.py`
+- `backend/tests/`
+- `frontend/src/services/apiClient.js`
+- `frontend/src/components/`
+- `.github/workflows/ci.yml`

--- a/docs/codebase/INTEGRATIONS.md
+++ b/docs/codebase/INTEGRATIONS.md
@@ -1,0 +1,113 @@
+# External Integrations
+
+This reference lists external systems, local runtimes, and persistence paths
+used by the tracked source.
+
+## 1) Integration Inventory
+
+| System | Type | Purpose | Auth model | Criticality | Evidence |
+|--------|------|---------|------------|-------------|----------|
+| Gemini API through Google ADK / GenAI SDK | External AI API | Requirement extraction, requirement analysis, test-case generation, review/refinement, automation POM generation | `GEMINI_API_KEY` normalized to `GOOGLE_API_KEY` | High | `backend/app/config.py`, `backend/app/adk_client.py`, `backend/app/agents/test_case_agent.py`, `backend/app/agents/automation_agent.py` |
+| Firebase Authentication | External identity provider | Frontend sign-in and backend Firebase ID token verification | Firebase ID token bearer token | High | `frontend/src/firebase.js`, `backend/app/auth/firebase_auth.py`, `backend/app/services/firebase_admin.py` |
+| Backend-issued JWT | Local auth compatibility path | Legacy/local API token support and E2E helper token minting | `JWT_SECRET_KEY`, `JWT_ALGORITHM` | Medium | `backend/app/auth/jwt_auth.py`, `scripts/e2e_playwright_workflow.py` |
+| Google Identity credential verification | External identity provider path | `/auth/google/login` exchanges Google credential for backend JWT | Google ID token verified against allowed audiences | Medium | `backend/app/auth/google_auth.py`, `backend/app/routers/auth.py` |
+| Firestore | External data store | Audit events, workflow runs, version records, connection records, billing repository, reporting data | Firebase Admin SDK credentials | High | `backend/app/services/firebase_admin.py`, `backend/app/services/audit_service.py`, `backend/app/services/versioning_service.py`, `backend/app/services/billing_repository.py`, `backend/app/services/reporting_service.py` |
+| JIRA Cloud | External API | Store user JIRA connection, import requirements, sync managed requirement blocks, export tests placeholder | User email plus API token, token encrypted before storage | High | `backend/app/adapters/jira.py`, `backend/app/services/jira_connection_service.py`, `backend/app/services/jira_requirements_service.py`, `backend/app/services/jira_sync_service.py`, `backend/app/routers/integrations_jira.py` |
+| Azure DevOps Services | External API | Store user Azure DevOps connection, import work items, sync managed requirement blocks | Personal Access Token, encrypted before storage | High | `backend/app/adapters/azure_devops.py`, `backend/app/services/azure_devops_connection_service.py`, `backend/app/services/azure_devops_requirements_service.py`, `backend/app/services/azure_devops_sync_service.py`, `backend/app/routers/integrations_azure_devops.py` |
+| Remote artifact URLs | External HTTP(S) resources | Ground app/prototype/diagram/image links into UI/API/workflow context | Public HTTP(S), no user-supplied auth | Medium | `backend/app/services/artifact_fetcher.py`, `backend/app/services/context_grounding.py`, `backend/app/routers/requirements.py` |
+| Playwright Test execution runtime | Local subprocess/runtime | Convert executable candidates into generated specs, run selected cases, collect reports | Local process, environment config | High for automation feature | `backend/app/services/execution_service.py`, `backend/plain_english_test_framework/local_runner.py`, `backend/execution_runtime/playwright.config.ts` |
+| Cloud Run / Artifact Registry / Secret Manager | Deployment platform | Deploy backend and frontend containers to managed infrastructure | `gcloud` credentials and Secret Manager | Medium | `scripts/deploy_cloud_run.sh`, `backend/Dockerfile`, `frontend/Dockerfile` |
+| Prometheus-compatible metrics | Observability endpoint | Expose request, workflow, fallback, and audit failure counters | Public route unless deployment protects it | Medium | `backend/app/main.py`, `backend/app/observability/metrics.py` |
+| OpenTelemetry | Optional tracing | FastAPI tracing and trace ID propagation | `OTEL_*` environment variables | Medium | `backend/app/observability/tracing.py`, `backend/requirements.txt` |
+
+## 2) Data Stores
+
+| Store | Role | Access layer | Key risk | Evidence |
+|-------|------|--------------|----------|----------|
+| Firestore | Durable workflow/audit/version/reporting/billing/integration metadata | `backend/app/services/firebase_admin.py` plus service modules | Runtime behavior depends on Firebase credentials; several services degrade or warn when Firestore is unavailable | `backend/app/services/*.py`, `backend/tests/test_reporting_service.py` |
+| In-memory process state | Fallback/dead-letter and local billing repository behavior in selected paths | Service module globals and test fakes | Not durable across processes or restarts | `backend/app/services/audit_service.py`, `backend/app/services/billing_repository.py` |
+| Browser localStorage | Frontend access token and user session persistence | `frontend/src/App.jsx`, `frontend/src/constants/workflow.js` | XSS would expose token; current MVP stores token client-side | `frontend/src/App.jsx`, `README.md` |
+| Local filesystem | Execution artifacts, exported E2E outputs, generated client outputs | `backend/app/services/execution_service.py`, scripts under `scripts/` | Local artifacts can grow and leak data if ignored boundaries are bypassed | `.gitignore`, `scripts/e2e_playwright_workflow.py`, `docs/client-submission-workflow.md` |
+
+## 3) Secrets and Credentials Handling
+
+Credential sources:
+
+- `.env` and environment variables for local development.
+- `.env.example` as the documented template.
+- Secret Manager through `scripts/deploy_cloud_run.sh` for Cloud Run deployment.
+- Firebase Admin credentials through `FIREBASE_SERVICE_ACCOUNT_JSON` or
+  `GOOGLE_APPLICATION_CREDENTIALS`.
+- User JIRA API tokens and Azure DevOps PATs are submitted through protected
+  endpoints and encrypted before Firestore storage.
+
+Hardcoding checks:
+
+- `scripts/azure_devops_smoke.py` includes a default organization URL for a
+  smoke helper, but no PAT is hardcoded.
+- `.env.example` contains placeholders, not real secrets.
+- Generated outputs and local `.env` files are ignored by `.gitignore`.
+
+Rotation/lifecycle notes:
+
+- [TODO] No credential rotation workflow is documented for JIRA/Azure DevOps
+  connection secrets.
+- [TODO] No Secret Manager rotation automation is tracked.
+- [TODO] No formal token lifetime policy is documented beyond JWT expiration
+  settings and Firebase token verification behavior.
+
+## 4) Reliability and Failure Behavior
+
+- Agent workflows include parser diagnostics, retryable parser failure checks,
+  deterministic fallback output, and public workflow diagnostics.
+- Artifact fetching blocks non-HTTP(S), loopback, local, private, reserved,
+  multicast, and unresolved hosts before fetch.
+- Artifact fetching has request timeout, byte limit, redirect limit, and partial
+  failure behavior.
+- Audit writes use bounded retry settings and sanitized local dead-letter
+  summaries.
+- JIRA and Azure DevOps connection services encrypt tokens and surface status
+  summaries with token hints.
+- Execution preview classifies candidates as executable, manual, unsupported,
+  or invalid before any subprocess run.
+- Execution run limits cases per request by `EXECUTION_MAX_CASES_PER_REQUEST`.
+- Billing shadow mode defaults to true and can record usage without hard
+  blocking.
+
+## 5) Observability for Integrations
+
+- Request middleware logs completed and failed HTTP requests with request ID,
+  trace ID, method, path, status, and duration.
+- Agent workflow logs carry request/workflow/user/operation context.
+- `/metrics` exposes Prometheus-compatible counters and durations through
+  `backend/app/observability/metrics.py`.
+- Optional OpenTelemetry tracing is configured through
+  `backend/app/observability/tracing.py`.
+
+Missing visibility gaps:
+
+- [TODO] Integration adapters do not have a documented per-provider latency and
+  error SLO.
+- [TODO] No durable external dead-letter queue is implemented for audit failures.
+- [TODO] Broader explicit instrumentation for non-agent admin/auth/reporting
+  flows is still listed as not fully implemented in the observability feature
+  document.
+
+## 6) Evidence
+
+- `backend/app/config.py`
+- `backend/app/adk_client.py`
+- `backend/app/agents/test_case_agent.py`
+- `backend/app/auth/firebase_auth.py`
+- `backend/app/auth/jwt_auth.py`
+- `backend/app/auth/google_auth.py`
+- `backend/app/services/firebase_admin.py`
+- `backend/app/services/artifact_fetcher.py`
+- `backend/app/services/context_grounding.py`
+- `backend/app/services/audit_service.py`
+- `backend/app/services/billing_repository.py`
+- `backend/app/adapters/jira.py`
+- `backend/app/adapters/azure_devops.py`
+- `backend/execution_runtime/playwright.config.ts`
+- `scripts/deploy_cloud_run.sh`
+- `docs/observability-logging-tracing-feature.md`

--- a/docs/codebase/STACK.md
+++ b/docs/codebase/STACK.md
@@ -1,0 +1,147 @@
+# Technology Stack
+
+This reference describes the current tracked source stack. It excludes ignored
+execution artifacts, local virtual environments, Node modules, screenshots, and
+generated client submission outputs.
+
+## 1) Runtime Summary
+
+| Area | Value | Evidence |
+|------|-------|----------|
+| Backend language | Python | `backend/app/main.py`, `backend/requirements.txt` |
+| Backend runtime | Python 3.12 in CI and backend Docker image; README recommends local Python 3.10+ | `.github/workflows/ci.yml`, `backend/Dockerfile`, `README.md` |
+| Backend package manager | `pip` with `backend/requirements.txt` | `backend/requirements.txt`, `.github/workflows/ci.yml` |
+| Backend web framework | FastAPI served by Uvicorn | `backend/app/main.py`, `backend/requirements.txt`, `backend/Dockerfile` |
+| Frontend language | JavaScript and JSX | `frontend/src/App.jsx`, `frontend/package.json` |
+| Frontend runtime | Node.js for build/dev tooling; browser runtime for React app | `frontend/package.json`, `.github/workflows/ci.yml`, `frontend/Dockerfile` |
+| Frontend package manager | `npm` with checked-in lockfile | `frontend/package.json`, `frontend/package-lock.json` |
+| Frontend build system | Vite | `frontend/package.json`, `frontend/vite.config.js` |
+| Execution runtime | Node.js Playwright Test runtime isolated under `backend/execution_runtime/` | `backend/execution_runtime/package.json`, `backend/execution_runtime/playwright.config.ts` |
+| Container runtime | Backend Python image and frontend Nginx image, composed locally by Docker Compose | `backend/Dockerfile`, `frontend/Dockerfile`, `compose.yaml` |
+
+## 2) Production Frameworks and Dependencies
+
+| Dependency | Version | Role in system | Evidence |
+|------------|---------|----------------|----------|
+| `fastapi` | `>=0.136.3` | Backend API routing, dependency injection, OpenAPI contract | `backend/requirements.txt`, `backend/app/main.py` |
+| `uvicorn` | `>=0.49.0` | ASGI server for local and container backend runs | `backend/requirements.txt`, `backend/Dockerfile` |
+| `pydantic` | `>=2.13.4` | Request, response, workflow, billing, integration, and execution models | `backend/requirements.txt`, `backend/app/models.py` |
+| `google-adk` | `>=2.2.0,<3.0` | Multi-agent requirement/test-case workflows | `backend/requirements.txt`, `backend/app/adk_client.py`, `backend/app/agents/test_case_agent.py` |
+| `google-genai` | `>=2.8.0,<3.0` | Gemini API calls for agent and automation generation | `backend/requirements.txt`, `backend/app/agents/automation_agent.py` |
+| `firebase-admin` | `>=7.4.0` | Firebase ID token verification and Firestore client access | `backend/requirements.txt`, `backend/app/auth/firebase_auth.py`, `backend/app/services/firebase_admin.py` |
+| `PyJWT` | `>=2.13.0` | Backend-issued legacy/local JWT support and E2E helper token minting | `backend/requirements.txt`, `backend/app/auth/jwt_auth.py`, `scripts/e2e_playwright_workflow.py` |
+| `google-auth` | `>=2.53.0` | Google credential verification for `/auth/google/login` | `backend/requirements.txt`, `backend/app/auth/google_auth.py` |
+| `cryptography` | `>=48.0.1` | Fernet encryption for stored JIRA tokens and Azure DevOps PATs | `backend/requirements.txt`, `backend/app/services/jira_connection_service.py`, `backend/app/services/azure_devops_connection_service.py` |
+| `python-docx` | `>=1.2.0` | Word requirement parsing and client brief generation | `backend/requirements.txt`, `backend/app/routers/requirements.py`, `scripts/build_client_solution_brief.py` |
+| `openpyxl` | `>=3.1.5` | Excel requirement parsing and XLSX export | `backend/requirements.txt`, `backend/app/utils/excel_parser.py`, `backend/app/agents/export_agent.py` |
+| `PyYAML` | `>=6.0.3` | Plain-English spec, IR, environment, and data fixture handling | `backend/requirements.txt`, `backend/plain_english_test_framework/compiler.py` |
+| `jsonschema` | `>=4.26.0` | Schema validation for plain-English spec and IR contracts | `backend/requirements.txt`, `schemas/spec.schema.json`, `schemas/ir.schema.json` |
+| OpenTelemetry packages | pinned around `1.41.1` / `0.62b1` | Optional tracing support | `backend/requirements.txt`, `backend/app/observability/tracing.py` |
+| `react` / `react-dom` | `^19.2.7` | Frontend UI runtime | `frontend/package.json`, `frontend/src/main.jsx` |
+| `firebase` | `^12.14.0` | Frontend Firebase Authentication provider setup | `frontend/package.json`, `frontend/src/firebase.js` |
+| `@react-oauth/google` | `^0.13.5` | Google OAuth dependency still present in frontend package manifest | `frontend/package.json` |
+
+## 3) Development Toolchain
+
+| Tool | Purpose | Evidence |
+|------|---------|----------|
+| `python -m unittest` | Backend regression suite | `backend/tests/`, `.github/workflows/ci.yml` |
+| Offline evaluation scripts | Deterministic requirement and generation quality gates | `scripts/evaluate_requirements.py`, `scripts/evaluate_generation.py`, `.github/workflows/ci.yml` |
+| `scripts/export_openapi.py` | FastAPI contract export | `scripts/export_openapi.py`, `.github/workflows/ci.yml` |
+| Vite | Frontend dev server and production build | `frontend/package.json` |
+| Playwright Test | Frontend E2E checks and backend execution runtime | `frontend/package.json`, `frontend/playwright.config.js`, `backend/execution_runtime/package.json` |
+| Docker Compose | Local two-container runtime | `compose.yaml` |
+| GitHub Actions | CI for backend, offline benchmarks, frontend build, and focused mocked E2E | `.github/workflows/ci.yml` |
+
+There is no tracked lint or formatter configuration such as ESLint, Prettier,
+Ruff, Black, or isort. Use local style and existing tests until a future issue
+adds enforced formatting.
+
+## 4) Key Commands
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip
+python -m pip install -r backend/requirements.txt
+
+uvicorn app.main:app --reload --app-dir backend --reload-dir backend
+
+cd frontend
+npm ci
+npm run dev
+npm run build
+npm run test:e2e -- e2e/export-approval-gate.spec.js
+
+cd backend/execution_runtime
+npm ci
+npm run test:playwright -- --list
+
+python -m unittest discover -s backend/tests -p 'test_*.py'
+python scripts/evaluate_requirements.py --offline --strict
+python scripts/evaluate_generation.py --offline --strict
+python scripts/export_openapi.py --output /tmp/agentic-tcg-openapi.json --indent 0
+```
+
+## 5) Environment and Config
+
+- Main local template: `.env.example`.
+- Backend config loader: `backend/app/config.py`.
+- Frontend build-time config: `frontend/src/firebase.js`, `frontend/src/services/apiClient.js`, `frontend/Dockerfile`.
+- Local container config: `compose.yaml`.
+- Cloud Run deployment helper: `scripts/deploy_cloud_run.sh`.
+
+Required or important backend variables:
+
+- `GEMINI_API_KEY`
+- `MODEL_NAME`
+- `JWT_SECRET_KEY`
+- `JWT_ALGORITHM`
+- `JWT_EXPIRATION_MINUTES`
+- `CORS_ALLOW_ORIGINS`
+- `FIREBASE_PROJECT_ID`
+- `FIREBASE_SERVICE_ACCOUNT_JSON`
+- `JIRA_CONNECTION_SECRET_KEY`
+- `AZURE_DEVOPS_CONNECTION_SECRET_KEY`
+- `EXECUTION_ENABLED`
+- `EXECUTION_ARTIFACT_ROOT`
+- `EXECUTION_DEFAULT_BASE_URL`
+- `EXECUTION_PLAYWRIGHT_CONFIG`
+- `EXECUTION_RUNTIME_CWD`
+- `EXECUTION_MAX_CASES_PER_REQUEST`
+- `EXECUTION_BROWSER_CHANNEL`
+- `BILLING_*`
+- `OTEL_*`
+- `LOG_*`
+
+Required or important frontend variables:
+
+- `VITE_API_BASE`
+- `VITE_GOOGLE_CLIENT_ID`
+- `VITE_FIREBASE_API_KEY`
+- `VITE_FIREBASE_AUTH_DOMAIN`
+- `VITE_FIREBASE_PROJECT_ID`
+- `VITE_FIREBASE_APP_ID`
+- `VITE_FIREBASE_*` optional metadata and provider toggles.
+
+Deployment/runtime constraints:
+
+- Backend Docker installs Node.js, npm, the execution runtime dependencies, and
+  Microsoft Edge Playwright support so backend execution endpoints can generate
+  and run Playwright specs.
+- Frontend Docker builds static assets with Vite and serves them through Nginx.
+- Local generated execution outputs live under `.execution_artifacts/` and are
+  ignored by git.
+
+## 6) Evidence
+
+- `backend/requirements.txt`
+- `frontend/package.json`
+- `backend/execution_runtime/package.json`
+- `backend/app/config.py`
+- `backend/app/main.py`
+- `.env.example`
+- `.github/workflows/ci.yml`
+- `backend/Dockerfile`
+- `frontend/Dockerfile`
+- `compose.yaml`

--- a/docs/codebase/STRUCTURE.md
+++ b/docs/codebase/STRUCTURE.md
@@ -1,0 +1,119 @@
+# Codebase Structure
+
+This reference maps the tracked source tree and the boundaries maintainers
+should preserve when changing the application.
+
+## 1) Top-Level Map
+
+| Path | Purpose | Evidence |
+|------|---------|----------|
+| `backend/` | FastAPI API, agents, services, auth, tests, execution framework, backend Dockerfile | `backend/app/main.py`, `backend/tests/`, `backend/Dockerfile` |
+| `backend/app/` | Runtime application package | `backend/app/main.py` |
+| `backend/app/routers/` | HTTP endpoint groups registered by `main.py` | `backend/app/main.py`, `backend/app/routers/*.py` |
+| `backend/app/agents/` | ADK/Gemini-facing workflow agents and prompt helpers | `backend/app/adk_client.py`, `backend/app/agents/test_case_agent.py` |
+| `backend/app/services/` | Business services, persistence adapters, execution services, billing, reporting, grounding | `backend/app/services/*.py` |
+| `backend/app/adapters/` | External API clients for JIRA and Azure DevOps | `backend/app/adapters/jira.py`, `backend/app/adapters/azure_devops.py` |
+| `backend/app/auth/` | Firebase, Google credential, backend JWT, role, and authorization helpers | `backend/app/auth/*.py` |
+| `backend/app/observability/` | Structured logging, Prometheus-style metrics, optional tracing | `backend/app/observability/*.py` |
+| `backend/app/utils/` | Parsing, JSON recovery, requirement normalization, workflow diagnostics | `backend/app/utils/*.py` |
+| `backend/plain_english_test_framework/` | Structured-English spec parser, compiler, IR validator, Playwright generator, and local runner | `backend/plain_english_test_framework/*.py` |
+| `backend/execution_runtime/` | Node-based Playwright Test runtime used by backend execution endpoints | `backend/execution_runtime/package.json`, `backend/execution_runtime/playwright.config.ts` |
+| `backend/tests/` | Backend unit and integration-style tests using `unittest` and local fakes/patches | `backend/tests/test_*.py` |
+| `frontend/` | React/Vite web application, E2E specs, frontend Dockerfile, Nginx config | `frontend/src/main.jsx`, `frontend/package.json`, `frontend/Dockerfile` |
+| `frontend/src/components/` | Focused UI components grouped by feature or layout | `frontend/src/components/**` |
+| `frontend/src/services/` | Frontend API helper functions | `frontend/src/services/apiClient.js` |
+| `frontend/src/hooks/` | Reusable React hooks | `frontend/src/hooks/*.js` |
+| `frontend/src/utils/` | Pure frontend helpers | `frontend/src/utils/*.js` |
+| `frontend/e2e/` | Playwright browser workflow tests and screenshot capture script | `frontend/e2e/*.js`, `frontend/e2e/*.mjs` |
+| `schemas/` | JSON schemas for the plain-English spec and IR contracts | `schemas/spec.schema.json`, `schemas/ir.schema.json` |
+| `scripts/` | Evaluation scripts, smoke/E2E scripts, deployment helper, payload fixtures, benchmark fixtures | `scripts/*.py`, `scripts/*.sh`, `scripts/api_payloads/` |
+| `docs/` | Planning, architecture, traceability, observability, client workflow, and codebase docs | `docs/*.md` |
+| `.github/workflows/` | CI pipeline definitions | `.github/workflows/ci.yml` |
+| `compose.yaml` | Local two-container app orchestration | `compose.yaml` |
+| `.env.example` | Local environment template | `.env.example` |
+
+## 2) Entry Points
+
+- Main backend runtime entry: `backend/app/main.py`.
+- Frontend runtime entry: `frontend/src/main.jsx`.
+- Frontend orchestration component: `frontend/src/App.jsx`.
+- Backend execution runtime config: `backend/execution_runtime/playwright.config.ts`.
+- Frontend E2E config: `frontend/playwright.config.js`.
+- Backend container entry: `backend/Dockerfile`.
+- Frontend container entry: `frontend/Dockerfile`.
+- Local container entry: `compose.yaml`.
+- Reproducible next-version E2E workflow: `scripts/e2e_playwright_workflow.py`.
+- API smoke workflow: `scripts/run_api_smoke.sh` and `scripts/e2e_api_verify.py`.
+- OpenAPI export: `scripts/export_openapi.py`.
+
+`backend/app/main.py` creates the FastAPI app, installs CORS and request
+middleware, registers routers, configures tracing, exposes `/health`, and
+exposes `/metrics`.
+
+## 3) Module Boundaries
+
+| Boundary | What belongs here | What must not be here |
+|----------|-------------------|------------------------|
+| `backend/app/routers/` | HTTP request parsing, FastAPI dependencies, workflow audit start/complete calls, response assembly | Low-level external API request code, raw SDK setup, large agent prompts |
+| `backend/app/agents/` | ADK/Gemini workflow orchestration, prompt construction, deterministic fallbacks, test-design review logic | HTTP endpoint definitions, Firestore collection setup, frontend-specific shaping |
+| `backend/app/services/` | Domain services for billing, audit, versioning, execution, grounding, reporting, integration connection storage | FastAPI route decorators, JSX/UI behavior |
+| `backend/app/adapters/` | Provider-specific JIRA and Azure DevOps HTTP semantics | App-wide workflow decisions or billing policy |
+| `backend/app/auth/` | Bearer token resolution, Firebase verification, Google credential verification, role normalization | Business workflow behavior |
+| `backend/app/observability/` | Logging context, metric counters, optional OpenTelemetry wiring | Endpoint business logic |
+| `backend/plain_english_test_framework/` | Structured-English spec to schema-valid IR to Playwright generation | API billing, user auth, remote artifact fetching |
+| `frontend/src/components/` | Presentational and workflow UI components receiving props | Backend API transport details beyond passed callbacks/data |
+| `frontend/src/services/` | API base URL, request ID, API error parsing, download helpers | Large workflow state or JSX markup |
+| `frontend/src/utils/` | Pure formatting, requirement, usage, and workflow helpers | React state or network side effects |
+| `scripts/` | Local, CI, deployment, evaluation, and reproducibility utilities | Runtime API code imported by production paths unless intentionally shared |
+| `docs/` | Human-readable planning, reference, explanation, and how-to material | Generated screenshots, exported client data, secrets |
+
+## 4) Naming and Organization Rules
+
+- Python files use snake_case, for example `test_case_agent.py`,
+  `artifact_fetcher.py`, and `azure_devops_sync_service.py`.
+- Python classes and Pydantic models use PascalCase, for example
+  `RequirementAnalysis`, `ExecutionPreviewResponse`, and `BillingAccount`.
+- Python functions and helpers use snake_case. Private/internal helpers are
+  commonly prefixed with `_`, for example `_get_request_id()` and
+  `_normalize_base_url()`.
+- JSX component files use PascalCase, for example `AutomationPanel.jsx` and
+  `RequirementReviewWorkbench.jsx`.
+- Frontend helper files use camelCase or lower-case domain names, for example
+  `apiClient.js`, `useBillingStatus.js`, and `workflow.js`.
+- Backend route modules are grouped by product area, for example
+  `requirements.py`, `testcases.py`, `integrations_jira.py`, and
+  `integrations_azure_devops.py`.
+- Frontend component directories are grouped by feature or layout, for example
+  `automation/`, `generation/`, `integrations/`, `requirements/`, and
+  `layout/`.
+- There are no tracked TypeScript path aliases. Backend imports use relative
+  package imports inside `backend/app/`; frontend imports use relative paths.
+
+## 5) Generated and Ignored Boundaries
+
+Do not document generated files as source conventions and do not commit them.
+
+- `.execution_artifacts/` is ignored and contains generated execution specs,
+  IR, Playwright results, reports, traces, videos, and environment files.
+- `client_submission/` is ignored and contains generated client screenshots,
+  downloaded exports, and generated briefs.
+- `frontend/dist/`, `frontend/test-results/`, `frontend/playwright-report/`,
+  Node modules, Python caches, and `.venv/` are ignored.
+- Backend execution runtime artifacts under `backend/execution_runtime/artifacts/`
+  are ignored.
+
+## 6) Evidence
+
+- `git ls-files`
+- `backend/app/main.py`
+- `backend/app/routers/`
+- `backend/app/services/`
+- `backend/app/agents/`
+- `backend/plain_english_test_framework/`
+- `backend/execution_runtime/package.json`
+- `frontend/src/App.jsx`
+- `frontend/src/components/`
+- `frontend/src/services/apiClient.js`
+- `frontend/e2e/`
+- `.gitignore`
+- `.dockerignore`

--- a/docs/codebase/TESTING.md
+++ b/docs/codebase/TESTING.md
@@ -1,0 +1,184 @@
+# Testing Patterns
+
+This guide explains the current validation gates and how to reproduce the first
+next-version end-to-end Playwright documentation workflow.
+
+## 1) Test Stack and Commands
+
+Primary backend framework: Python `unittest`.
+
+Primary frontend/E2E framework: Playwright Test.
+
+Primary quality gates:
+
+```bash
+source .venv/bin/activate
+python -m unittest discover -s backend/tests -p 'test_*.py'
+python scripts/evaluate_requirements.py --offline --strict
+python scripts/evaluate_generation.py --offline --strict
+python scripts/export_openapi.py --output /tmp/agentic-tcg-openapi.json --indent 0
+
+cd frontend
+npm ci
+npm run build
+npm run test:e2e -- e2e/export-approval-gate.spec.js
+
+cd backend/execution_runtime
+npm ci
+npm run test:playwright -- --list
+```
+
+CI currently runs:
+
+- Backend unittest suite.
+- Offline requirement evaluation.
+- Offline generation evaluation.
+- OpenAPI export.
+- Frontend production build.
+- Focused mocked frontend E2E spec `e2e/export-approval-gate.spec.js`.
+
+Evidence: `.github/workflows/ci.yml`.
+
+## 2) Test Layout
+
+- Backend tests: `backend/tests/test_*.py`.
+- Frontend browser specs: `frontend/e2e/*.spec.js`.
+- Frontend E2E support: `frontend/e2e/support/`.
+- Execution runtime smoke/list command: `backend/execution_runtime/package.json`.
+- Plain-English test framework source: `backend/plain_english_test_framework/`.
+- Plain-English schema contracts: `schemas/spec.schema.json` and
+  `schemas/ir.schema.json`.
+- Benchmark inputs and expectations: `scripts/benchmark_*`.
+- API payload fixtures: `scripts/api_payloads/`.
+
+## 3) Test Scope Matrix
+
+| Scope | Covered? | Typical target | Notes |
+|-------|----------|----------------|-------|
+| Backend unit | Yes | Config parsing, auth, model parsing, agents, services, billing, reporting, grounding, execution conversion | Uses `unittest` and `unittest.mock.patch` |
+| Backend integration-style | Yes | FastAPI endpoints, JIRA/Azure DevOps import/sync routes, audit hooks, billing access | Uses `TestClient` and patched dependencies |
+| Offline quality benchmarks | Yes | Requirement extraction and test-case generation quality | `--offline --strict` avoids live model dependency |
+| OpenAPI contract | Yes | FastAPI schema export | `scripts/export_openapi.py` |
+| Frontend build | Yes | React/Vite production build | `npm run build` |
+| Frontend E2E | Yes | Mocked browser workflow slices | `frontend/e2e/export-approval-gate.spec.js`, `workflow.spec.js`, `jira-workflow.spec.js` |
+| Backend execution runtime | Partial | Playwright Test availability and generated spec execution | Runtime list check in validation; full run covered by `scripts/e2e_playwright_workflow.py` when backend and credentials are available |
+| Coverage thresholds | [TODO] | [TODO] | No tracked coverage tool or threshold was found |
+
+## 4) Mocking and Isolation Strategy
+
+- Backend tests patch Firestore clients, provider adapters, auth dependencies,
+  billing services, and agent calls at module boundaries.
+- JIRA and Azure DevOps sync tests verify direct source metadata paths avoid
+  unnecessary Firestore mapping reads where possible.
+- Frontend focused E2E tests mock API responses and use a local Vite server.
+- Offline evaluation scripts use deterministic fallback behavior instead of
+  live Gemini calls.
+- Execution service tests validate preview classification, conversion, and
+  local runner behavior without requiring every generated case to hit a live
+  product site.
+
+Common failure modes:
+
+- Missing `.venv` dependencies for backend commands.
+- Missing `frontend/node_modules` or `backend/execution_runtime/node_modules`.
+- Browser channel mismatch for execution runtime; defaults target Microsoft
+  Edge through `EXECUTION_BROWSER_CHANNEL` / `PETF_PLAYWRIGHT_BROWSER_CHANNEL`.
+- Firestore/Firebase credentials missing in local runs that exercise real
+  Firebase-backed paths.
+- Live model or external documentation workflows taking longer than unit tests.
+
+## 5) Reproduce the Next-Version E2E Success
+
+The first successful next-version workflow is captured by
+`scripts/e2e_playwright_workflow.py`. It exercises:
+
+1. Local JWT minting.
+2. Markdown requirement parsing from `scripts/playwright_docs_requirements.md`.
+3. Human feedback requirement refinement.
+4. Grounded context enrichment against Playwright for Python documentation URLs.
+5. Test-case generation with analysis, coverage, traceability, and review.
+6. CSV, XLSX, and JSON export.
+7. Playwright POM stub generation.
+8. Execution preview.
+9. Selected Playwright execution run and report artifact generation.
+
+Prerequisites:
+
+```bash
+source .venv/bin/activate
+python -m pip install -r backend/requirements.txt
+
+cd backend/execution_runtime
+npm ci
+cd ../..
+```
+
+Start the backend:
+
+```bash
+source .venv/bin/activate
+uvicorn app.main:app --reload --app-dir backend --reload-dir backend
+```
+
+Run the E2E workflow in another terminal:
+
+```bash
+source .venv/bin/activate
+python scripts/e2e_playwright_workflow.py
+```
+
+Expected outputs:
+
+- JSON workflow snapshots and exports under `/tmp/pw_workflow_out`.
+- Execution specs, IR, generated Playwright tests, and reports under
+  `.execution_artifacts/exec_*` when execution is enabled.
+- Console summary showing parsed/refined/enriched requirements, generated test
+  cases, executable preview counts, and execution run status.
+
+Recorded validation evidence:
+
+- Issue #15 evidence in `docs/requirements_traceability.md` records a full
+  workflow against `https://playwright.dev/python/` that parsed requirements,
+  generated approved test cases, exported CSV/XLSX/JSON, and generated
+  Playwright POM stubs.
+- Issue #16 evidence records grounded documentation URLs, extracted UI
+  elements, executable preview, and 5 selected Playwright report cases passing.
+
+Use this script for release confidence when changes affect requirement parsing,
+grounded context, generation, exports, automation, execution preview, or the
+plain-English framework. It is slower and more environment-sensitive than the
+offline CI gates, so do not replace unit and offline benchmark checks with it.
+
+## 6) Validation Gate Selection
+
+Use the smallest gate that proves the change:
+
+- Backend service/router/model change: backend unittest plus focused tests.
+- Agent, fallback, coverage, or parsing change: backend unittest plus both
+  offline evaluation scripts.
+- API contract change: OpenAPI export.
+- Frontend UI or API call change: frontend build and focused E2E if the flow is
+  covered.
+- Execution conversion/runtime change: backend execution tests and
+  `backend/execution_runtime` Playwright list check.
+- End-to-end workflow or release confidence change: run
+  `scripts/e2e_playwright_workflow.py`.
+
+When a gate cannot be run, record the command, blocker, and remaining risk in
+the issue, PR, or handoff note.
+
+## 7) Evidence
+
+- `.github/workflows/ci.yml`
+- `backend/tests/`
+- `frontend/e2e/`
+- `frontend/playwright.config.js`
+- `backend/execution_runtime/package.json`
+- `backend/execution_runtime/playwright.config.ts`
+- `scripts/evaluate_requirements.py`
+- `scripts/evaluate_generation.py`
+- `scripts/export_openapi.py`
+- `scripts/e2e_playwright_workflow.py`
+- `docs/requirements_traceability.md`
+- `schemas/spec.schema.json`
+- `schemas/ir.schema.json`

--- a/docs/github-issues-backlog.md
+++ b/docs/github-issues-backlog.md
@@ -17,21 +17,99 @@ This file contains issue-ready drafts for the implementation plan in `docs/imple
 - [#11](https://github.com/lumensparkxy/agentic_test_case_generator/issues/11) — Phase 2: expand backend and E2E regression coverage
 - [#17](https://github.com/lumensparkxy/agentic_test_case_generator/issues/17) — Update project dependencies to latest compatible versions
 
+## Created concern hardening issues
+
+These issues were created from `docs/codebase/CONCERNS.md` after the first
+next-version end-to-end Playwright documentation workflow succeeded.
+
+### Phase 3 - Architecture Hardening
+
+- Epic [#35](https://github.com/lumensparkxy/agentic_test_case_generator/issues/35) - Reduce high-churn architecture hotspots
+  - [#39](https://github.com/lumensparkxy/agentic_test_case_generator/issues/39) - Extract frontend workflow state from App.jsx into hooks
+  - [#40](https://github.com/lumensparkxy/agentic_test_case_generator/issues/40) - Modularize frontend CSS by feature ownership
+  - [#41](https://github.com/lumensparkxy/agentic_test_case_generator/issues/41) - Split test_case_agent.py into focused backend modules
+  - [#42](https://github.com/lumensparkxy/agentic_test_case_generator/issues/42) - Split backend Pydantic contracts by domain
+- Epic [#36](https://github.com/lumensparkxy/agentic_test_case_generator/issues/36) - Strengthen contract safety and engineering hygiene
+  - [#43](https://github.com/lumensparkxy/agentic_test_case_generator/issues/43) - Generate frontend API types from FastAPI OpenAPI
+  - [#44](https://github.com/lumensparkxy/agentic_test_case_generator/issues/44) - Add formatter and linter baseline for backend and frontend
+  - [#45](https://github.com/lumensparkxy/agentic_test_case_generator/issues/45) - Deduplicate execution settings in .env.example and docs
+  - [#46](https://github.com/lumensparkxy/agentic_test_case_generator/issues/46) - Refresh planning docs to distinguish history from roadmap
+  - [#47](https://github.com/lumensparkxy/agentic_test_case_generator/issues/47) - Exclude ignored generated artifacts from codebase scans
+
+### Phase 4 - Operational Readiness
+
+- Epic [#37](https://github.com/lumensparkxy/agentic_test_case_generator/issues/37) - Settle production persistence and auth architecture
+  - [#48](https://github.com/lumensparkxy/agentic_test_case_generator/issues/48) - Spike: decide Firestore versus Postgres persistence target
+  - [#49](https://github.com/lumensparkxy/agentic_test_case_generator/issues/49) - Introduce durable persistence boundary for audit and billing
+  - [#50](https://github.com/lumensparkxy/agentic_test_case_generator/issues/50) - Spike: define production auth policy for Firebase and JWT
+  - [#51](https://github.com/lumensparkxy/agentic_test_case_generator/issues/51) - Enforce accepted production auth mode explicitly
+- Epic [#38](https://github.com/lumensparkxy/agentic_test_case_generator/issues/38) - Harden operational security and production readiness
+  - [#52](https://github.com/lumensparkxy/agentic_test_case_generator/issues/52) - Protect or scope the metrics endpoint for production
+  - [#53](https://github.com/lumensparkxy/agentic_test_case_generator/issues/53) - Define artifact retention policy and cleanup command
+  - [#54](https://github.com/lumensparkxy/agentic_test_case_generator/issues/54) - Document credential rotation for integrations and secrets
+  - [#55](https://github.com/lumensparkxy/agentic_test_case_generator/issues/55) - Add integration latency and error metrics for JIRA and Azure DevOps
+  - [#56](https://github.com/lumensparkxy/agentic_test_case_generator/issues/56) - Add durable audit dead-letter sink for compliance deployments
+  - [#57](https://github.com/lumensparkxy/agentic_test_case_generator/issues/57) - Harden artifact fetching threat model and validation
+
 > Note: issue numbers do not strictly follow the planned sequence because several issues were created in parallel.
+
+## Pending issue-ready drafts
+
+### Draft - Document current codebase after first next-version E2E success
+
+**Suggested labels:** `type:task`, `area:docs`, `priority:p2`, `status:ready`
+
+**Suggested milestone:** `Phase 2 - Grounded Context`
+
+#### Summary
+
+Add repository-level codebase documentation after the first successful
+next-version end-to-end Playwright documentation workflow so maintainers and
+automation agents can understand the current architecture, validation gates,
+integration boundaries, and remaining risks.
+
+#### Acceptance criteria
+
+- [ ] Scan the tracked codebase and existing planning docs.
+- [ ] Add `docs/codebase/STACK.md`, `STRUCTURE.md`, `ARCHITECTURE.md`,
+      `CONVENTIONS.md`, `INTEGRATIONS.md`, `TESTING.md`, and `CONCERNS.md`.
+- [ ] Each codebase document includes evidence paths for non-trivial claims.
+- [ ] Fold the first next-version E2E workflow into `docs/codebase/TESTING.md`.
+- [ ] Update `README.md` with links to the new codebase documentation.
+- [ ] Capture unresolved intent-dependent questions as `[ASK USER]` items.
+
+#### Test plan
+
+- [ ] Review the Markdown files for internal links, evidence paths, and
+      unsupported claims.
+- [ ] Run a lightweight file-presence check for the expected docs.
+- [ ] Run `git diff --check`.
 
 ## Suggested milestones
 
 - `Phase 0 - Evaluation`
 - `Phase 1 - Coverage Intelligence`
 - `Phase 2 - Grounded Context`
+- `Phase 3 - Architecture Hardening`
+- `Phase 4 - Operational Readiness`
 
 ## Suggested labels
 
 - `type:enhancement`
 - `type:epic`
+- `type:story`
+- `type:task`
+- `type:spike`
 - `area:backend`
 - `area:frontend`
 - `area:qa`
+- `area:docs`
+- `area:devops`
+- `priority:p1`
+- `priority:p2`
+- `priority:p3`
+- `status:ready`
+- `status:blocked`
 - `phase:0`
 - `phase:1`
 - `phase:2`


### PR DESCRIPTION
## Summary
- Add Diataxis-aligned codebase documentation under `docs/codebase/`.
- Add a Mermaid architecture diagram and fold the next-version Playwright docs E2E workflow into `TESTING.md`.
- Update `README.md` with a documentation map.
- Record created concern-hardening GitHub issues and milestones in `docs/github-issues-backlog.md`.
- Document the protected-branch workflow in `AGENTS.md`.

## Validation
- `git diff --check`
- Markdown/file-presence review for the expected docs
- GitHub issue/milestone verification with `gh issue list`

Related to #36.
