### PR TITLE
[codex] Recover coverage planning from truncated JSON output

### DIFF
--- a/backend/app/agents/test_case_agent.py
+++ b/backend/app/agents/test_case_agent.py
@@ -25,7 +25,6 @@ from ..models import (
     GenerateTestCasesInput,
     RefineTestCasesInput,
     Requirement,
-    RequirementCoveragePlanOutput,
     ReviewResult,
     TestCase,
     TestCasesOutput,
@@ -166,6 +165,32 @@ def _record_parser_failure(
     )
 
 
+def _record_parser_recovery(
+    diagnostics: Dict[str, Any],
+    author: str,
+    error: Optional[str],
+    raw_text: Optional[str] = None,
+) -> None:
+    if not error:
+        return
+    message = f"{author}: {error}"
+    sample = _diagnostic_sample(raw_text)
+    if sample:
+        message = f"{message} | sample: {sample}"
+    _append_unique_message(diagnostics["parser_failures"], message)
+    if diagnostics["status"] == "completed":
+        diagnostics["status"] = "partial"
+    _append_unique_message(diagnostics["warnings"], f"{author}: recovered usable coverage-plan JSON from malformed output.")
+    _log_test_case_workflow(
+        "parser_recovery",
+        author=author,
+        error=error,
+        sample=sample or None,
+        parser_failure_count=len(diagnostics["parser_failures"]),
+        status=diagnostics["status"],
+    )
+
+
 def _record_event_error(diagnostics: Dict[str, Any], author: str, event: Any) -> None:
     error_code = getattr(event, "error_code", None)
     error_message = getattr(event, "error_message", None)
@@ -208,8 +233,7 @@ def _build_coverage_planner_agent(
         name="CoveragePlannerAgent",
         model=model,
         include_contents="none",
-        generate_content_config=json_generation_config(max_output_tokens=12000),
-        output_schema=RequirementCoveragePlanOutput,
+        generate_content_config=json_generation_config(max_output_tokens=24000),
         instruction=f"""You are a Senior QA Strategist creating a scenario coverage plan before detailed test cases are written.
 
     {TEST_DESIGN_PROMPT_GUARDRAILS}
@@ -667,6 +691,7 @@ Human feedback:
                     parsed_coverage_plan, parse_error = parse_coverage_plan_json_detailed(text)
                     if parsed_coverage_plan:
                         current_coverage_plan = _normalize_coverage_plan(parsed_coverage_plan, requirements)
+                        _record_parser_recovery(diagnostics, author, parse_error, text)
                     else:
                         _record_parser_failure(diagnostics, author, parse_error, text)
 
@@ -787,8 +812,11 @@ Human feedback:
 
     state_coverage_plan_raw = session_state.get(STATE_COVERAGE_PLAN, "[]")
     state_coverage_plan, state_coverage_plan_error = parse_coverage_plan_json_detailed(state_coverage_plan_raw)
+    had_event_coverage_plan = bool(current_coverage_plan)
     if state_coverage_plan:
         current_coverage_plan = _normalize_coverage_plan(state_coverage_plan, requirements)
+        if not had_event_coverage_plan:
+            _record_parser_recovery(diagnostics, "SessionStateCoveragePlan", state_coverage_plan_error, state_coverage_plan_raw)
     elif str(state_coverage_plan_raw).strip() not in {"", "[]"}:
         _record_parser_failure(diagnostics, "SessionStateCoveragePlan", state_coverage_plan_error, state_coverage_plan_raw)
 

--- a/backend/app/utils/llm_json.py
+++ b/backend/app/utils/llm_json.py
@@ -95,6 +95,43 @@ def extract_json(text: Any) -> Optional[str]:
     return normalized[start : end + 1]
 
 
+def _recover_complete_array_items(json_text: str, *, key: str) -> List[Any]:
+    """Return complete items from a JSON array prefix after a decode failure."""
+    normalized = str(json_text or "")
+    stripped = normalized.lstrip()
+    offset = len(normalized) - len(stripped)
+
+    if stripped.startswith("["):
+        array_start = offset
+    else:
+        key_match = re.search(rf'"{re.escape(key)}"\s*:', normalized)
+        if not key_match:
+            return []
+        array_start = normalized.find("[", key_match.end())
+        if array_start == -1:
+            return []
+
+    decoder = json.JSONDecoder()
+    items: List[Any] = []
+    index = array_start + 1
+    length = len(normalized)
+
+    while index < length:
+        while index < length and normalized[index] in " \r\n\t,":
+            index += 1
+
+        if index >= length or normalized[index] == "]":
+            break
+
+        try:
+            item, index = decoder.raw_decode(normalized, index)
+        except json.JSONDecodeError:
+            break
+        items.append(item)
+
+    return items
+
+
 def parse_requirements_json_detailed(text: Any) -> tuple[List[Dict[str, Any]], Optional[str]]:
     """Parse requirements payload from model output and return an error when invalid."""
     if _is_blank_output(text):
@@ -175,26 +212,13 @@ def parse_test_cases_json(text: Any) -> List[Dict[str, Any]]:
     return parsed
 
 
-def parse_coverage_plan_json_detailed(text: Any) -> tuple[List[Dict[str, Any]], Optional[str]]:
-    """Parse requirement coverage plan payload from model output and return an error when invalid."""
-    if _is_blank_output(text):
-        return [], "empty output"
-
-    json_text = extract_json(text)
-    if not json_text:
-        return [], "no JSON payload found"
-
-    try:
-        data = json.loads(json_text)
-    except json.JSONDecodeError as exc:
-        return [], f"invalid JSON payload: {exc.msg}"
-
+def _valid_coverage_plan_entries(data: Any) -> List[Dict[str, Any]]:
     if isinstance(data, list):
         plan = data
     elif isinstance(data, dict) and "coverage_plan" in data and isinstance(data["coverage_plan"], list):
         plan = data["coverage_plan"]
     else:
-        return [], "coverage-plan payload must be a JSON array or an object with a coverage_plan array"
+        return []
 
     valid: List[Dict[str, Any]] = []
     for item in plan:
@@ -212,7 +236,35 @@ def parse_coverage_plan_json_detailed(text: Any) -> tuple[List[Dict[str, Any]], 
                 "scenarios": [scenario for scenario in scenarios if isinstance(scenario, dict)],
             }
         )
+    return valid
 
+
+def parse_coverage_plan_json_detailed(text: Any) -> tuple[List[Dict[str, Any]], Optional[str]]:
+    """Parse requirement coverage plan payload from model output and return an error when invalid."""
+    if _is_blank_output(text):
+        return [], "empty output"
+
+    json_text = extract_json(text)
+    if not json_text:
+        return [], "no JSON payload found"
+
+    try:
+        data = json.loads(json_text)
+    except json.JSONDecodeError as exc:
+        recovered_plan = _recover_complete_array_items(json_text, key="coverage_plan")
+        recovered_valid = _valid_coverage_plan_entries(recovered_plan)
+        if recovered_valid:
+            return recovered_valid, f"invalid JSON payload: {exc.msg}; recovered {len(recovered_valid)} complete coverage_plan entries"
+        return [], f"invalid JSON payload: {exc.msg}"
+
+    if isinstance(data, list):
+        plan = data
+    elif isinstance(data, dict) and "coverage_plan" in data and isinstance(data["coverage_plan"], list):
+        plan = data["coverage_plan"]
+    else:
+        return [], "coverage-plan payload must be a JSON array or an object with a coverage_plan array"
+
+    valid = _valid_coverage_plan_entries(plan)
     if valid:
         return valid, None
     if not plan:

--- a/backend/tests/test_generation_recovery.py
+++ b/backend/tests/test_generation_recovery.py
@@ -8,12 +8,24 @@ if str(BACKEND_DIR) not in sys.path:
     sys.path.insert(0, str(BACKEND_DIR))
 
 from app.agents.analysis_agent import fallback_requirement_analysis
-from app.agents.test_case_agent import generate_test_cases
+from app.agents.test_case_agent import _build_coverage_planner_agent, generate_test_cases
 from app.agents.test_case_coverage import _fallback_coverage_plan
 from app.models import GenerateTestCasesInput, Requirement, TestCaseTemplate
 
 
 class TestCaseGenerationRecoveryTests(unittest.TestCase):
+    def test_coverage_planner_uses_raw_json_output_for_parser_recovery(self) -> None:
+        agent = _build_coverage_planner_agent(
+            "test-model",
+            "REQ-001: The system shall allow users to sign in.",
+            "No additional context provided.",
+        )
+
+        self.assertIsNone(getattr(agent, "output_schema", None))
+        self.assertEqual(getattr(agent, "output_key", None), "coverage_plan")
+        self.assertGreaterEqual(agent.generate_content_config.max_output_tokens, 24000)
+        self.assertEqual(agent.generate_content_config.response_mime_type, "application/json")
+
     def test_rejected_model_suite_is_recovered_with_fallback_coverage(self) -> None:
         requirements = [
             Requirement(id="REQ-001", text="The system shall allow users to sign in using email and password."),

--- a/backend/tests/test_llm_json.py
+++ b/backend/tests/test_llm_json.py
@@ -225,6 +225,67 @@ class DetailedPayloadParserTests(unittest.TestCase):
         self.assertEqual(review_error, None)
         self.assertEqual(review["score"], 95)
 
+    def test_coverage_plan_parser_recovers_complete_entries_from_truncated_output(self) -> None:
+        payload = """
+        {
+          "coverage_plan": [
+            {
+              "requirement_id": "REQ-001",
+              "requirement_text": "Users can sign in.",
+              "scenarios": [
+                {
+                  "id": "REQ-001-SCN-01",
+                  "scenario_type": "Happy Path",
+                  "title": "Successful sign in",
+                  "objective": "Validate successful sign in.",
+                  "priority": "High",
+                  "must_have": true
+                }
+              ]
+            },
+            {
+              "requirement_id": "REQ-002",
+              "requirement_text": "Accounts lock after repeated failures.",
+              "scenarios": [
+                {
+                  "id": "REQ-002-SCN-01",
+                  "scenario_type": "Negative",
+                  "title": "Account lockout",
+                  "objective": "Validate lockout after failed attempts.",
+                  "priority": "High",
+                  "must_have": true
+                }
+              ]
+            },
+            {
+              "requirement_id": "REQ-003",
+              "requirement_text": "Audit events are retained.",
+              "scenarios": [
+                {
+                  "id": "REQ-003-SCN-01",
+                  "scenario_type": "Happy Path",
+                  "title": "Audit retention",
+                  "objective": "Validate audit retention.",
+                  "priority": "High",
+                  "must
+        """
+
+        coverage_plan, coverage_error = parse_coverage_plan_json_detailed(payload)
+
+        self.assertEqual([item["requirement_id"] for item in coverage_plan], ["REQ-001", "REQ-002"])
+        self.assertIsNotNone(coverage_error)
+        self.assertIn("invalid JSON payload", coverage_error)
+        self.assertIn("recovered 2 complete coverage_plan entries", coverage_error)
+
+    def test_coverage_plan_parser_rejects_truncated_output_without_complete_entries(self) -> None:
+        payload = '{"coverage_plan": [{"requirement_id": "REQ-001", "scenarios": [{"id": "REQ-001-SCN-01", "must'
+
+        coverage_plan, coverage_error = parse_coverage_plan_json_detailed(payload)
+
+        self.assertEqual(coverage_plan, [])
+        self.assertIsNotNone(coverage_error)
+        self.assertIn("invalid JSON payload", coverage_error)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #136.

## Summary
- Recover complete coverage-plan entries from malformed/truncated planner JSON instead of dropping the whole plan.
- Stop using ADK schema validation for the coverage planner so raw JSON reaches the backend parser and diagnostics path.
- Raise the coverage planner output cap from 12k to 24k tokens for larger QA projects like `testerx`.
- Record parser recovery in workflow diagnostics while allowing normalized fallback scenarios to fill missing requirements.

## Root cause
The `testerx` test-case generation failed before the generator stage because `CoveragePlannerAgent` used `RequirementCoveragePlanOutput` as an ADK `output_schema`. The model response was truncated mid-string, ADK raised a Pydantic JSON validation exception, and `_run_workflow_sync_inner` fell back after retries with no test cases from the pipeline.

## Validation
- `python -m unittest backend/tests/test_llm_json.py backend/tests/test_generation_recovery.py`
- `python -m unittest discover -s backend/tests -p 'test_*.py'` (286 tests)
- `python scripts/evaluate_generation.py --offline --strict`
- `python scripts/evaluate_requirements.py --offline --strict`
- `python scripts/export_openapi.py --output /tmp/agentic-tcg-openapi.json --indent 0`
