### PR TITLE
Remove header branding copy

### DIFF
--- a/frontend/src/components/layout/AppHeader.jsx
+++ b/frontend/src/components/layout/AppHeader.jsx
@@ -311,11 +311,6 @@ export default function CommandDeckHeader({
 
 	return (
 		<header className="command-header">
-			<div className="command-brand">
-				<h1 className="title">Agentic Test Case Generator</h1>
-				<p className="subtitle">QA command deck for requirements, generation, automation, and export.</p>
-			</div>
-
 			<ProjectMenu
 				projects={projects}
 				currentProject={currentProject}

--- a/frontend/src/styles/layout.css
+++ b/frontend/src/styles/layout.css
@@ -9,7 +9,7 @@
 /* Header */
 .command-header {
 	display: grid;
-	grid-template-columns: minmax(240px, 1.1fr) minmax(280px, 0.8fr) auto;
+	grid-template-columns: minmax(280px, 430px) minmax(0, 1fr);
 	align-items: center;
 	gap: 1.25rem;
 	margin: -0.25rem -0.5rem 1.25rem;
@@ -32,21 +32,6 @@
 	align-items: flex-end;
 	gap: 0.75rem;
 	min-width: 320px;
-}
-
-.title {
-	font-size: 1.45rem;
-	font-weight: 800;
-	letter-spacing: 0;
-	margin: 0;
-	color: #0f172a;
-}
-
-.subtitle {
-	color: var(--text-muted);
-	font-size: 0.86rem;
-	margin: 0.25rem 0 0;
-	max-width: 520px;
 }
 
 .command-project-control {


### PR DESCRIPTION
## Summary

- remove the visible app title and command-deck subtitle from the main header
- collapse the header grid to the remaining project selector and action controls
- leave browser metadata/title unchanged

## Validation

- `npm run build`
- `git diff --check`

Closes #153