### PR TITLE
Move app controls into left navigation

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,7 +7,7 @@ import {
 	hasFirebaseAuthConfig,
 	visibleFirebaseAuthProviders,
 } from "./firebase";
-import CommandDeckHeader, { SignInDialog } from "./components/layout/AppHeader";
+import AppNavigationControls, { SignInDialog } from "./components/layout/AppHeader";
 import AutomationPanel from "./components/automation/AutomationPanel";
 import ContextInputsPanel from "./components/context/ContextInputsPanel";
 import ExportPanel from "./components/export/ExportPanel";
@@ -3121,39 +3121,39 @@ export default function App() {
 		deleteStoredAzureDevOpsConnection,
 		isDeletingAzureDevOpsConnection,
 	};
+	const navigationControls = (
+		<AppNavigationControls
+			isAuthenticated={isAuthenticated}
+			billingStatusItems={billingStatusItems}
+			statusUsageItems={statusUsageItems}
+			isUsageLoading={isUsageLoading}
+			isBillingLoading={isBillingLoading}
+			onOpenSettings={() => openSettingsDialog("workflow")}
+			isVerifyingSession={isVerifyingSession}
+			currentUser={currentUser}
+			getAuthProviderLabel={getAuthProviderLabel}
+			handleLogout={handleLogout}
+			isAuthenticating={isAuthenticating}
+			hasFirebaseAuthConfig={hasFirebaseAuthConfig}
+			hasVisibleAuthProviders={hasVisibleAuthProviders}
+			openSignInDialog={openSignInDialog}
+			currentAuthProviderLabel={currentAuthProviderLabel}
+			projects={projects}
+			currentProject={currentProject}
+			isLoadingProjects={isLoadingProjects}
+			isOpeningProject={isOpeningProject}
+			authActionDisabled={authActionDisabled}
+			newProjectName={newProjectName}
+			setNewProjectName={setNewProjectName}
+			isCreatingProject={isCreatingProject}
+			onOpenProject={(projectId) => openProject(projectId)}
+			onCreateProject={createProject}
+			onRefreshProjects={() => loadProjects()}
+		/>
+	);
 
 	return (
 		<div className="page">
-			<CommandDeckHeader
-				status={status}
-				isAuthenticated={isAuthenticated}
-				billingStatusItems={billingStatusItems}
-				statusUsageItems={statusUsageItems}
-				isUsageLoading={isUsageLoading}
-				isBillingLoading={isBillingLoading}
-				onOpenSettings={() => openSettingsDialog("workflow")}
-				isVerifyingSession={isVerifyingSession}
-				currentUser={currentUser}
-				getAuthProviderLabel={getAuthProviderLabel}
-				handleLogout={handleLogout}
-				isAuthenticating={isAuthenticating}
-				hasFirebaseAuthConfig={hasFirebaseAuthConfig}
-				hasVisibleAuthProviders={hasVisibleAuthProviders}
-				openSignInDialog={openSignInDialog}
-				currentAuthProviderLabel={currentAuthProviderLabel}
-				projects={projects}
-				currentProject={currentProject}
-				isLoadingProjects={isLoadingProjects}
-				isOpeningProject={isOpeningProject}
-				authActionDisabled={authActionDisabled}
-				newProjectName={newProjectName}
-				setNewProjectName={setNewProjectName}
-				isCreatingProject={isCreatingProject}
-				onOpenProject={(projectId) => openProject(projectId)}
-				onCreateProject={createProject}
-				onRefreshProjects={() => loadProjects()}
-			/>
-
 			{!isAuthenticated && !isVerifyingSession && (
 				<div className="auth-warning-banner">🔐 Sign in to parse requirements, generate test cases, and export artifacts.</div>
 			)}
@@ -3192,6 +3192,7 @@ export default function App() {
 					statusByTabId={workflowNavStatusByTabId}
 					isCollapsed={isWorkflowNavCollapsed}
 					onToggleCollapsed={toggleWorkflowNavCollapsed}
+					controls={navigationControls}
 				/>
 
 				<main className="workflow-main" aria-label="Workflow workspace">

--- a/frontend/src/components/layout/AppHeader.jsx
+++ b/frontend/src/components/layout/AppHeader.jsx
@@ -45,10 +45,12 @@ function AuthPanel({
 				<span className="auth-message">Checking session...</span>
 			) : isAuthenticated ? (
 				<div className="auth-user">
-					{currentUser?.picture && <img src={currentUser.picture} alt={currentUser.name} className="auth-avatar" />}
-					<div className="auth-user-meta">
-						<strong>{currentUser?.name}</strong>
-						<span>{currentUser?.email || getAuthProviderLabel(currentUser?.provider) || currentUser?.sub}</span>
+					<div className="auth-user-identity">
+						{currentUser?.picture && <img src={currentUser.picture} alt={currentUser.name} className="auth-avatar" />}
+						<div className="auth-user-meta">
+							<strong>{currentUser?.name}</strong>
+							<span>{currentUser?.email || getAuthProviderLabel(currentUser?.provider) || currentUser?.sub}</span>
+						</div>
 					</div>
 					<button type="button" onClick={handleLogout} className="secondary auth-logout-btn" disabled={isAuthenticating}>
 						{isAuthenticating ? "Signing out..." : "Sign Out"}
@@ -279,7 +281,7 @@ export function SignInDialog({ isOpen, onOverlayClick, onClose, isAuthenticating
 	);
 }
 
-export default function CommandDeckHeader({
+export default function AppNavigationControls({
 	isAuthenticated,
 	billingStatusItems,
 	statusUsageItems,
@@ -310,7 +312,7 @@ export default function CommandDeckHeader({
 	const healthLabel = isAuthenticated ? "System healthy" : "Sign in required";
 
 	return (
-		<header className="command-header">
+		<div className="app-navigation-controls" aria-label="Workspace controls">
 			<ProjectMenu
 				projects={projects}
 				currentProject={currentProject}
@@ -325,48 +327,46 @@ export default function CommandDeckHeader({
 				onRefreshProjects={onRefreshProjects}
 			/>
 
-			<div className="command-actions">
-				<details className={`command-health ${isAuthenticated ? "status-authenticated" : ""}`}>
-					<summary>
-						<span className="command-health-dot" aria-hidden="true" />
-						<span className="status-message">{healthLabel}</span>
-					</summary>
-					<div className="command-health-details">
-						<p>
-							{isAuthenticated ? "Session active. Workflow messages stay in the active workspace." : "Sign in to enable workflow actions."}
-						</p>
-						{isAuthenticated && (
-							<StatusUsagePills
-								billingStatusItems={billingStatusItems}
-								statusUsageItems={statusUsageItems}
-								isUsageLoading={isUsageLoading}
-								isBillingLoading={isBillingLoading}
-							/>
-						)}
-					</div>
-				</details>
-				<button
-					type="button"
-					className="settings-open-btn"
-					data-testid="settings-open-button"
-					onClick={onOpenSettings}
-					aria-label="Open settings"
-				>
-					Settings
-				</button>
-				<AuthPanel
-					isVerifyingSession={isVerifyingSession}
-					isAuthenticated={isAuthenticated}
-					currentUser={currentUser}
-					getAuthProviderLabel={getAuthProviderLabel}
-					handleLogout={handleLogout}
-					isAuthenticating={isAuthenticating}
-					hasFirebaseAuthConfig={hasFirebaseAuthConfig}
-					hasVisibleAuthProviders={hasVisibleAuthProviders}
-					openSignInDialog={openSignInDialog}
-					currentAuthProviderLabel={currentAuthProviderLabel}
-				/>
-			</div>
-		</header>
+			<details className={`command-health ${isAuthenticated ? "status-authenticated" : ""}`}>
+				<summary>
+					<span className="command-health-dot" aria-hidden="true" />
+					<span className="status-message">{healthLabel}</span>
+				</summary>
+				<div className="command-health-details">
+					<p>
+						{isAuthenticated ? "Session active. Workflow messages stay in the active workspace." : "Sign in to enable workflow actions."}
+					</p>
+					{isAuthenticated && (
+						<StatusUsagePills
+							billingStatusItems={billingStatusItems}
+							statusUsageItems={statusUsageItems}
+							isUsageLoading={isUsageLoading}
+							isBillingLoading={isBillingLoading}
+						/>
+					)}
+				</div>
+			</details>
+			<button
+				type="button"
+				className="settings-open-btn"
+				data-testid="settings-open-button"
+				onClick={onOpenSettings}
+				aria-label="Open settings"
+			>
+				Settings
+			</button>
+			<AuthPanel
+				isVerifyingSession={isVerifyingSession}
+				isAuthenticated={isAuthenticated}
+				currentUser={currentUser}
+				getAuthProviderLabel={getAuthProviderLabel}
+				handleLogout={handleLogout}
+				isAuthenticating={isAuthenticating}
+				hasFirebaseAuthConfig={hasFirebaseAuthConfig}
+				hasVisibleAuthProviders={hasVisibleAuthProviders}
+				openSignInDialog={openSignInDialog}
+				currentAuthProviderLabel={currentAuthProviderLabel}
+			/>
+		</div>
 	);
 }

--- a/frontend/src/components/layout/WorkflowNavigationDrawer.jsx
+++ b/frontend/src/components/layout/WorkflowNavigationDrawer.jsx
@@ -23,6 +23,7 @@ export default function WorkflowNavigationDrawer({
 	statusByTabId = {},
 	isCollapsed = false,
 	onToggleCollapsed,
+	controls = null,
 }) {
 	const toggleLabel = isCollapsed ? "Expand workflow navigation" : "Collapse workflow navigation";
 	const ToggleIcon = isCollapsed ? PanelLeftOpen : PanelLeftClose;
@@ -71,6 +72,7 @@ export default function WorkflowNavigationDrawer({
 					);
 				})}
 			</div>
+			{controls && <div className="workflow-navigation-controls">{controls}</div>}
 		</nav>
 	);
 }

--- a/frontend/src/styles/layout.css
+++ b/frontend/src/styles/layout.css
@@ -6,17 +6,6 @@
 	min-height: 100vh;
 }
 
-/* Header */
-.command-header {
-	display: grid;
-	grid-template-columns: minmax(280px, 430px) minmax(0, 1fr);
-	align-items: center;
-	gap: 1.25rem;
-	margin: -0.25rem -0.5rem 1.25rem;
-	padding: 0.9rem 0.5rem 1.1rem;
-	border-bottom: 1px solid rgba(148, 163, 184, 0.24);
-}
-
 .header {
 	display: flex;
 	justify-content: space-between;
@@ -32,6 +21,18 @@
 	align-items: flex-end;
 	gap: 0.75rem;
 	min-width: 320px;
+}
+
+.app-navigation-controls {
+	display: grid;
+	gap: 0.75rem;
+	min-width: 0;
+	padding-top: 0.85rem;
+	border-top: 1px solid rgba(148, 163, 184, 0.26);
+}
+
+.app-navigation-controls > * {
+	min-width: 0;
 }
 
 .command-project-control {
@@ -262,17 +263,9 @@
 	white-space: nowrap;
 }
 
-.command-actions {
-	display: flex;
-	align-items: center;
-	justify-content: flex-end;
-	gap: 0.75rem;
-	min-width: 0;
-}
-
 .command-health {
 	position: relative;
-	min-width: 170px;
+	min-width: 0;
 	border: 1px solid #cfe0f7;
 	border-radius: var(--radius-md);
 	background: #ffffff;
@@ -303,16 +296,16 @@
 }
 
 .command-health-details {
-	position: absolute;
+	position: static;
 	z-index: 5;
-	top: calc(100% + 0.4rem);
-	right: 0;
-	width: min(360px, 88vw);
+	width: 100%;
+	box-sizing: border-box;
+	margin-top: 0.4rem;
 	padding: 0.85rem;
 	border: 1px solid var(--border-color);
 	border-radius: var(--radius-md);
 	background: #ffffff;
-	box-shadow: var(--shadow-lg);
+	box-shadow: none;
 }
 
 .command-health-details p {
@@ -407,24 +400,33 @@
 
 .auth-panel {
 	display: flex;
-	align-items: center;
-	justify-content: flex-end;
+	align-items: stretch;
+	justify-content: flex-start;
 	width: 100%;
-	min-height: 42px;
+	min-height: 0;
 }
 
 .auth-login {
 	display: flex;
-	justify-content: flex-end;
+	justify-content: flex-start;
+	width: 100%;
+}
+
+.auth-login button {
 	width: 100%;
 }
 
 .auth-user {
+	display: grid;
+	gap: 0.65rem;
+	width: 100%;
+}
+
+.auth-user-identity {
 	display: flex;
 	align-items: center;
-	justify-content: flex-end;
-	gap: 0.75rem;
-	width: 100%;
+	gap: 0.65rem;
+	min-width: 0;
 }
 
 .auth-avatar {
@@ -438,8 +440,16 @@
 .auth-user-meta {
 	display: flex;
 	flex-direction: column;
-	text-align: right;
+	min-width: 0;
+	text-align: left;
 	line-height: 1.2;
+}
+
+.auth-user-meta strong,
+.auth-user-meta span {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 .auth-user-meta strong {
@@ -453,6 +463,7 @@
 }
 
 .auth-logout-btn {
+	width: 100%;
 	padding: 0.5rem 0.8rem;
 	font-size: 0.8rem;
 }
@@ -460,7 +471,9 @@
 .settings-open-btn {
 	display: inline-flex;
 	align-items: center;
+	justify-content: center;
 	gap: 0.45rem;
+	width: 100%;
 	padding: 0.62rem 0.85rem;
 	border: 1px solid var(--border-color);
 	background: var(--card-bg);
@@ -804,7 +817,7 @@
 
 /* Workflow Navigation */
 .workflow-shell {
-	--workflow-nav-column: minmax(210px, 240px);
+	--workflow-nav-column: minmax(260px, 300px);
 	--project-rail-column: minmax(300px, 360px);
 
 	display: grid;
@@ -893,6 +906,12 @@
 .workflow-navigation-list {
 	display: grid;
 	gap: 0.4rem;
+}
+
+.workflow-navigation-controls {
+	display: grid;
+	gap: 0.75rem;
+	min-width: 0;
 }
 
 .workflow-navigation-item {
@@ -1020,6 +1039,7 @@
 
 .workflow-navigation-drawer.collapsed .workflow-navigation-header > div,
 .workflow-navigation-drawer.collapsed .workflow-navigation-header strong,
+.workflow-navigation-drawer.collapsed .workflow-navigation-controls,
 .workflow-navigation-drawer.collapsed .workflow-navigation-copy,
 .workflow-navigation-drawer.collapsed .workflow-navigation-copy span,
 .workflow-navigation-drawer.collapsed .workflow-navigation-state {

--- a/frontend/src/styles/responsive.css
+++ b/frontend/src/styles/responsive.css
@@ -1,13 +1,13 @@
 /* Responsive */
 @media (max-width: 1100px) {
 	.workflow-shell {
-		--workflow-nav-column: minmax(84px, 96px);
+		--workflow-nav-column: minmax(240px, 280px);
 
 		grid-template-columns: var(--workflow-nav-column) minmax(0, 1fr);
 	}
 
 	.workflow-shell.nav-collapsed {
-		--workflow-nav-column: 64px;
+		--workflow-nav-column: 72px;
 	}
 
 	.project-information-rail {
@@ -18,21 +18,6 @@
 
 	.workflow-navigation-drawer {
 		padding: 0.7rem;
-	}
-
-	.workflow-navigation-header strong,
-	.workflow-navigation-copy,
-	.workflow-navigation-copy span,
-	.workflow-navigation-state {
-		display: none;
-	}
-
-	.workflow-navigation-item {
-		grid-template-columns: 1fr;
-		justify-items: center;
-		gap: 0.35rem;
-		padding: 0.62rem 0.45rem;
-		text-align: center;
 	}
 }
 
@@ -82,18 +67,6 @@
 	.workflow-navigation-state {
 		grid-column: 2;
 		justify-self: start;
-	}
-
-	.command-header {
-		grid-template-columns: 1fr;
-		gap: 0.85rem;
-		margin-left: 0;
-		margin-right: 0;
-	}
-
-	.command-actions {
-		justify-content: flex-start;
-		flex-wrap: wrap;
 	}
 
 	.command-project-control {
@@ -159,15 +132,6 @@
 	.auth-panel,
 	.auth-login {
 		justify-content: flex-start;
-	}
-
-	.settings-open-btn {
-		align-self: flex-start;
-	}
-
-	.auth-user {
-		justify-content: flex-start;
-		flex-wrap: wrap;
 	}
 
 	.auth-dialog-overlay {


### PR DESCRIPTION
## Summary

- move the project selector, health indicator, settings button, and auth/user controls into the workflow navigation drawer
- remove the redundant top command header from the page layout
- keep existing project, settings, health, and auth handlers wired through the same component
- widen the left navigation at desktop/tablet widths so the moved controls remain usable

## Validation

- `npm ci`
- `npm run build`
- `git diff --check`
- Playwright CLI rendered checks at 1440x900 and 390x844
- Playwright CLI verified the relocated Settings button opens the existing Settings dialog

## Stacking

Stacked on PR #154 / issue #153 because this assumes the standalone header branding is already removed. Retarget this PR to `main` after #154 merges.

Closes #155