### PR TITLE
Assign unique IDs to backfilled coverage scenarios (#231)

### DIFF
--- a/backend/app/agents/test_case_coverage.py
+++ b/backend/app/agents/test_case_coverage.py
@@ -520,10 +520,18 @@ def _normalize_coverage_plan(raw_plan: List[Dict[str, Any]], requirements: List[
             continue
 
         existing_types = {scenario["scenario_type"] for scenario in existing["scenarios"]}
+        existing_ids = {scenario["id"] for scenario in existing["scenarios"]}
         for default_scenario in _default_scenarios_for_requirement(requirement):
             if default_scenario["scenario_type"] in existing_types or len(existing["scenarios"]) >= 4:
                 continue
-            existing["scenarios"].append({**default_scenario, "must_have": False})
+            # Default IDs are index-based and may collide with model-supplied IDs.
+            sequence = len(existing["scenarios"]) + 1
+            scenario_id = f"{requirement.id}-SCN-{sequence:02d}"
+            while scenario_id in existing_ids:
+                sequence += 1
+                scenario_id = f"{requirement.id}-SCN-{sequence:02d}"
+            existing_ids.add(scenario_id)
+            existing["scenarios"].append({**default_scenario, "id": scenario_id, "must_have": False})
             existing_types.add(default_scenario["scenario_type"])
 
         normalized_plan.append(existing)

--- a/backend/tests/test_analysis_coverage_metrics.py
+++ b/backend/tests/test_analysis_coverage_metrics.py
@@ -320,6 +320,50 @@ class CoveragePlanNormalizationTests(unittest.TestCase):
         self.assertTrue(scenarios[0]["must_have"])
         self.assertTrue(all(not scenario["must_have"] for scenario in scenarios[1:]))
 
+    def test_backfilled_scenarios_do_not_reuse_existing_ids(self) -> None:
+        requirements = [
+            Requirement(
+                id="REQ-001",
+                text="The system shall display the dashboard summary for the signed-in user.",
+            )
+        ]
+
+        normalized_plan = _normalize_coverage_plan(
+            [
+                {
+                    "requirement_id": "REQ-001",
+                    "requirement_text": requirements[0].text,
+                    "scenarios": [
+                        {
+                            "id": "REQ-001-SCN-01",
+                            "scenario_type": "Happy Path",
+                            "title": "Dashboard summary is displayed",
+                            "objective": "Verify the signed-in user sees the dashboard summary.",
+                            "priority": "High",
+                            "must_have": True,
+                        },
+                        {
+                            "id": "REQ-001-SCN-03",
+                            "scenario_type": "Negative",
+                            "title": "Dashboard summary hidden when signed out",
+                            "objective": "Verify signed-out users cannot see the dashboard summary.",
+                            "priority": "High",
+                            "must_have": True,
+                        },
+                    ],
+                }
+            ],
+            requirements,
+        )
+
+        scenarios = normalized_plan[0]["scenarios"]
+        ids = [scenario["id"] for scenario in scenarios]
+        self.assertEqual(len(ids), len(set(ids)))
+        self.assertEqual(ids[:2], ["REQ-001-SCN-01", "REQ-001-SCN-03"])
+        self.assertGreater(len(scenarios), 2)
+        self.assertNotIn("REQ-001-SCN-03", ids[2:])
+        self.assertTrue(all(scenario_id.startswith("REQ-001-SCN-") for scenario_id in ids))
+
     def test_heuristic_review_ignores_backfilled_optional_scenario_gaps(self) -> None:
         requirements = [
             Requirement(


### PR DESCRIPTION
Closes #231

## Summary
- `_normalize_coverage_plan` backfilled default scenarios with fixed index-based IDs (`REQ-XXX-SCN-<index>`), which collided with model-supplied scenario IDs (e.g. `REQ-001-SCN-03` appearing twice). This surfaced as duplicate React key warnings/errors on the Use Cases page.
- Backfill now allocates the next free `SCN` sequence for the requirement, preserving existing IDs untouched.
- Added `test_backfilled_scenarios_do_not_reuse_existing_ids` covering the collision case.

## Validation
- `python -m unittest discover -s backend/tests -p 'test_*.py'` — 377 tests OK
- `python scripts/evaluate_requirements.py --offline --strict` — pass (avg_score=100)
- `python scripts/evaluate_generation.py --offline --strict` — pass (avg_score=100)
- `python scripts/export_openapi.py --output /tmp/agentic-tcg-openapi.json --indent 0` — OK

No frontend files changed.