### PR TITLE
Fix scenario counts in Home and Reviews

### DIFF
--- a/backend/app/contracts/workspace.py
+++ b/backend/app/contracts/workspace.py
@@ -40,6 +40,7 @@ class WorkspaceWorkItem(BaseModel):
     enabled: bool = False
     primary: bool = False
     count: Optional[int] = Field(default=None, ge=0)
+    requirement_group_count: Optional[int] = Field(default=None, ge=0)
     reason: str
     current_snapshot_id: Optional[str] = None
     updated_at: datetime

--- a/backend/app/services/workflow_project_service.py
+++ b/backend/app/services/workflow_project_service.py
@@ -227,8 +227,11 @@ def list_projects(*, actor: AuthUser, include_archived: bool = False) -> list[Qa
     return projects
 
 
-def _workspace_snapshot_for(project_id: str, snapshot_id: str) -> Optional[QaProjectStageSnapshot]:
-    payload = _document_to_dict(_get_project_doc(project_id).collection("snapshots").document(snapshot_id).get(field_paths=WORKSPACE_SNAPSHOT_FIELDS))
+def _workspace_snapshot_for(project_id: str, snapshot_id: str, stage: ProjectStageName) -> Optional[QaProjectStageSnapshot]:
+    # Coverage plans are arrays, so Firestore cannot project just nested scenario IDs.
+    # Read the current use-case plan to count legacy artifacts without rewriting them.
+    fields = WORKSPACE_SNAPSHOT_FIELDS + (("payload.coverage_plan",) if stage == "use_cases" else ())
+    payload = _document_to_dict(_get_project_doc(project_id).collection("snapshots").document(snapshot_id).get(field_paths=fields))
     if not payload:
         return None
     snapshot = QaProjectStageSnapshot.model_validate(payload)
@@ -331,7 +334,7 @@ def list_workspace_projects(
         for stage, state in summary.stage_state.items():
             if not state.current_snapshot_id:
                 continue
-            current_snapshot = _workspace_snapshot_for(summary.project_id, state.current_snapshot_id)
+            current_snapshot = _workspace_snapshot_for(summary.project_id, state.current_snapshot_id, stage)
             if current_snapshot is not None and current_snapshot.stage == stage:
                 current_snapshots[stage] = current_snapshot
 

--- a/backend/app/services/workspace_summary_service.py
+++ b/backend/app/services/workspace_summary_service.py
@@ -78,6 +78,8 @@ def _work_item_count(
     snapshot_count = _snapshot_count(snapshot, stage_state.stage)
     if snapshot_count is not None:
         return snapshot_count
+    if stage_state.stage == "use_cases":
+        return None
     return _first_count(
         dict(stage_state.summary or {}),
         (
@@ -91,6 +93,14 @@ def _work_item_count(
             "evidence_count",
         ),
     )
+
+
+def _requirement_group_count(project: QaProjectDetail, stage: OrchestratorStageName) -> Optional[int]:
+    if stage != "use_cases":
+        return None
+    snapshot = project.current_snapshots.get(stage)
+    plan = snapshot.payload.get("coverage_plan") if snapshot else None
+    return len(plan) if isinstance(plan, list) else None
 
 
 def _work_item_kind(action: OrchestratorActionRecommendation) -> str:
@@ -124,6 +134,7 @@ def _work_item_for(
         enabled=action.enabled,
         primary=action.primary,
         count=_work_item_count(project, stage_state),
+        requirement_group_count=_requirement_group_count(project, stage_state.stage),
         reason=reason,
         current_snapshot_id=snapshot_id,
         updated_at=updated_at,
@@ -150,6 +161,7 @@ def _informational_work_item_for(
         enabled=False,
         primary=False,
         count=_work_item_count(project, stage_state),
+        requirement_group_count=_requirement_group_count(project, stage_state.stage),
         reason=reason,
         current_snapshot_id=stage_state.current_snapshot_id,
         updated_at=stage_state.updated_at or project.updated_at,

--- a/backend/tests/test_workspace_summary_service.py
+++ b/backend/tests/test_workspace_summary_service.py
@@ -137,8 +137,23 @@ class FakeDocument:
         self.query_log = query_log
 
     def get(self, field_paths: Optional[tuple[str, ...]] = None) -> FakeSnapshot:
-        del field_paths
-        return FakeSnapshot(self.store.get(self.path), self.path.rsplit("/", 1)[-1])
+        payload = self.store.get(self.path)
+        if payload is not None and field_paths is not None:
+            projected = {}
+            for field in field_paths:
+                parts = field.split(".")
+                source = payload
+                for part in parts:
+                    if not isinstance(source, dict) or part not in source:
+                        break
+                    source = source[part]
+                else:
+                    target = projected
+                    for part in parts[:-1]:
+                        target = target.setdefault(part, {})
+                    target[parts[-1]] = source
+            payload = projected
+        return FakeSnapshot(payload, self.path.rsplit("/", 1)[-1])
 
     def collection(self, name: str) -> "FakeCollection":
         return FakeCollection(f"{self.path}/{name}", self.store, self.query_log)
@@ -288,6 +303,55 @@ class WorkspaceSummaryServiceTests(unittest.TestCase):
         self.assertIn("approved", review_item.reason.lower())
         self.assertEqual(result.projects[0].current_stage, "use_cases")
         self.assertEqual(result.projects[0].current_status, "attention_required")
+
+    def test_persisted_use_case_counts_follow_current_snapshot_and_refresh(self) -> None:
+        plan = [{"requirement_id": f"REQ-{i}", "scenarios": [{"id": f"SCN-{i}-{j}"} for j in range(4 if i < 4 else 3)]} for i in range(8)]
+        actor = AuthUser(sub="user-1", email="user@example.com", name="User")
+        snapshot = _snapshot(
+            project_id="counts",
+            stage="use_cases",
+            snapshot_id="use-cases-1",
+            created_at=BASE_TIME,
+            payload={"coverage_plan": plan, "private_unneeded_payload": "not projected"},
+            metadata={"coverage_plan_count": 8},
+        )
+        project = _project(
+            "counts",
+            stage_state={
+                "requirements": _stage_state("requirements-1", updated_at=BASE_TIME, approved=True),
+                "use_cases": _stage_state(snapshot.snapshot_id, updated_at=BASE_TIME, metadata={"coverage_plan_count": 8}),
+            },
+        )
+        project_data = project.model_dump(exclude={"current_snapshots", "timeline", "execution_runs"})
+        store = {
+            "qa_projects/counts": project_data,
+            "qa_projects/counts/snapshots/use-cases-1": snapshot.model_dump(),
+        }
+        collection = FakeCollection("qa_projects", store, [])
+        with patch("app.services.workflow_project_service.get_required_firestore_collection", return_value=collection):
+            for version, payload, expected_count, expected_groups in [
+                (1, {"coverage_plan": plan}, 28, 8),
+                (2, {"coverage_plan": [{"scenarios": [{"id": "new"}]}]}, 1, 1),
+                (3, {"coverage_plan": []}, 0, 0),
+                (4, {}, None, None),
+            ]:
+                with self.subTest(version=version):
+                    snapshot_id = f"use-cases-{version}"
+                    store[f"qa_projects/counts/snapshots/{snapshot_id}"] = {
+                        **snapshot.model_dump(),
+                        "snapshot_id": snapshot_id,
+                        "payload": {**payload, "private_unneeded_payload": "not projected"},
+                    }
+                    project_data["stage_state"]["use_cases"]["current_snapshot_id"] = snapshot_id
+                    projects = list_workspace_projects(actor=actor, include_archived=False, project_limit=20, execution_run_limit=20)
+                    result = build_workspace_summary(projects, work_items_limit=50, runs_limit=20, reports_limit=20)
+                    item = next(item for item in result.work_items if item.stage == "use_cases")
+                    self.assertEqual(item.current_snapshot_id, snapshot_id)
+                    self.assertEqual(item.count, expected_count)
+                    self.assertEqual(item.requirement_group_count, expected_groups)
+                    self.assertEqual(result.continue_working.count, expected_count)
+                    self.assertNotIn("coverage_plan", item.model_dump())
+                    self.assertNotIn("private_unneeded_payload", projects[0].current_snapshots["use_cases"].payload)
 
     def test_work_items_are_deduplicated_ranked_and_used_for_continue_working(self) -> None:
         enabled_project = _project("project-a", updated_at=BASE_TIME)

--- a/docs/codebase/CONVENTIONS.md
+++ b/docs/codebase/CONVENTIONS.md
@@ -233,3 +233,13 @@ work.
 - `frontend/eslint.config.js`
 - `frontend/.prettierrc.json`
 - `frontend/package.json`
+
+### Workspace use-case counts (#237)
+
+For `use_cases` work items, `count` is the total number of nested scenarios in
+`coverage_plan`; `requirement_group_count` is the number of groups in that plan.
+Home and Reviews show both units. Empty plans yield zero; unavailable plans yield
+null counts rather than falling back to `coverage_plan_count` (a group count).
+Workspace reads project the current use-case coverage plan internally so existing
+snapshots need no migration or regeneration. Raw plans are not returned in the
+workspace summary API. Other stages keep their existing count semantics.

--- a/docs/github-issues-backlog.md
+++ b/docs/github-issues-backlog.md
@@ -2,6 +2,10 @@
 
 This file contains issue-ready drafts for the implementation plan in `docs/implementation-plan.md`.
 
+## UI/UX audit follow-up
+
+- In progress: [#237](https://github.com/lumensparkxy/agentic_test_case_generator/issues/237) — Correct use-case scenario counts in workspace summaries. Count nested scenarios separately from requirement groups and keep Home, Reviews, and the current artifact consistent.
+
 ## Created GitHub issues
 
 The original Phase 0 through Phase 2 issues in this section are historical

--- a/frontend/e2e/review-inbox.spec.js
+++ b/frontend/e2e/review-inbox.spec.js
@@ -2,7 +2,7 @@ import { expect, test } from "@playwright/test";
 
 import { buildProjectPath } from "../src/app/workflowRoutes.js";
 import { seedAuthenticatedSession } from "./support/auth.js";
-import { installUseCaseReviewApi, useCaseProjectFixture } from "./support/use-case-review.js";
+import { installUseCaseReviewApi, useCaseProjectFixture, useCaseSnapshotFixture } from "./support/use-case-review.js";
 import {
 	createDeferred,
 	installWorkspaceApi,
@@ -488,4 +488,30 @@ test.describe("Global Review Inbox", () => {
 		await expect.poll(() => api.requests.workspaceSummary.length).toBeGreaterThanOrEqual(3);
 		expect(api.requests.review).toHaveLength(1);
 	});
+});
+
+test("scenario counts agree across Home, Reviews, and the current artifact after refresh", async ({ page }) => {
+	const snapshot = useCaseSnapshotFixture();
+	snapshot.payload.coverage_plan = Array.from({ length: 8 }, (_, i) => ({
+		requirement_id: `REQ-${i}`,
+		requirement_text: `Requirement ${i}`,
+		scenarios: Array.from({ length: i < 4 ? 4 : 3 }, (_, j) => ({
+			id: `SCN-${i}-${j}`,
+			title: `Scenario ${i}-${j}`,
+			objective: "Verify the requirement",
+			priority: "High",
+		})),
+	}));
+	const project = useCaseProjectFixture({ snapshot });
+	await installUseCaseReviewApi(page, { initialProject: project });
+	await seedAuthenticatedSession(page);
+	await page.goto("/");
+	await expect(page.getByRole("region", { name: "Continue working" })).toContainText("28 scenarios · 8 requirement groups");
+	await page.getByRole("navigation", { name: "Global navigation" }).getByRole("link", { name: "Reviews", exact: true }).click();
+	await expect(inboxList(page)).toContainText("28 scenarios · 8 requirement groups");
+	await page.getByRole("button", { name: "Refresh reviews" }).click();
+	await expect(inboxList(page)).toContainText("28 scenarios · 8 requirement groups");
+	await inboxList(page).getByRole("link").click();
+	await expect(page.getByRole("heading", { name: "28 scenarios", exact: true })).toBeVisible();
+	await expect(page.getByRole("region", { name: "28 scenarios", exact: true })).toContainText("8 requirement groups");
 });

--- a/frontend/e2e/support/use-case-review.js
+++ b/frontend/e2e/support/use-case-review.js
@@ -398,6 +398,7 @@ export function useCaseWorkspaceSummaryFixture(project, overrides = {}) {
 				enabled: action.enabled,
 				primary: action.primary,
 				count: action.stage === "use_cases" ? useCaseScenarioTotal(project) : null,
+				requirement_group_count: action.stage === "use_cases" ? (snapshot?.payload?.coverage_plan?.length ?? null) : null,
 				reason: action.reason,
 				current_snapshot_id: snapshot?.snapshot_id || null,
 				updated_at: project.updated_at,

--- a/frontend/src/api/generated/api-contracts.d.ts
+++ b/frontend/src/api/generated/api-contracts.d.ts
@@ -1034,6 +1034,7 @@ export interface WorkspaceWorkItem {
 	project_name: string;
 	project_revision: number;
 	reason: string;
+	requirement_group_count?: number | null;
 	stage: "requirements" | "context" | "use_cases" | "impact_analysis" | "test_cases" | "automation" | "execution" | "review" | "reports";
 	status: "not_started" | "ready" | "blocked" | "completed" | "stale" | "failed" | "attention_required";
 	updated_at: string;

--- a/frontend/src/components/reviews/ReviewInbox.jsx
+++ b/frontend/src/components/reviews/ReviewInbox.jsx
@@ -2,6 +2,7 @@ import { CircleAlert, CircleCheck, ClipboardCheck, Info, ListChecks, Sparkles, W
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import {
+	formatWorkItemCount,
 	formatWorkspaceDate,
 	formatWorkspaceLabel,
 	formatWorkspaceStatus,
@@ -52,6 +53,7 @@ export const isActionableReviewItem = (item) =>
 	item?.enabled === true && item?.kind !== "information" && !COMPLETED_STATUSES.has(item?.status);
 
 const formatCount = (item) => {
+	if (item?.stage === "use_cases") return formatWorkItemCount(item);
 	if (!Number.isInteger(item?.count)) return "";
 	const unit = COUNT_UNIT_BY_STAGE[item.stage] || "item";
 	return `${item.count} ${unit}${item.count === 1 ? "" : "s"}`;

--- a/frontend/src/components/workspace/HomeWorkspaceSections.jsx
+++ b/frontend/src/components/workspace/HomeWorkspaceSections.jsx
@@ -3,6 +3,7 @@ import { Activity, ClipboardCheck, FileText, FolderKanban, PlayCircle } from "lu
 
 import { PROJECT_DESTINATIONS } from "../../app/workflowRoutes";
 import {
+	formatWorkItemCount,
 	formatWorkspaceDate,
 	formatWorkspaceLabel,
 	getProjectDestination,
@@ -37,7 +38,7 @@ export function ContinueWorkingSection({
 						</div>
 						<h3>{getWorkItemTitle(item)}</h3>
 						<p>{item.reason}</p>
-						{Number.isInteger(item.count) ? <span className="workspace-count">{item.count} items</span> : null}
+						{formatWorkItemCount(item) ? <span className="workspace-count">{formatWorkItemCount(item)}</span> : null}
 						<ProjectProgress completed={project?.completed_stage_count} total={project?.total_stage_count} />
 					</div>
 					<ProjectOpenLink
@@ -115,7 +116,7 @@ export function MyWorkSection({
 												</div>
 												<strong>{getWorkItemTitle(item)}</strong>
 												<p>{item.reason}</p>
-												{Number.isInteger(item.count) ? <span className="workspace-count">{item.count} items</span> : null}
+												{formatWorkItemCount(item) ? <span className="workspace-count">{formatWorkItemCount(item)}</span> : null}
 											</div>
 											<ProjectOpenLink projectId={item.project_id} destination={getWorkItemDestination(item)} onOpenProject={onOpenProject}>
 												Open

--- a/frontend/src/components/workspace/workspacePresentation.js
+++ b/frontend/src/components/workspace/workspacePresentation.js
@@ -111,3 +111,13 @@ export const matchesWorkspaceQuery = (query, ...values) => {
 export function getProjectPath(projectId, destination = PROJECT_DESTINATIONS.OVERVIEW) {
 	return buildProjectPath(projectId, destination);
 }
+
+export const formatWorkItemCount = (item) => {
+	if (item?.stage !== "use_cases") return Number.isInteger(item?.count) ? `${item.count} items` : "";
+	const parts = [];
+	if (Number.isInteger(item.count)) parts.push(`${item.count} scenario${item.count === 1 ? "" : "s"}`);
+	if (Number.isInteger(item.requirement_group_count)) {
+		parts.push(`${item.requirement_group_count} requirement group${item.requirement_group_count === 1 ? "" : "s"}`);
+	}
+	return parts.join(" · ");
+};


### PR DESCRIPTION
## Change
Fixes #237.

A persisted artifact with 28 scenarios across 8 requirement groups appeared as “8 scenarios” in Reviews and “8 items” on Home. The workspace snapshot projection omitted the coverage plan, causing the count to fall back to group metadata.

Read the current use-case plan for workspace counts, return a separate optional `requirement_group_count`, and show “28 scenarios · 8 requirement groups” consistently in Home and Reviews. Missing plans produce unknown counts; empty plans produce zero. Existing artifacts need no regeneration or migration.

## Validation
- Backend unittest discovery: 379 passed; focused persisted-count test covers 28/8, newer current snapshots, empty and unavailable plans.
- Focused Home, Reviews, and Use Cases E2E: 62 passed, including cross-screen count comparison and refresh.
- Strict offline requirements, generation, and orchestrator evaluations: passed.
- OpenAPI export and generated frontend API type check: passed.
- Backend Ruff lint/format and frontend lint/format: passed.
- `npm ci` and frontend production build: passed. Existing large JavaScript chunk warning remains.
- Live local authenticated project: Home and Reviews show 28 scenarios · 8 requirement groups after refresh; Use Cases still shows 28 scenarios across 8 groups, revision 5. No artifact or approval changes made.

## Tradeoff
Firestore cannot project individual fields within coverage-plan arrays, so workspace reads include the current use-case plan internally. The request remains bounded by the existing project limits, and raw plans are not exposed in the summary response. Other stage projections and count semantics are unchanged.
