### PR TITLE
Unify Overview and artifact review screens (#239)

### DIFF
--- a/backend/app/contracts/workspace.py
+++ b/backend/app/contracts/workspace.py
@@ -40,6 +40,7 @@ class WorkspaceWorkItem(BaseModel):
     enabled: bool = False
     primary: bool = False
     count: Optional[int] = Field(default=None, ge=0)
+    requirement_group_count: Optional[int] = Field(default=None, ge=0)
     reason: str
     current_snapshot_id: Optional[str] = None
     updated_at: datetime

--- a/backend/app/services/workflow_project_service.py
+++ b/backend/app/services/workflow_project_service.py
@@ -227,8 +227,11 @@ def list_projects(*, actor: AuthUser, include_archived: bool = False) -> list[Qa
     return projects
 
 
-def _workspace_snapshot_for(project_id: str, snapshot_id: str) -> Optional[QaProjectStageSnapshot]:
-    payload = _document_to_dict(_get_project_doc(project_id).collection("snapshots").document(snapshot_id).get(field_paths=WORKSPACE_SNAPSHOT_FIELDS))
+def _workspace_snapshot_for(project_id: str, snapshot_id: str, stage: ProjectStageName) -> Optional[QaProjectStageSnapshot]:
+    # Coverage plans are arrays, so Firestore cannot project just nested scenario IDs.
+    # Read the current use-case plan to count legacy artifacts without rewriting them.
+    fields = WORKSPACE_SNAPSHOT_FIELDS + (("payload.coverage_plan",) if stage == "use_cases" else ())
+    payload = _document_to_dict(_get_project_doc(project_id).collection("snapshots").document(snapshot_id).get(field_paths=fields))
     if not payload:
         return None
     snapshot = QaProjectStageSnapshot.model_validate(payload)
@@ -331,7 +334,7 @@ def list_workspace_projects(
         for stage, state in summary.stage_state.items():
             if not state.current_snapshot_id:
                 continue
-            current_snapshot = _workspace_snapshot_for(summary.project_id, state.current_snapshot_id)
+            current_snapshot = _workspace_snapshot_for(summary.project_id, state.current_snapshot_id, stage)
             if current_snapshot is not None and current_snapshot.stage == stage:
                 current_snapshots[stage] = current_snapshot
 

--- a/backend/app/services/workspace_summary_service.py
+++ b/backend/app/services/workspace_summary_service.py
@@ -78,6 +78,8 @@ def _work_item_count(
     snapshot_count = _snapshot_count(snapshot, stage_state.stage)
     if snapshot_count is not None:
         return snapshot_count
+    if stage_state.stage == "use_cases":
+        return None
     return _first_count(
         dict(stage_state.summary or {}),
         (
@@ -91,6 +93,14 @@ def _work_item_count(
             "evidence_count",
         ),
     )
+
+
+def _requirement_group_count(project: QaProjectDetail, stage: OrchestratorStageName) -> Optional[int]:
+    if stage != "use_cases":
+        return None
+    snapshot = project.current_snapshots.get(stage)
+    plan = snapshot.payload.get("coverage_plan") if snapshot else None
+    return len(plan) if isinstance(plan, list) else None
 
 
 def _work_item_kind(action: OrchestratorActionRecommendation) -> str:
@@ -124,6 +134,7 @@ def _work_item_for(
         enabled=action.enabled,
         primary=action.primary,
         count=_work_item_count(project, stage_state),
+        requirement_group_count=_requirement_group_count(project, stage_state.stage),
         reason=reason,
         current_snapshot_id=snapshot_id,
         updated_at=updated_at,
@@ -150,6 +161,7 @@ def _informational_work_item_for(
         enabled=False,
         primary=False,
         count=_work_item_count(project, stage_state),
+        requirement_group_count=_requirement_group_count(project, stage_state.stage),
         reason=reason,
         current_snapshot_id=stage_state.current_snapshot_id,
         updated_at=stage_state.updated_at or project.updated_at,

--- a/backend/tests/test_workspace_summary_service.py
+++ b/backend/tests/test_workspace_summary_service.py
@@ -137,8 +137,23 @@ class FakeDocument:
         self.query_log = query_log
 
     def get(self, field_paths: Optional[tuple[str, ...]] = None) -> FakeSnapshot:
-        del field_paths
-        return FakeSnapshot(self.store.get(self.path), self.path.rsplit("/", 1)[-1])
+        payload = self.store.get(self.path)
+        if payload is not None and field_paths is not None:
+            projected = {}
+            for field in field_paths:
+                parts = field.split(".")
+                source = payload
+                for part in parts:
+                    if not isinstance(source, dict) or part not in source:
+                        break
+                    source = source[part]
+                else:
+                    target = projected
+                    for part in parts[:-1]:
+                        target = target.setdefault(part, {})
+                    target[parts[-1]] = source
+            payload = projected
+        return FakeSnapshot(payload, self.path.rsplit("/", 1)[-1])
 
     def collection(self, name: str) -> "FakeCollection":
         return FakeCollection(f"{self.path}/{name}", self.store, self.query_log)
@@ -288,6 +303,55 @@ class WorkspaceSummaryServiceTests(unittest.TestCase):
         self.assertIn("approved", review_item.reason.lower())
         self.assertEqual(result.projects[0].current_stage, "use_cases")
         self.assertEqual(result.projects[0].current_status, "attention_required")
+
+    def test_persisted_use_case_counts_follow_current_snapshot_and_refresh(self) -> None:
+        plan = [{"requirement_id": f"REQ-{i}", "scenarios": [{"id": f"SCN-{i}-{j}"} for j in range(4 if i < 4 else 3)]} for i in range(8)]
+        actor = AuthUser(sub="user-1", email="user@example.com", name="User")
+        snapshot = _snapshot(
+            project_id="counts",
+            stage="use_cases",
+            snapshot_id="use-cases-1",
+            created_at=BASE_TIME,
+            payload={"coverage_plan": plan, "private_unneeded_payload": "not projected"},
+            metadata={"coverage_plan_count": 8},
+        )
+        project = _project(
+            "counts",
+            stage_state={
+                "requirements": _stage_state("requirements-1", updated_at=BASE_TIME, approved=True),
+                "use_cases": _stage_state(snapshot.snapshot_id, updated_at=BASE_TIME, metadata={"coverage_plan_count": 8}),
+            },
+        )
+        project_data = project.model_dump(exclude={"current_snapshots", "timeline", "execution_runs"})
+        store = {
+            "qa_projects/counts": project_data,
+            "qa_projects/counts/snapshots/use-cases-1": snapshot.model_dump(),
+        }
+        collection = FakeCollection("qa_projects", store, [])
+        with patch("app.services.workflow_project_service.get_required_firestore_collection", return_value=collection):
+            for version, payload, expected_count, expected_groups in [
+                (1, {"coverage_plan": plan}, 28, 8),
+                (2, {"coverage_plan": [{"scenarios": [{"id": "new"}]}]}, 1, 1),
+                (3, {"coverage_plan": []}, 0, 0),
+                (4, {}, None, None),
+            ]:
+                with self.subTest(version=version):
+                    snapshot_id = f"use-cases-{version}"
+                    store[f"qa_projects/counts/snapshots/{snapshot_id}"] = {
+                        **snapshot.model_dump(),
+                        "snapshot_id": snapshot_id,
+                        "payload": {**payload, "private_unneeded_payload": "not projected"},
+                    }
+                    project_data["stage_state"]["use_cases"]["current_snapshot_id"] = snapshot_id
+                    projects = list_workspace_projects(actor=actor, include_archived=False, project_limit=20, execution_run_limit=20)
+                    result = build_workspace_summary(projects, work_items_limit=50, runs_limit=20, reports_limit=20)
+                    item = next(item for item in result.work_items if item.stage == "use_cases")
+                    self.assertEqual(item.current_snapshot_id, snapshot_id)
+                    self.assertEqual(item.count, expected_count)
+                    self.assertEqual(item.requirement_group_count, expected_groups)
+                    self.assertEqual(result.continue_working.count, expected_count)
+                    self.assertNotIn("coverage_plan", item.model_dump())
+                    self.assertNotIn("private_unneeded_payload", projects[0].current_snapshots["use_cases"].payload)
 
     def test_work_items_are_deduplicated_ranked_and_used_for_continue_working(self) -> None:
         enabled_project = _project("project-a", updated_at=BASE_TIME)

--- a/design-qa.md
+++ b/design-qa.md
@@ -1,72 +1,65 @@
-# Collapsed Workflow Rail Design QA
+# Design QA — issue #239
 
-- Source visual truth: `/Users/m1/Documents/Screenshot 2026-09-02 at 23.58.34.png`
-- Implementation screenshot: `/tmp/issue-229-collapsed-after.png`
-- Combined comparison: `/tmp/issue-229-design-qa-comparison.png`
-- Browser and state: Codex in-app browser, authenticated local E2E account, project overview, desktop rail collapsed
-- CSS viewport: 1440 × 900 at `deviceScaleFactor: 1`
-- Source pixels: 234 × 1594 at approximately 2× density
-- Implementation pixels: 1440 × 900 at 1× density
-- Density normalization: source downsampled to 117 × 797; implementation cropped to the same 117 × 797 CSS-pixel rail region before horizontal comparison
-
-## Full-view comparison evidence
-
-The browser-rendered desktop view shows the global app bar, collapsed workflow
-rail, project heading, contextual task, and workbench cards together. The rail
-contains one primary icon for each of the seven destinations, its active state
-remains clear, the workspace gains vertical breathing room, and no content is
-hidden by the change.
-
-## Focused comparison evidence
-
-The normalized side-by-side rail comparison was required because the source is
-a narrow 2× crop rather than a full viewport. The source shows a second circular
-status icon below every stage icon. The implementation removes those repeated
-tokens and preserves a single centered stage icon per destination. The active
-Overview tile shrinks to the same one-icon rhythm instead of grouping two
-control-like shapes.
-
-## Required fidelity surfaces
-
-- Fonts and typography: no typography changed; expanded labels and status copy retain the existing family, weights, line heights, truncation, and hierarchy.
-- Spacing and layout rhythm: the collapsed rail keeps its 72-pixel column and existing padding, while each destination now occupies one compact icon row. The intentional reduction in rail height is the selected design change.
-- Colors and visual tokens: existing active blue, success green, warning amber, pending neutral, borders, radii, and shadows remain mapped to the primary stage markers.
-- Image quality and asset fidelity: the reference contains only standard UI icons. The implementation keeps the existing Lucide icon set and does not introduce raster, placeholder, custom SVG, or CSS-drawn assets.
-- Copy and content: no user-facing destination or status copy was removed. Collapsed accessible names and native hover text still expose values such as “Requirements — Complete.”
+final result: passed
 
 ## Findings
 
-No actionable P0, P1, or P2 mismatch remains. The visible difference from the
-source—the removal of every circled status token—is the requested design change.
+No remaining actionable P0/P1/P2 visual findings in the selected project screens. This implements the selected design direction using the existing product typography and real artifact content; it is not a literal copy of illustrative mock text.
+
+## Visual truth and captures
+
+Reference directory: `/Users/m1/.codex/generated_images/01a08b92-58ae-7fd2-94e0-74fc99835662/`.
+
+- Overview: `exec-2f4f6154-22f4-4acb-9041-0be6ddbf0d5e.png`, 1487 × 1058 pixels.
+- Use Cases: `exec-750c4586-cb4c-4cd8-a6fb-55f453771438.png`, 1489 × 1056 pixels.
+- Test Cases: `exec-cf5f5851-48a8-412d-a04c-39614b53259d.png`, 1489 × 1056 pixels.
+
+Implementation directory: `/Users/m1/.codex/visualizations/2026/09/10/01a08b92-58ae-7fd2-94e0-74fc99835662/overview-design/`.
+
+- `implemented-overview-final.png`: Overview, next action and attention rows.
+- `implemented-use-cases-final.png`: first requirement expanded, no review decision selected.
+- `implemented-test-cases-final.png`: generated cases tab, TC-001 selected, two steps visible.
+- `use-cases-mobile.png` and `test-cases-mobile.png`: narrow layout evidence.
+
+Desktop CSS viewport was 1488 × 1056, devicePixelRatio 1. Browser screenshot output is a JPEG encoded at 1477 × 1048 despite its .png filename. Reference and capture were compared at equivalent display size; the approximately 0.7% capture scaling was treated as transport scaling, not a typography or spacing defect. Mobile CSS viewport was 390 × 844; expanded Use Cases details were also checked at 320 × 900. Screenshots are local review artifacts and are not committed.
+
+## Comparison evidence and fidelity surfaces
+
+The reference and final capture for each screen were opened together in the same visual comparison input. Full views show the shared 76px header, approximately 276px sidebar, aligned content start, flat white surface, blue route selection, and restrained semantic states. Text and controls were readable in the combined full-size comparisons; additional crops were unnecessary. Live DOM checks supplemented visual review for font metrics, full field content and narrow-width containment.
+
+- **Typography:** retained Inter/system fallback and the shared production scale (36px desktop page headings, 30px narrow headings). The illustrative images use larger display text. This is an intentional consistency choice based on the shared design direction, rather than changing fonts independently per page. Long real requirement and case titles wrap instead of becoming shortened mock labels.
+- **Spacing/layout:** Overview has one next action, a slim count strip and attention rows. Use Cases has grouped scenarios and a decision panel. Test Cases has a list and detail workspace below a compact quality strip. Columns stack on smaller widths. Search and preserved metadata disclosures add useful product controls beyond the simplified references.
+- **Colors/tokens:** existing blue primary, pale selected surface, neutral borders and muted text are reused. Primary button gradients were removed. Approval, refinement and blocked states retain explicit words and icons; selected navigation no longer masks workflow status.
+- **Assets:** standard Lucide icons fit the selected outline icon family. No custom imagery, raster artwork, synthetic logos or placeholder assets were needed. The existing account image is preserved.
+- **Copy/content:** actual 8 requirements, 28 scenarios and 25 cases are retained. The server-provided next task remains “Approve Use Cases” with “Open workbench”; it opens the review workbench and does not approve automatically. Quality score 65/100, threshold 90 and blocked export remain truthful. Full findings, expected results, test data and metadata are available through disclosures.
 
 ## Comparison history
 
-1. First post-change capture showed seven centered workflow icons, zero
-   collapsed status tokens, and no overflow. The normalized focused comparison
-   confirmed that the duplicate icon row was removed without altering the rail's
-   visual language, so no corrective visual iteration was required.
+1. P2: initial Test Cases layout repeated generation/readiness panels above the selected artifact. Reduced duplicate headings, condensed quality findings and placed optional actions in More actions. Evidence: `implemented-test-cases-v1.png`, `implemented-test-cases-v2.png`, then final capture.
+2. P2: Use Cases inherited an enclosing grid that squeezed both review columns. Removed the conflicting composition, aligned the columns and compacted summary/history. Evidence: `implemented-use-cases-v1.png`, `implemented-use-cases-v2.png`, then final capture.
+3. P2: active sidebar status contrast and collapsed badges conflicted with the reference. Separated route selection from workflow status, hid status text in icon-only mode and allowed long labels to wrap. Confirmed final captures and responsive tests.
+4. P2: Overview next task was constrained to a narrow card. Expanded it across the content column and aligned counts and attention rows. Evidence: `implemented-overview-v1.png`, then final capture.
+5. P2: narrow Use Cases status actions and expanded metadata could overflow. Added wrapping, zero intrinsic minimum widths and bounded flex children. Confirmed live 320px expanded details and automated 320–1920px reflow checks.
+6. Capture correction: rapid hard navigation produced transient Failed to fetch recovery screens during live capture. Backend health and CORS responded successfully; normal Projects → Open navigation loaded the real project. Replaced recovery/scroll-offset captures with loaded, top-of-page captures. Prior console fetch errors remain in browser history; no claim is made that the full historical console is empty.
 
-## Interaction and responsive evidence
+## Validation
 
-- Collapsed desktop: seven destinations, one visible SVG per destination, zero status tokens.
-- Expanded desktop: seven status tokens restored and visible.
-- Compact boundary at 900 pixels: navigation begins closed, opens from its named button, restores seven visible status tokens, and has no horizontal overflow.
-- Accessible names retain destination plus status, and collapsed items expose matching hover text.
-- Selecting the collapsed Requirements icon navigates to its canonical workbench and preserves the one-icon collapsed state; returning to Overview does the same.
-- Browser console showed no runtime errors after authenticated navigation and interaction. The expected local warning about incomplete Firebase web configuration remains and does not affect the stored E2E session or this workflow.
+- `npm run lint`: passed.
+- `npm run format:check`: passed.
+- `npm run build`: passed; existing bundle-size warning remains (578.06 kB JavaScript chunk).
+- `npm run test:e2e:home-first -- --workers=4 --retries=0 --timeout=45000`: **143 passed**. Covers focused design interactions, navigation, mobile reflow, WCAG serious/critical checks, export override gates, generation preservation, persisted decisions, stale responses, retries and double submission.
+- `git diff --check`: passed.
+- Live manual checks: project navigation, first requirement expansion, supporting-history disclosure, narrow overflow, case search, selection fallback, all steps and metadata. No live approval, generation or export was submitted.
+
+## Open questions and follow-up polish
+
+No blocking questions. P3: mobile result tabs retain the existing stacked layout; a future dedicated mobile interaction pass could compare a horizontal tab strip. Existing bundle splitting remains separate from this design issue.
 
 ## Implementation checklist
 
-- [x] One visible icon per collapsed workflow destination
-- [x] No separate collapsed status token
-- [x] Expanded desktop status tokens preserved
-- [x] Opened compact navigation status tokens preserved
-- [x] Accessible destination and status names preserved
-- [x] Hover status text preserved
-- [x] Desktop and compact overflow checks passed
-
-## Follow-up polish
-
-No P3 follow-up is required for this scope.
-
-final result: passed
+- [x] Reuse the shared shell and page header.
+- [x] Implement the three selected layouts with real content.
+- [x] Preserve review/export gates and complete artifact details.
+- [x] Verify responsive, keyboard and core workflow behavior.
+- [x] Compare final browser captures against all selected references.
+- [x] Keep the local Test Cases preview open.

--- a/docs/codebase/CONVENTIONS.md
+++ b/docs/codebase/CONVENTIONS.md
@@ -233,3 +233,13 @@ work.
 - `frontend/eslint.config.js`
 - `frontend/.prettierrc.json`
 - `frontend/package.json`
+
+### Workspace use-case counts (#237)
+
+For `use_cases` work items, `count` is the total number of nested scenarios in
+`coverage_plan`; `requirement_group_count` is the number of groups in that plan.
+Home and Reviews show both units. Empty plans yield zero; unavailable plans yield
+null counts rather than falling back to `coverage_plan_count` (a group count).
+Workspace reads project the current use-case coverage plan internally so existing
+snapshots need no migration or regeneration. Raw plans are not returned in the
+workspace summary API. Other stages keep their existing count semantics.

--- a/docs/github-issues-backlog.md
+++ b/docs/github-issues-backlog.md
@@ -2,6 +2,10 @@
 
 This file contains issue-ready drafts for the implementation plan in `docs/implementation-plan.md`.
 
+## UI/UX audit follow-up
+
+- In progress: [#237](https://github.com/lumensparkxy/agentic_test_case_generator/issues/237) — Correct use-case scenario counts in workspace summaries. Count nested scenarios separately from requirement groups and keep Home, Reviews, and the current artifact consistent.
+
 ## Created GitHub issues
 
 The original Phase 0 through Phase 2 issues in this section are historical

--- a/docs/github-issues-backlog.md
+++ b/docs/github-issues-backlog.md
@@ -4,6 +4,8 @@ This file contains issue-ready drafts for the implementation plan in `docs/imple
 
 ## UI/UX audit follow-up
 
+- In progress: [#239](https://github.com/lumensparkxy/agentic_test_case_generator/issues/239) — Implement the selected shared design across Overview, Use Cases and Test Cases, preserving review gates and responsive access. Builds on #237.
+
 - In progress: [#237](https://github.com/lumensparkxy/agentic_test_case_generator/issues/237) — Correct use-case scenario counts in workspace summaries. Count nested scenarios separately from requirement groups and keep Home, Reviews, and the current artifact consistent.
 
 ## Created GitHub issues

--- a/docs/project-design.md
+++ b/docs/project-design.md
@@ -1,0 +1,15 @@
+# Shared project design
+
+Tracked by [#239](https://github.com/lumensparkxy/agentic_test_case_generator/issues/239), based on the selected Overview, Use Cases and Test Cases designs. Builds on scenario-count correction #237.
+
+Project destinations share `ProjectPageHeader`, the project navigation, and existing color and typography tokens through `project-design.css`. Route selection is independent of workflow status. Overview has no invented completion status; other destinations retain text and icons for their current state.
+
+Overview prioritizes the server-provided next action, artifact counts, and actionable review/export blockers. Additional workbenches remain available in a disclosure.
+
+Use Cases groups scenarios by requirement. Scenario objectives and metadata, machine quality findings, coverage and review history remain available through disclosures. The decision form starts without a selected option; the reviewer explicitly chooses Approve or Request changes. Existing comment requirements, version checks, retries and persistence continue to apply.
+
+Test Cases presents a searchable selectable list alongside the current case, with steps, expected results, test data and full metadata. Search covers IDs, titles and linked requirement IDs. The first matching case is selected when the existing selection disappears. Quality findings are expandable. Template setup controls the export format independently of the review presentation. Traceability, coverage, analysis, diagnostics, refinement and export controls remain available.
+
+On narrow screens the review columns stack, navigation becomes a disclosure, and long labels wrap. Desktop navigation can still collapse to icons. Focus, status announcements and semantic labels remain part of the interaction contract.
+
+Validation: frontend build, lint, formatting, and the `test:e2e:home-first` suite, including the focused `shared-project-design.spec.js` checks. Visual comparison evidence and known constraints are recorded in the root `design-qa.md`.

--- a/frontend/e2e/accessibility-navigation.spec.js
+++ b/frontend/e2e/accessibility-navigation.spec.js
@@ -17,7 +17,7 @@ const surfaceRoutes = {
 const surfaceHeadings = {
 	"empty Home": "Home",
 	"populated Home": "Home",
-	"project Overview": "Mercury Checkout",
+	"project Overview": "Overview",
 	"Use Cases": "Use Cases",
 	Automation: "Automation",
 };
@@ -32,7 +32,7 @@ async function openSurface(page, surface, width) {
 	}
 	await seedAuthenticatedSession(page);
 	await page.goto(surfaceRoutes[surface]);
-	await expect(page.getByRole("heading", { name: surfaceHeadings[surface], level: surface === "Automation" ? 2 : 1 })).toBeVisible({
+	await expect(page.getByRole("heading", { name: surfaceHeadings[surface], level: 1 })).toBeVisible({
 		timeout: 30_000,
 	});
 	if (surface === "empty Home") {
@@ -97,7 +97,7 @@ test("moves focus to each SPA destination through links, Back, and Forward", asy
 	await expect(page.locator("#main-content")).toBeFocused();
 
 	const projectNavigation = page.getByRole("navigation", { name: /^Project navigation$/i });
-	await projectNavigation.getByRole("link", { name: /^Overview,/i }).click();
+	await projectNavigation.getByRole("link", { name: /^Overview$/i }).click();
 	await expect(page).toHaveURL(buildProjectPath(USE_CASE_PROJECT_ID));
 	await expect(page.locator("#main-content")).toBeFocused();
 

--- a/frontend/e2e/automation-preview-consistency.spec.js
+++ b/frontend/e2e/automation-preview-consistency.spec.js
@@ -534,7 +534,7 @@ test.describe("Automation preview consistency", () => {
 		const requests = await installApi(page, scenario);
 		await openAutomation(page);
 
-		const panel = page.locator("section.panel").filter({ has: page.getByRole("heading", { name: /^Automation$/i }) });
+		const panel = page.locator("section.panel").filter({ has: page.getByRole("heading", { name: /^Execution setup$/i }) });
 		const previewButton = page.getByRole("button", { name: /^Preview Execution$/ });
 		await previewButton.click({ noWaitAfter: true });
 		await expect.poll(() => requests.previews).toBe(1);

--- a/frontend/e2e/contextual-next-action.spec.js
+++ b/frontend/e2e/contextual-next-action.spec.js
@@ -364,11 +364,11 @@ test.describe("Contextual next task", () => {
 		}
 
 		await page.goto(buildProjectPath(PROJECT_ID, "test-cases"));
-		await page.getByRole("tab", { name: /^Template setup$/i }).click();
+		await page.getByRole("button", { name: /^Template setup$/i }).click();
 		await expect(page.getByLabel("Contextual task")).toHaveCount(0);
 
 		scenario.status = statusFixture([]);
-		await page.getByRole("tab", { name: /^Generate and review$/i }).click();
+		await page.getByRole("button", { name: /^Generate and review$/i }).click();
 		await page.reload();
 		await expect(page.getByLabel("Contextual task")).toHaveCount(0);
 		await expect(page.getByRole("button", { name: /Analyze Impact for/i })).toBeVisible();
@@ -469,6 +469,7 @@ test.describe("Contextual next task", () => {
 		await openTestCases(page);
 
 		const optionalTask = page.getByLabel("Contextual task");
+		await page.getByText("More actions", { exact: true }).first().click();
 		await expect(optionalTask.getByRole("heading", { name: /^Optional test suite actions$/i })).toBeVisible();
 		await expect(optionalTask.locator(".contextual-task-controls > button")).toHaveCount(0);
 		await optionalTask.getByText(/^Details$/i).click();
@@ -480,7 +481,7 @@ test.describe("Contextual next task", () => {
 		scenario.project.stage_state.use_cases.metadata = {};
 		scenario.status.has_baseline_test_suite = true;
 		await page.reload();
-		await expect(page.getByRole("row", { name: new RegExp(OLD_CASE_TITLE, "i") })).toBeVisible();
+		await expect(page.getByRole("button", { name: new RegExp(OLD_CASE_TITLE, "i") })).toBeVisible();
 		await expect(page.getByRole("button", { name: /Implement Changes/i })).toHaveCount(0);
 		expect(requests.generation).toBe(0);
 	});
@@ -503,8 +504,8 @@ test.describe("Contextual next task", () => {
 		const scenario = { project: projectFixture(), status: statusFixture(staleActions()), generationGate, statusAfterGeneration };
 		const requests = await installApi(page, scenario);
 		await openTestCases(page);
-		const oldCaseRow = page.getByRole("row", { name: new RegExp(OLD_CASE_TITLE, "i") });
-		const newCaseRow = page.getByRole("row", { name: new RegExp(NEW_CASE_TITLE, "i") });
+		const oldCaseRow = page.getByRole("button", { name: new RegExp(OLD_CASE_TITLE, "i") });
+		const newCaseRow = page.getByRole("button", { name: new RegExp(NEW_CASE_TITLE, "i") });
 		await expect(oldCaseRow).toBeVisible();
 
 		const task = page.getByLabel("Contextual task");
@@ -566,8 +567,8 @@ test.describe("Contextual next task", () => {
 		await expect(dialog.getByRole("alert")).toContainText(/current suite was preserved/i);
 		await expect(dialog.getByRole("button", { name: /^Confirm regeneration$/i })).toBeEnabled();
 		await expect(dialog.getByRole("button", { name: /^Confirm regeneration$/i })).toBeFocused();
-		await expect(page.getByRole("row", { name: new RegExp(OLD_CASE_TITLE, "i") })).toBeVisible();
-		await expect(page.getByRole("row", { name: new RegExp(NEW_CASE_TITLE, "i") })).toHaveCount(0);
+		await expect(page.getByRole("button", { name: new RegExp(OLD_CASE_TITLE, "i") })).toBeVisible();
+		await expect(page.getByRole("button", { name: new RegExp(NEW_CASE_TITLE, "i") })).toHaveCount(0);
 		expect(requests.generation).toBe(1);
 	});
 });

--- a/frontend/e2e/export-approval-gate.spec.js
+++ b/frontend/e2e/export-approval-gate.spec.js
@@ -274,9 +274,11 @@ test.describe("Export approval gate", () => {
 		await page.getByRole("button", { name: /^Next$/ }).click();
 		await expect(page).toHaveURL(testCasesPath);
 		await page.getByRole("button", { name: /generate from \d+ approved/i }).click();
+		await page.getByText("View findings", { exact: true }).click();
 		await expect(page.getByText(/Needs additional negative coverage/i)).toBeVisible();
 		await page.getByRole("tab", { name: /test cases/i }).click();
-		await expect(page.getByRole("region", { name: "Generated test cases table" })).toHaveAttribute("tabindex", "0");
+		await expect(page.getByRole("region", { name: "Generated test cases", exact: true })).toBeVisible();
+		await expect(page.getByRole("region", { name: "Selected test case", exact: true })).toBeVisible();
 		await page.getByRole("tab", { name: /traceability/i }).click();
 		await expect(page.getByRole("region", { name: "Requirement traceability table" })).toHaveAttribute("tabindex", "0");
 		await page.getByRole("tab", { name: /diagnostics/i }).click();

--- a/frontend/e2e/home-workspace.spec.js
+++ b/frontend/e2e/home-workspace.spec.js
@@ -681,7 +681,8 @@ test.describe("Authenticated Projects experience", () => {
 		await expect.poll(() => api.requests.projectCreate.length).toBe(1);
 		expect(api.requests.projectCreate[0].payload).toEqual({ name: createdProject.name });
 		await expect(page).toHaveURL(buildProjectPath(createdProject.project_id));
-		await expect(page.getByRole("heading", { name: new RegExp(`^${createdProject.name}$`, "i") })).toBeVisible({ timeout: 30_000 });
+		await expect(page.getByRole("heading", { name: "Overview", exact: true })).toBeVisible({ timeout: 30_000 });
+		await expect(page.locator(".project-page-header")).toContainText(createdProject.name);
 		await expect
 			.poll(() => page.evaluate((key) => window.localStorage.getItem(key), STORAGE_CURRENT_PROJECT_ID))
 			.toBe(createdProject.project_id);

--- a/frontend/e2e/responsive-reflow.spec.js
+++ b/frontend/e2e/responsive-reflow.spec.js
@@ -230,7 +230,7 @@ test.describe("Responsive project shell", () => {
 			expect(mainBox).not.toBeNull();
 			expect(appBarBox.height).toBeGreaterThanOrEqual(68);
 			expect(appBarBox.height).toBeLessThanOrEqual(76);
-			expect(Math.round(mainBox.y - (appBarBox.y + appBarBox.height))).toBe(16);
+			expect(Math.round(mainBox.y - (appBarBox.y + appBarBox.height))).toBe(0);
 			await expect(projectMenuTrigger).toContainText(PROJECT_NAME);
 			await expect(projectMenuTrigger).toContainText("revision 12");
 			await expect(page.getByRole("button", { name: /^Open system health details$/i })).toBeVisible();
@@ -244,12 +244,13 @@ test.describe("Responsive project shell", () => {
 	for (const viewport of viewports) {
 		test(`contains project content at ${viewport.width}px (${viewport.label})`, async ({ page }) => {
 			await openResponsiveProject(page, viewport);
-			const heading = page.locator(".route-page-header h1");
+			const heading = page.locator(".project-page-header h1");
 			const routePage = page.locator(".route-page");
 			const globalNavigation = page.getByRole("navigation", { name: "Global navigation" });
 			const projectNavigation = page.getByRole("navigation", { name: "Project navigation" });
 
-			await expect(heading).toHaveText(PROJECT_NAME);
+			await expect(heading).toHaveText("Overview");
+			await expect(page.locator(".project-page-header")).toContainText(PROJECT_NAME);
 			await expect(page.getByLabel("Contextual task").getByRole("button", { name: /^Open workbench$/i })).toBeVisible();
 			await expect(page.getByLabel("Project information rail")).toHaveCount(0);
 			await expectExactlyOneCurrent(globalNavigation);
@@ -265,7 +266,7 @@ test.describe("Responsive project shell", () => {
 				await expect(projectNavigation.locator(".workflow-navigation-list")).toBeHidden();
 			} else {
 				await expect(page.getByRole("button", { name: /^Open workspace controls$/i })).toHaveCount(0);
-				await expect(projectNavigation.getByRole("link", { name: /^Overview, Current$/i })).toBeVisible();
+				await expect(projectNavigation.getByRole("link", { name: /^Overview$/i })).toBeVisible();
 			}
 
 			if ([390, 760].includes(viewport.width)) {
@@ -306,7 +307,7 @@ test.describe("Responsive project shell", () => {
 			await projectToggle.focus();
 			await page.keyboard.press(width === 760 ? "Space" : "Enter");
 			await expect(projectNavigation.locator(".workflow-navigation-list")).toBeVisible();
-			await expect(projectNavigation.locator(".workflow-navigation-state")).toHaveCount(7);
+			await expect(projectNavigation.locator(".nav-workflow-status")).toHaveCount(6);
 			await expect(projectNavigation.getByRole("button", { name: /^Close project navigation$/i })).toHaveAttribute("aria-expanded", "true");
 			await page.keyboard.press("Tab");
 			await expect(projectNavigation.getByRole("link").first()).toBeFocused();
@@ -326,18 +327,23 @@ test.describe("Responsive project shell", () => {
 		await expect(globalNavigation.locator('[aria-current="page"]')).toContainText("Projects");
 
 		const expectedStates = [
-			{ name: "Overview, Current", tone: "active" },
+			{ name: "Overview", tone: "active" },
 			{ name: "Requirements, Complete", tone: "complete" },
 			{ name: "Context, Pending", tone: "pending" },
-			{ name: "Use Cases, Needs attention", tone: "attention" },
+			{ name: "Use Cases, Awaiting review", tone: "attention" },
 			{ name: "Automation, Blocked", tone: "blocked" },
 		];
 		for (const expectedState of expectedStates) {
 			const item = projectNavigation.getByRole("link", { name: expectedState.name });
-			const badge = item.locator(".workflow-navigation-state");
+			const badge = item.locator(".nav-workflow-status");
 			await expect(item).toBeVisible();
-			await expect(badge).toHaveAttribute("data-status-tone", expectedState.tone);
-			await expect(badge.locator("svg")).toBeVisible();
+			if (expectedState.tone === "active") {
+				await expect(item).toHaveAttribute("aria-current", "page");
+				await expect(badge).toHaveCount(0);
+			} else {
+				await expect(badge).toHaveClass(new RegExp(expectedState.tone));
+				await expect(badge.locator("svg")).toBeVisible();
+			}
 		}
 
 		await projectNavigation.getByRole("button", { name: /^Collapse project navigation$/i }).click();
@@ -368,12 +374,12 @@ test.describe("Responsive project shell", () => {
 		await expect(page.getByLabel("Project information rail")).toHaveCount(0);
 		await expectVisuallyContained(workflowLabel, workflowLabel.locator("xpath=.."));
 		await expectVisuallyContained(globalLabel, globalNavigation);
-		expect(await workflowLabel.evaluate((element) => getComputedStyle(element).overflowWrap)).not.toBe("anywhere");
-		expect(await workflowLabel.evaluate((element) => getComputedStyle(element).textOverflow)).toBe("ellipsis");
+		expect(await workflowLabel.evaluate((element) => getComputedStyle(element).overflowWrap)).toBe("anywhere");
+		expect(await workflowLabel.evaluate((element) => getComputedStyle(element).whiteSpace)).toBe("normal");
 		await expectNoDocumentOverflow(page, "long expanded shell labels");
 
 		await page.setViewportSize({ width: 320, height: 900 });
-		const heading = page.locator(".route-page-header h1");
+		const heading = page.locator(".project-page-header h1");
 		await heading.evaluate((element) => {
 			element.textContent = "InternationalizedQualityAssuranceWorkspaceWithoutNaturalBreakpoints";
 		});

--- a/frontend/e2e/review-inbox.spec.js
+++ b/frontend/e2e/review-inbox.spec.js
@@ -2,7 +2,7 @@ import { expect, test } from "@playwright/test";
 
 import { buildProjectPath } from "../src/app/workflowRoutes.js";
 import { seedAuthenticatedSession } from "./support/auth.js";
-import { installUseCaseReviewApi, useCaseProjectFixture } from "./support/use-case-review.js";
+import { installUseCaseReviewApi, useCaseProjectFixture, useCaseSnapshotFixture } from "./support/use-case-review.js";
 import {
 	createDeferred,
 	installWorkspaceApi,
@@ -488,4 +488,30 @@ test.describe("Global Review Inbox", () => {
 		await expect.poll(() => api.requests.workspaceSummary.length).toBeGreaterThanOrEqual(3);
 		expect(api.requests.review).toHaveLength(1);
 	});
+});
+
+test("scenario counts agree across Home, Reviews, and the current artifact after refresh", async ({ page }) => {
+	const snapshot = useCaseSnapshotFixture();
+	snapshot.payload.coverage_plan = Array.from({ length: 8 }, (_, i) => ({
+		requirement_id: `REQ-${i}`,
+		requirement_text: `Requirement ${i}`,
+		scenarios: Array.from({ length: i < 4 ? 4 : 3 }, (_, j) => ({
+			id: `SCN-${i}-${j}`,
+			title: `Scenario ${i}-${j}`,
+			objective: "Verify the requirement",
+			priority: "High",
+		})),
+	}));
+	const project = useCaseProjectFixture({ snapshot });
+	await installUseCaseReviewApi(page, { initialProject: project });
+	await seedAuthenticatedSession(page);
+	await page.goto("/");
+	await expect(page.getByRole("region", { name: "Continue working" })).toContainText("28 scenarios · 8 requirement groups");
+	await page.getByRole("navigation", { name: "Global navigation" }).getByRole("link", { name: "Reviews", exact: true }).click();
+	await expect(inboxList(page)).toContainText("28 scenarios · 8 requirement groups");
+	await page.getByRole("button", { name: "Refresh reviews" }).click();
+	await expect(inboxList(page)).toContainText("28 scenarios · 8 requirement groups");
+	await inboxList(page).getByRole("link").click();
+	await expect(page.getByRole("heading", { name: "28 scenarios", exact: true })).toBeVisible();
+	await expect(page.getByRole("region", { name: "28 scenarios", exact: true })).toContainText("8 requirement groups");
 });

--- a/frontend/e2e/review-inbox.spec.js
+++ b/frontend/e2e/review-inbox.spec.js
@@ -475,6 +475,7 @@ test.describe("Global Review Inbox", () => {
 
 		await expect(page).toHaveURL(buildProjectPath(project.project_id, "use-cases"));
 		await expect(page.getByRole("heading", { name: /^Use Cases$/i, level: 1 })).toBeVisible({ timeout: 30_000 });
+		await page.getByRole("radio", { name: /^Approve/i }).check();
 		await page.getByRole("button", { name: /^Approve Use Cases$/i }).click();
 		await expect(page.getByRole("form", { name: /^Human review decision$/i }).getByRole("status")).toContainText(/approved/i);
 
@@ -512,6 +513,7 @@ test("scenario counts agree across Home, Reviews, and the current artifact after
 	await page.getByRole("button", { name: "Refresh reviews" }).click();
 	await expect(inboxList(page)).toContainText("28 scenarios · 8 requirement groups");
 	await inboxList(page).getByRole("link").click();
-	await expect(page.getByRole("heading", { name: "28 scenarios", exact: true })).toBeVisible();
+	await expect(page.locator(".use-case-compact-summary")).toContainText("28 scenarios");
+	await page.getByText("Quality, coverage and review history", { exact: true }).click();
 	await expect(page.getByRole("region", { name: "28 scenarios", exact: true })).toContainText("8 requirement groups");
 });

--- a/frontend/e2e/shared-project-design.spec.js
+++ b/frontend/e2e/shared-project-design.spec.js
@@ -1,0 +1,109 @@
+import { expect, test } from "@playwright/test";
+import { seedAuthenticatedSession } from "./support/auth.js";
+import { installUseCaseReviewApi, useCaseProjectFixture, USE_CASE_PROJECT_ID } from "./support/use-case-review.js";
+
+const caseFixture = (id, title) => ({
+	id,
+	title,
+	description: `Objective for ${title}`,
+	priority: "High",
+	type: "Functional",
+	status: "Draft",
+	preconditions: "Signed in",
+	expected_result: `Result for ${id}`,
+	test_data: "Fixture test data",
+	estimated_time: "3 minutes",
+	automation_status: "Manual",
+	component: "Checkout",
+	tags: ["REQ-101"],
+	steps: [1, 2, 3].map((n) => ({
+		step: n,
+		action: `${id} action ${n}`,
+		expected: `${id} expectation ${n}`,
+		test_data: n === 3 ? "Step-specific data" : "",
+	})),
+});
+
+async function openCases(page, testCases = [caseFixture("TC-001", "Valid checkout"), caseFixture("TC-002", "Declined card")]) {
+	const project = useCaseProjectFixture();
+	project.current_snapshots.test_cases = {
+		snapshot_id: "cases-v1",
+		project_id: USE_CASE_PROJECT_ID,
+		stage: "test_cases",
+		version: 1,
+		project_revision: 7,
+		payload: {
+			test_cases: testCases,
+			review: {
+				approved: false,
+				score: 65,
+				threshold: 90,
+				blocking_issues: ["TC-001 requires a grounded button label."],
+				summary: "Grounded UI details required.",
+			},
+		},
+	};
+	project.stage_state.test_cases = { current_snapshot_id: "cases-v1", approved: false, stale: false, version: 1 };
+	await installUseCaseReviewApi(page, { initialProject: project });
+	await seedAuthenticatedSession(page);
+	await page.goto(`/projects/${USE_CASE_PROJECT_ID}/test-cases`);
+	await expect(page.getByRole("heading", { name: "Test Cases", exact: true, level: 1 })).toBeVisible();
+	return project;
+}
+
+test("selects cases, expands steps and preserves all case metadata while searching", async ({ page }) => {
+	await openCases(page);
+	const detail = page.getByRole("region", { name: "Selected test case" });
+	await expect(detail.getByRole("heading", { name: "Valid checkout" })).toBeVisible();
+	await expect(detail).not.toContainText("TC-001 action 3");
+	await detail.getByRole("button", { name: "Show all 3 steps" }).click();
+	await expect(detail).toContainText("TC-001 action 3");
+	await expect(detail).toContainText("Step-specific data");
+	await detail.getByText("Test data and metadata", { exact: true }).click();
+	await expect(detail).toContainText("Fixture test data");
+	await expect(detail).toContainText("Manual");
+	await page.getByRole("button", { name: /TC-002 Declined card/ }).click();
+	await expect(detail.getByRole("heading", { name: "Declined card" })).toBeVisible();
+	await expect(detail).toContainText("Result for TC-002");
+	await expect(detail).not.toContainText("TC-001 action");
+	await page.getByRole("searchbox", { name: "Search test cases" }).fill("Valid");
+	await expect(detail.getByRole("heading", { name: "Valid checkout" })).toBeVisible();
+	await page.getByRole("searchbox", { name: "Search test cases" }).fill("unmatched");
+	await expect(page.getByText("No test cases match your search.")).toBeVisible();
+	await expect(detail).toContainText("Select a test case");
+	await page.getByRole("searchbox", { name: "Search test cases" }).fill("");
+	await expect(detail.getByRole("heading", { name: "Declined card" })).toBeVisible();
+	await page.getByRole("region", { name: "Test case quality" }).getByText("View findings", { exact: true }).click();
+	await expect(page.getByRole("region", { name: "Test case quality" })).toContainText("TC-001 requires a grounded button label.");
+	await page.getByRole("button", { name: "Template setup", exact: true }).click();
+	await page.getByRole("button", { name: "Generate and review", exact: true }).click();
+	await expect(page.getByRole("heading", { name: "Generated Test Cases", exact: true })).toBeVisible();
+});
+
+test("requires an explicit human decision and keeps navigation status separate", async ({ page }) => {
+	const api = await installUseCaseReviewApi(page);
+	await seedAuthenticatedSession(page);
+	await page.goto(`/projects/${USE_CASE_PROJECT_ID}/use-cases`);
+	const form = page.getByRole("form", { name: "Human review decision" });
+	await expect(form.getByRole("radio", { name: /^Approve/ })).not.toBeChecked();
+	await expect(form.getByRole("radio", { name: /^Request changes/ })).not.toBeChecked();
+	await expect(form.getByRole("button", { name: "Choose a decision" })).toBeDisabled();
+	const nav = page.getByRole("navigation", { name: "Project navigation", exact: true });
+	await expect(nav.getByRole("link", { name: "Use Cases, Awaiting review" })).toHaveAttribute("aria-current", "page");
+	await form.getByRole("radio", { name: /^Request changes/ }).check();
+	await form.getByRole("button", { name: "Request changes", exact: true }).click();
+	await expect(form.getByRole("alert")).toContainText("Comment required");
+	expect(api.requests.review).toHaveLength(0);
+});
+
+for (const width of [390, 901, 1488]) {
+	test(`test-case review reflows without document overflow at ${width}px`, async ({ page }) => {
+		await page.setViewportSize({ width, height: 1056 });
+		await openCases(page);
+		await expect(page.getByRole("region", { name: "Selected test case" })).toBeVisible();
+		expect(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth)).toBe(true);
+		const input = page.getByRole("searchbox", { name: "Search test cases" });
+		await input.fill("Declined");
+		await expect(page.getByRole("region", { name: "Selected test case" })).toContainText("Declined card");
+	});
+}

--- a/frontend/e2e/support/use-case-review.js
+++ b/frontend/e2e/support/use-case-review.js
@@ -398,6 +398,7 @@ export function useCaseWorkspaceSummaryFixture(project, overrides = {}) {
 				enabled: action.enabled,
 				primary: action.primary,
 				count: action.stage === "use_cases" ? useCaseScenarioTotal(project) : null,
+				requirement_group_count: action.stage === "use_cases" ? (snapshot?.payload?.coverage_plan?.length ?? null) : null,
 				reason: action.reason,
 				current_snapshot_id: snapshot?.snapshot_id || null,
 				updated_at: project.updated_at,

--- a/frontend/e2e/use-case-review.spec.js
+++ b/frontend/e2e/use-case-review.spec.js
@@ -23,11 +23,11 @@ function reviewMain(page) {
 }
 
 function machineReviewRegion(page) {
-	return reviewMain(page).getByRole("region", { name: /^Machine quality review$/i });
+	return reviewMain(page).getByRole("region", { name: /^Machine quality review$/i, includeHidden: true });
 }
 
 function humanReviewRegion(page) {
-	return reviewMain(page).getByRole("region", { name: /^Human review status$/i });
+	return reviewMain(page).getByRole("region", { name: /^Human review status$/i, includeHidden: true });
 }
 
 function decisionPanel(page) {
@@ -67,6 +67,10 @@ async function openUseCaseReview(page, options = {}) {
 	await seedAuthenticatedSession(page);
 	await page.goto(buildProjectPath(USE_CASE_PROJECT_ID, "use-cases"));
 	await expect(page.getByRole("heading", { name: /^Use Cases$/i, level: 1 })).toBeVisible({ timeout: 30_000 });
+	if (await page.getByText("Quality, coverage and review history", { exact: true }).count()) {
+		await page.getByText("Quality, coverage and review history", { exact: true }).click();
+		if (await approveOption(page).isEnabled()) await approveOption(page).check();
+	}
 	return api;
 }
 
@@ -175,6 +179,7 @@ test.describe("Use Cases review workbench", () => {
 
 		await expect(page).toHaveURL(buildProjectPath(USE_CASE_PROJECT_ID, "use-cases"));
 		await expect(reviewMain(page)).toBeVisible();
+		await page.getByText("Quality, coverage and review history", { exact: true }).click();
 		await expect(machineReviewRegion(page)).toBeVisible();
 		await expect(page.getByRole("heading", { name: /^Upload Requirements$/i })).toHaveCount(0);
 	});
@@ -197,10 +202,10 @@ test.describe("Use Cases review workbench", () => {
 		await expect(reviewMain(page).getByRole("status", { name: "Current human review status" })).toContainText(/Awaiting human review/i);
 		await page
 			.getByRole("navigation", { name: "Project navigation" })
-			.getByRole("link", { name: /^Overview,/i })
+			.getByRole("link", { name: /^Overview$/i })
 			.click();
 		await expect(
-			page.getByRole("navigation", { name: "Project navigation" }).getByRole("link", { name: /^Use Cases, Needs attention$/i })
+			page.getByRole("navigation", { name: "Project navigation" }).getByRole("link", { name: /^Use Cases, Awaiting review$/i })
 		).toBeVisible();
 		await expect(page.getByLabel("Contextual task").getByRole("heading", { name: /^Approve Use Cases$/i })).toBeVisible();
 		await page

--- a/frontend/e2e/workflow-navigation.spec.js
+++ b/frontend/e2e/workflow-navigation.spec.js
@@ -365,20 +365,20 @@ test.describe("Route-driven application shell", () => {
 		await seedAuthenticatedSession(page);
 
 		const destinations = [
-			{ destination: "overview", heading: PROJECT_A.name, active: "Overview" },
-			{ destination: "requirements", heading: "Upload Requirements", active: "Requirements" },
-			{ destination: "context", heading: "Context Inputs", active: "Context" },
+			{ destination: "overview", heading: "Overview", active: "Overview" },
+			{ destination: "requirements", heading: "Requirements", active: "Requirements" },
+			{ destination: "context", heading: "Context", active: "Context" },
 			{ destination: "use-cases", heading: "Use Cases", active: "Use Cases" },
-			{ destination: "test-cases", heading: "Generate Test Cases", active: "Test Cases" },
+			{ destination: "test-cases", heading: "Test Cases", active: "Test Cases" },
 			{ destination: "automation", heading: "Automation", active: "Automation" },
-			{ destination: "reports", heading: "Export Test Cases", active: "Reports" },
+			{ destination: "reports", heading: "Reports", active: "Reports" },
 		];
 
 		for (const destination of destinations) {
 			const path = buildProjectPath(PROJECT_A.project_id, destination.destination);
 			await page.goto(path);
 			await expect(page).toHaveURL(new RegExp(`${path}/?$`));
-			await expect(page.getByRole("heading", { name: new RegExp(`^${destination.heading}$`, "i") })).toBeVisible({
+			await expect(page.getByRole("heading", { name: new RegExp(`^${destination.heading}$`, "i"), level: 1 })).toBeVisible({
 				timeout: 30_000,
 			});
 			await expect(page.getByRole("button", { name: "Open QA project menu" })).toContainText(PROJECT_A.name);
@@ -533,7 +533,7 @@ test.describe("Route-driven application shell", () => {
 		await page.getByRole("button", { name: "Open QA project menu" }).click();
 		await page.getByRole("button", { name: `Open QA project ${PROJECT_B.name}` }).click();
 		await expect(page).toHaveURL(buildProjectPath(PROJECT_B.project_id));
-		await expect(page.getByRole("heading", { name: new RegExp(`^${PROJECT_B.name}$`, "i") })).toBeVisible({ timeout: 30_000 });
+		await expect(page.getByRole("heading", { name: /^Overview$/i })).toBeVisible({ timeout: 30_000 });
 		await expect(page.getByRole("button", { name: "Open QA project menu" })).toContainText(PROJECT_B.name);
 
 		const parseResponse = page.waitForResponse(
@@ -579,10 +579,10 @@ test.describe("Route-driven application shell", () => {
 
 		await page.getByRole("button", { name: "Open QA project menu" }).click();
 		await page.getByRole("button", { name: `Open QA project ${PROJECT_B.name}` }).click();
-		await expect(page.getByRole("heading", { name: new RegExp(`^${PROJECT_B.name}$`, "i") })).toBeVisible({ timeout: 30_000 });
+		await expect(page.getByRole("heading", { name: /^Overview$/i })).toBeVisible({ timeout: 30_000 });
 		await page.getByRole("button", { name: "Open QA project menu" }).click();
 		await page.getByRole("button", { name: `Open QA project ${PROJECT_A.name}` }).click();
-		await expect(page.getByRole("heading", { name: new RegExp(`^${PROJECT_A.name}$`, "i") })).toBeVisible({ timeout: 30_000 });
+		await expect(page.getByRole("heading", { name: /^Overview$/i })).toBeVisible({ timeout: 30_000 });
 		await page
 			.getByRole("navigation", { name: "Project navigation" })
 			.getByRole("link", { name: /^Requirements(?:,|$)/i })

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,7 @@
     "format:check": "prettier --check \"src/**/*.{js,jsx,css}\" \"e2e/**/*.{js,mjs}\" \"*.js\"",
     "preview": "vite preview",
     "test:e2e": "playwright test",
-    "test:e2e:home-first": "playwright test e2e/export-approval-gate.spec.js e2e/home-workspace.spec.js e2e/workflow-navigation.spec.js e2e/contextual-next-action.spec.js e2e/use-case-review.spec.js e2e/review-inbox.spec.js e2e/automation-preview-consistency.spec.js e2e/multi-environment-execution.spec.js e2e/responsive-reflow.spec.js e2e/runs-reports-index.spec.js e2e/accessibility-navigation.spec.js",
+    "test:e2e:home-first": "playwright test e2e/shared-project-design.spec.js e2e/export-approval-gate.spec.js e2e/home-workspace.spec.js e2e/workflow-navigation.spec.js e2e/contextual-next-action.spec.js e2e/use-case-review.spec.js e2e/review-inbox.spec.js e2e/automation-preview-consistency.spec.js e2e/multi-environment-execution.spec.js e2e/responsive-reflow.spec.js e2e/runs-reports-index.spec.js e2e/accessibility-navigation.spec.js",
     "test:e2e:headed": "playwright test --headed"
   },
   "dependencies": {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,3 +1,5 @@
+import ProjectPageHeader from "./components/layout/ProjectPageHeader";
+import TestCaseQualitySummary from "./components/generation/TestCaseQualitySummary";
 import { useEffect, useRef, useState } from "react";
 import { onAuthStateChanged, signInWithPopup, signOut } from "firebase/auth";
 import GlobalAppShell from "./app/GlobalAppShell";
@@ -4060,6 +4062,16 @@ export default function App() {
 							<ProjectOverviewPage
 								project={currentProject}
 								status={orchestratorStatus}
+								counts={{
+									requirements: requirements.length,
+									scenarios: (currentProject.current_snapshots?.use_cases?.payload?.coverage_plan || []).reduce(
+										(sum, group) => sum + (group.scenarios?.length || 0),
+										0
+									),
+									testCases: testCases.length,
+								}}
+								testCaseReview={testCaseReview}
+								exportLocked={exportGateLocked}
 								navigate={navigate}
 								contextualTask={
 									<OrchestratorCockpitPanel
@@ -4089,20 +4101,23 @@ export default function App() {
 							<main
 								id="main-content"
 								ref={workflowMainRef}
-								className="workflow-main"
+								className={`workflow-main ${route.destination === "test-cases" ? "test-cases-page" : ""}`}
 								aria-label={`Workflow workspace: ${activeProjectDestinationLabel}`}
 								tabIndex={-1}
 							>
-								{route.destination === "test-cases" ? (
-									<div className="test-cases-section-tabs" role="tablist" aria-label="Test Cases sections">
-										<button type="button" role="tab" aria-selected={activeTab === 2} onClick={() => selectWorkflowTab(2)}>
-											Template setup
-										</button>
-										<button type="button" role="tab" aria-selected={activeTab === 3} onClick={() => selectWorkflowTab(3)}>
-											Generate and review
-										</button>
-									</div>
-								) : null}
+								<ProjectPageHeader
+									title={activeProjectDestinationLabel}
+									project={currentProject}
+									navigate={navigate}
+									actions={
+										route.destination === "test-cases" ? (
+											<button className="secondary" onClick={() => selectWorkflowTab(activeTab === 2 ? 3 : 2)}>
+												{activeTab === 2 ? "Generate and review" : "Template setup"}
+											</button>
+										) : null
+									}
+								/>
+
 								<OrchestratorCockpitPanel
 									currentProject={currentProject}
 									status={orchestratorStatus}
@@ -4794,36 +4809,37 @@ export default function App() {
 									)}
 
 									{activeTab === 3 && (
-										<section className="panel">
+										<section className={`panel test-generation-panel ${testCases.length ? "has-test-cases" : ""}`}>
 											<h2 className="panel-title">Generate Test Cases</h2>
 											<p className="panel-description">
 												Generate structured test cases, or analyze impact against an existing suite when upstream inputs change.
 											</p>
-											{requirements.length > 0 && (
-												<div className={`generation-gate-card ${canGenerateFromApprovedRequirements ? "ready" : "blocked"}`}>
-													<div>
-														<strong>
-															{upstreamChangedForImpact
-																? "Existing suite needs impact analysis"
-																: canGenerateFromApprovedRequirements
-																	? "Ready for approved-requirement generation"
-																	: "Approval required before generation"}
-														</strong>
-														<p>
-															{approvedRequirementCount} approved • {reviewPendingRequirementCount} pending review •{" "}
-															{rejectedRequirementCount} rejected
-															{upstreamChangedForImpact
-																? ". The current suite is preserved while impact analysis reviews changed inputs."
-																: ". Only approved requirements are sent to the test-case agents."}
-														</p>
+											{requirements.length > 0 &&
+												(!testCases.length || !canGenerateFromApprovedRequirements || upstreamChangedForImpact) && (
+													<div className={`generation-gate-card ${canGenerateFromApprovedRequirements ? "ready" : "blocked"}`}>
+														<div>
+															<strong>
+																{upstreamChangedForImpact
+																	? "Existing suite needs impact analysis"
+																	: canGenerateFromApprovedRequirements
+																		? "Ready for approved-requirement generation"
+																		: "Approval required before generation"}
+															</strong>
+															<p>
+																{approvedRequirementCount} approved • {reviewPendingRequirementCount} pending review •{" "}
+																{rejectedRequirementCount} rejected
+																{upstreamChangedForImpact
+																	? ". The current suite is preserved while impact analysis reviews changed inputs."
+																	: ". Only approved requirements are sent to the test-case agents."}
+															</p>
+														</div>
+														{!canGenerateFromApprovedRequirements && (
+															<button type="button" className="secondary small" onClick={() => selectWorkflowTab(0)}>
+																Review requirements
+															</button>
+														)}
 													</div>
-													{!canGenerateFromApprovedRequirements && (
-														<button type="button" className="secondary small" onClick={() => selectWorkflowTab(0)}>
-															Review requirements
-														</button>
-													)}
-												</div>
-											)}
+												)}
 											{!contextualTestCaseTask &&
 											allowLegacyTestCaseMutations &&
 											(!hasExistingTestCaseBaseline || upstreamChangedForImpact) ? (
@@ -4849,27 +4865,10 @@ export default function App() {
 
 											{renderImpactAnalysisPanel()}
 
-											{testCaseReview && (
-												<div className={`review-banner ${testCaseReview.approved ? "review-approved" : "review-needs-work"}`}>
-													<div className="review-banner-header">
-														<strong>{testCaseReview.approved ? "Approved for export" : "Needs refinement"}</strong>
-														<div className="review-banner-metrics">
-															<span className="review-metric-pill review-metric-pill-strong">{testCaseReviewMeta.scoreLabel}</span>
-															{testCaseReviewMeta.thresholdLabel && (
-																<span className="review-metric-pill">{testCaseReviewMeta.thresholdLabel}</span>
-															)}
-														</div>
-													</div>
-													<p>{testCaseReview.summary || "The review loop completed without a summary."}</p>
-													{!testCaseReview.approved && testCaseReview.blocking_issues?.length > 0 && (
-														<ul className="review-issues">
-															{testCaseReview.blocking_issues.slice(0, 3).map((issue) => (
-																<li key={issue}>{issue}</li>
-															))}
-														</ul>
-													)}
-												</div>
-											)}
+											<p className="test-suite-summary">
+												{testCases.length} test cases · {approvedRequirementCount} approved requirements
+											</p>
+											<TestCaseQualitySummary review={testCaseReview} meta={testCaseReviewMeta} exportLocked={exportGateLocked} />
 
 											{hasGenerateResults ? (
 												<div className="generate-results-workspace">
@@ -4959,7 +4958,7 @@ export default function App() {
 														{activeGenerateResultTab === "test-cases" && (
 															<GeneratedTestCasesView
 																testCases={testCases}
-																templateFormat={templateFormat}
+																qualityIssues={testCaseReview?.blocking_issues || []}
 																expandedRows={expandedRows}
 																onToggleRowExpansion={toggleRowExpansion}
 																feedback={feedback}

--- a/frontend/src/api/generated/api-contracts.d.ts
+++ b/frontend/src/api/generated/api-contracts.d.ts
@@ -1034,6 +1034,7 @@ export interface WorkspaceWorkItem {
 	project_name: string;
 	project_revision: number;
 	reason: string;
+	requirement_group_count?: number | null;
 	stage: "requirements" | "context" | "use_cases" | "impact_analysis" | "test_cases" | "automation" | "execution" | "review" | "reports";
 	status: "not_started" | "ready" | "blocked" | "completed" | "stale" | "failed" | "attention_required";
 	updated_at: string;

--- a/frontend/src/app/RoutePages.jsx
+++ b/frontend/src/app/RoutePages.jsx
@@ -1,3 +1,5 @@
+import { CircleAlert, LockKeyhole } from "lucide-react";
+import ProjectPageHeader from "../components/layout/ProjectPageHeader";
 import RouteLink from "./RouteLink";
 import { GLOBAL_DESTINATIONS, PROJECT_DESTINATIONS, PROJECT_NAV_ITEMS, buildGlobalPath, buildProjectPath } from "./workflowRoutes";
 
@@ -175,32 +177,77 @@ export function ProjectLoadingPage({ projectId = "" }) {
 	);
 }
 
-export function ProjectOverviewPage({ project, status = null, navigate, contextualTask = null }) {
+export function ProjectOverviewPage({
+	project,
+	status = null,
+	navigate,
+	contextualTask = null,
+	counts = {},
+	testCaseReview,
+	exportLocked,
+}) {
 	const projectId = project?.project_id || "";
-	const currentStage = status?.current_stage || project?.latest_stage || "requirements";
+	const attention = Boolean(testCaseReview && !testCaseReview.approved);
 
 	return (
-		<main id="main-content" className="route-page" aria-labelledby="project-overview-title" tabIndex={-1}>
-			<header className="route-page-header">
-				<span className="route-page-kicker">Project overview</span>
-				<h1 id="project-overview-title">{project?.name || "Project"}</h1>
-				<p>
-					Revision {status?.project_revision ?? project?.current_revision ?? 0} · Current stage {`${currentStage}`.replaceAll("_", " ")}
-				</p>
-			</header>
+		<main id="main-content" className="route-page project-overview-page" aria-labelledby="project-overview-title" tabIndex={-1}>
+			<ProjectPageHeader
+				title="Overview"
+				titleId="project-overview-title"
+				project={{ ...project, current_revision: status?.project_revision ?? project?.current_revision }}
+				navigate={navigate}
+			/>
 			{projectId ? (
 				<>
 					{contextualTask}
-					<ul className="route-workbench-list" aria-label="Project workbenches">
-						{PROJECT_NAV_ITEMS.filter((item) => item.id !== PROJECT_DESTINATIONS.OVERVIEW).map((item) => (
-							<li key={item.id}>
-								<RouteLink to={buildProjectPath(projectId, item.id)} navigate={navigate}>
-									<strong>{item.label}</strong>
-									<span>{item.title}</span>
-								</RouteLink>
-							</li>
+					<div className="overview-counts" aria-label="Project artifact counts">
+						{[
+							["requirements", counts.requirements],
+							["scenarios", counts.scenarios],
+							["test cases", counts.testCases],
+						].map(([label, count]) => (
+							<div key={label}>
+								<strong>{count ?? "—"}</strong>
+								<span>{label}</span>
+							</div>
 						))}
-					</ul>
+					</div>
+					<section className="overview-attention" aria-labelledby="overview-attention-title">
+						<h2 id="overview-attention-title">Needs your attention</h2>
+						{attention && (
+							<div className="overview-attention-row">
+								<CircleAlert aria-hidden="true" />
+								<strong>Test cases need refinement</strong>
+								<p>{testCaseReview.summary || "Review the quality findings before continuing."}</p>
+								<RouteLink to={buildProjectPath(projectId, "test-cases")} navigate={navigate}>
+									View test cases
+								</RouteLink>
+							</div>
+						)}
+						{exportLocked && (
+							<div className="overview-attention-row">
+								<LockKeyhole aria-hidden="true" />
+								<strong>Export is blocked</strong>
+								<p>Complete the required reviews to unlock exports.</p>
+								<RouteLink to={buildProjectPath(projectId, "reports")} navigate={navigate}>
+									View requirements for export
+								</RouteLink>
+							</div>
+						)}
+						{!attention && !exportLocked && <p>No additional issues need your attention.</p>}
+					</section>
+					<details className="overview-workbenches">
+						<summary>All project workbenches</summary>
+						<ul className="route-workbench-list" aria-label="Project workbenches">
+							{PROJECT_NAV_ITEMS.filter((item) => item.id !== PROJECT_DESTINATIONS.OVERVIEW).map((item) => (
+								<li key={item.id}>
+									<RouteLink to={buildProjectPath(projectId, item.id)} navigate={navigate}>
+										{item.label}
+									</RouteLink>
+								</li>
+							))}
+						</ul>
+					</details>
 				</>
 			) : (
 				<RecoveryLinks navigate={navigate} />

--- a/frontend/src/components/automation/AutomationPanel.jsx
+++ b/frontend/src/components/automation/AutomationPanel.jsx
@@ -235,7 +235,7 @@ export default function AutomationPanel({
 
 	return (
 		<section className="panel" aria-busy={isPreviewingExecution || isRunningExecution || undefined}>
-			<h2 className="panel-title">Automation</h2>
+			<h2 className="panel-title">Execution setup</h2>
 			<p className="panel-description">Review executable candidates and run approved browser cases through Playwright.</p>
 			<div className="panel-form two-cols">
 				<div className="form-group">

--- a/frontend/src/components/generation/GeneratedTestCasesView.jsx
+++ b/frontend/src/components/generation/GeneratedTestCasesView.jsx
@@ -1,18 +1,9 @@
+import { useId, useState } from "react";
+import { ChevronRight } from "lucide-react";
 import { getTestCaseLinkedRequirementIds } from "../../utils/requirements";
-
-const getPriorityClass = (priority) => {
-	const map = { Critical: "priority-critical", High: "priority-high", Medium: "priority-medium", Low: "priority-low" };
-	return map[priority] || "";
-};
-
-const getStatusClass = (status) => {
-	const map = { Draft: "status-draft", Ready: "status-ready", "In Review": "status-review", Approved: "status-approved" };
-	return map[status] || "";
-};
 
 export default function GeneratedTestCasesView({
 	testCases,
-	templateFormat,
 	expandedRows,
 	onToggleRowExpansion,
 	feedback,
@@ -21,182 +12,157 @@ export default function GeneratedTestCasesView({
 	isGenerating,
 	testCaseActionDisabled,
 	allowRefinement = true,
+	qualityIssues = [],
 }) {
+	const [selectedId, setSelectedId] = useState(null);
+	const [query, setQuery] = useState("");
+	const searchId = useId();
+	const feedbackId = useId();
+	const cases = testCases.filter((tc) =>
+		[tc.id, tc.title, ...getTestCaseLinkedRequirementIds(tc)].join(" ").toLowerCase().includes(query.toLowerCase().trim())
+	);
+	const selected = cases.find((tc) => tc.id === selectedId) || cases[0];
+	const steps = selected?.steps || [];
+	const expanded = Boolean(expandedRows[selected?.id]);
+	const findings = selected
+		? qualityIssues.filter((issue) => new RegExp(`\\b${selected.id.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\b`).test(issue))
+		: [];
 	return (
 		<>
-			<div className="result-section generate-result-section">
-				<h3>Generated Test Cases</h3>
-				{testCases.length === 0 ? (
-					<span className="helper-text">No test cases generated yet.</span>
-				) : templateFormat === "table" ? (
-					<div className="test-cases-table-wrapper" role="region" aria-label="Generated test cases table" tabIndex={0}>
-						<table className="test-cases-table">
-							<thead>
-								<tr>
-									<th className="col-id">ID</th>
-									<th className="col-title">Title</th>
-									<th className="col-priority">Priority</th>
-									<th className="col-type">Type</th>
-									<th className="col-status">Status</th>
-									<th className="col-preconditions">Preconditions</th>
-									<th className="col-steps">Steps</th>
-									<th className="col-expected">Expected Result</th>
-									<th className="col-testdata">Test Data</th>
-									<th className="col-time">Est. Time</th>
-									<th className="col-automation">Automation</th>
-									<th className="col-component">Component</th>
-									<th className="col-tags">Linked Reqs</th>
-									<th className="col-tags">Tags</th>
-								</tr>
-							</thead>
-							<tbody>
-								{testCases.map((tc) => (
-									<tr key={tc.id} className={expandedRows[tc.id] ? "expanded" : ""} onClick={() => onToggleRowExpansion(tc.id)}>
-										<td className="tc-id">{tc.id}</td>
-										<td className="tc-title">
-											<div className="title-cell">
-												<span className="expand-icon">{expandedRows[tc.id] ? "▼" : "▶"}</span>
-												{tc.title}
-											</div>
-											{tc.description && <div className="tc-description">{tc.description}</div>}
-										</td>
-										<td className="tc-priority">
-											<span className={`priority-badge ${getPriorityClass(tc.priority)}`}>{tc.priority || "Medium"}</span>
-										</td>
-										<td className="tc-type">{tc.type || "Functional"}</td>
-										<td className="tc-status">
-											<span className={`status-badge ${getStatusClass(tc.status)}`}>{tc.status || "Draft"}</span>
-										</td>
-										<td className="tc-preconditions">{tc.preconditions || "-"}</td>
-										<td className="tc-steps">
-											<ol>
-												{tc.steps?.slice(0, expandedRows[tc.id] ? undefined : 2).map((step, index) => (
-													<li key={`${tc.id}-step-${step.step || index + 1}`}>
-														<strong>{step.action}</strong>
-														<span className="step-expected">→ {step.expected}</span>
-														{step.test_data && <span className="step-data">📋 {step.test_data}</span>}
-													</li>
-												))}
-												{!expandedRows[tc.id] && tc.steps?.length > 2 && (
-													<li className="more-steps">+{tc.steps.length - 2} more steps...</li>
-												)}
-											</ol>
-										</td>
-										<td className="tc-expected-result">{tc.expected_result || "-"}</td>
-										<td className="tc-testdata">{tc.test_data || "-"}</td>
-										<td className="tc-time">{tc.estimated_time || "-"}</td>
-										<td className="tc-automation">
-											<span className={`automation-badge ${tc.automation_status?.replace(/\s/g, "-").toLowerCase() || "manual"}`}>
-												{tc.automation_status || "Manual"}
-											</span>
-										</td>
-										<td className="tc-component">{tc.component || "-"}</td>
-										<td className="tc-tags">
-											{getTestCaseLinkedRequirementIds(tc).map((requirementId) => (
-												<span key={`${tc.id}-${requirementId}`} className="tag traceability-case-tag">
-													{requirementId}
-												</span>
-											))}
-										</td>
-										<td className="tc-tags">
-											{tc.tags?.map((tag) => (
-												<span key={tag} className="tag">
-													{tag}
-												</span>
-											))}
-										</td>
-									</tr>
+			<section className="test-review-workspace" aria-label="Generated test cases">
+				<div className="test-review-list">
+					<h2>Generated Test Cases</h2>
+					<label htmlFor={searchId} className="sr-only">
+						Search test cases
+					</label>
+					<input
+						id={searchId}
+						type="search"
+						placeholder="Search test cases"
+						value={query}
+						onChange={(event) => setQuery(event.target.value)}
+					/>
+					<p className="test-list-count" role="status">
+						{cases.length} of {testCases.length} test cases
+					</p>
+					<div className="test-review-items">
+						{cases.map((tc) => (
+							<button
+								key={tc.id}
+								type="button"
+								className={`test-review-item ${selected?.id === tc.id ? "selected" : ""}`}
+								aria-pressed={selected?.id === tc.id}
+								aria-controls="selected-test-case"
+								onClick={() => setSelectedId(tc.id)}
+							>
+								<span>
+									<small>{tc.id}</small>
+									<strong>{tc.title}</strong>
+									<span>
+										{tc.priority || "Medium"} priority · {getTestCaseLinkedRequirementIds(tc).join(", ") || "No linked requirements"}
+									</span>
+								</span>
+								<ChevronRight size={18} aria-hidden="true" />
+							</button>
+						))}
+					</div>
+					{!cases.length && <p>{testCases.length ? "No test cases match your search." : "No test cases generated yet."}</p>}
+				</div>
+				<section className="test-review-detail" id="selected-test-case" aria-label="Selected test case" aria-live="polite">
+					{selected ? (
+						<>
+							<span className="case-id">{selected.id}</span>
+							<p className="test-detail-meta">
+								{selected.type || "Functional"} · {selected.priority || "Medium"} priority ·{" "}
+								{getTestCaseLinkedRequirementIds(selected).join(", ")}
+							</p>
+							<h2>{selected.title}</h2>
+							{selected.description && <p>{selected.description}</p>}
+							{findings.length > 0 && (
+								<details className="test-inline-findings">
+									<summary>Quality findings for {selected.id}</summary>
+									<ul>
+										{findings.map((issue) => (
+											<li key={issue}>{issue}</li>
+										))}
+									</ul>
+								</details>
+							)}
+							<h3>Preconditions</h3>
+							<p>{selected.preconditions || "None specified."}</p>
+							<div className="test-steps-heading">
+								<h3>Steps and expected results</h3>
+								<span>{steps.length} steps</span>
+							</div>
+							<ol className="test-detail-steps">
+								{steps.slice(0, expanded ? undefined : 2).map((step, index) => (
+									<li key={`${selected.id}-${index}`}>
+										<p>{step.action}</p>
+										<p>
+											<strong>Expected</strong> {step.expected || "Not specified"}
+										</p>
+										{step.test_data && (
+											<p>
+												<strong>Test data</strong> {step.test_data}
+											</p>
+										)}
+									</li>
 								))}
-							</tbody>
-						</table>
-					</div>
-				) : (
-					<div className="test-cases-grid">
-						{testCases.map((tc) => {
-							const linkedRequirementIds = getTestCaseLinkedRequirementIds(tc);
-							return (
-								<div key={tc.id} className="case-card">
-									<div className="case-header">
-										<span className="case-id">{tc.id}</span>
-										<span className="case-title">{tc.title}</span>
-										<span className={`priority-badge ${getPriorityClass(tc.priority)}`}>{tc.priority}</span>
-									</div>
-									{tc.description && <div className="case-description">{tc.description}</div>}
-									<div className="case-meta">
-										<span className="meta-item">
-											<strong>Type:</strong> {tc.type}
-										</span>
-										<span className={`status-badge ${getStatusClass(tc.status)}`}>{tc.status}</span>
-										<span className="meta-item">
-											<strong>Est:</strong> {tc.estimated_time}
-										</span>
-									</div>
-									{linkedRequirementIds.length > 0 && (
-										<div className="case-tags traceability-links">
-											{linkedRequirementIds.map((requirementId) => (
-												<span key={`${tc.id}-linked-${requirementId}`} className="tag traceability-case-tag">
-													{requirementId}
-												</span>
-											))}
+							</ol>
+							{steps.length > 2 && (
+								<button
+									className="secondary small"
+									type="button"
+									aria-expanded={expanded}
+									onClick={() => onToggleRowExpansion(selected.id)}
+								>
+									{expanded ? "Show fewer steps" : `Show all ${steps.length} steps`}
+								</button>
+							)}
+							<h3>Expected result</h3>
+							<p>{selected.expected_result || "Not specified."}</p>
+							<details className="test-case-metadata">
+								<summary>Test data and metadata</summary>
+								<dl>
+									{Object.entries({
+										"Test data": selected.test_data,
+										"Estimated time": selected.estimated_time,
+										"Case status": selected.status || "Draft",
+										Automation: selected.automation_status || "Manual",
+										Component: selected.component,
+										"Linked requirements": getTestCaseLinkedRequirementIds(selected).join(", "),
+										Tags: selected.tags?.join(", "),
+									}).map(([label, value]) => (
+										<div key={label}>
+											<dt>{label}</dt>
+											<dd>{value || "Not specified"}</dd>
 										</div>
-									)}
-									{tc.preconditions && <div className="case-preconditions">{tc.preconditions}</div>}
-									<div className="case-steps">
-										<strong>Steps</strong>
-										<ol>
-											{tc.steps?.map((step, index) => (
-												<li key={`${tc.id}-card-step-${step.step || index + 1}`}>
-													<span className="step-action">
-														{step.step || index + 1}. {step.action}
-													</span>
-													<span className="step-expected">→ {step.expected}</span>
-													{step.test_data && <span className="step-data">📋 {step.test_data}</span>}
-												</li>
-											))}
-										</ol>
-									</div>
-									{tc.expected_result && (
-										<div className="case-expected">
-											<strong>Expected Result:</strong> {tc.expected_result}
-										</div>
-									)}
-									{tc.tags && tc.tags.length > 0 && (
-										<div className="case-tags">
-											{tc.tags.map((tag) => (
-												<span key={tag} className="tag">
-													{tag}
-												</span>
-											))}
-										</div>
-									)}
-								</div>
-							);
-						})}
-					</div>
-				)}
-			</div>
-
+									))}
+								</dl>
+								<p>Case status and automation intent do not indicate quality approval or execution readiness.</p>
+							</details>
+						</>
+					) : (
+						<p>Select a test case to review its details.</p>
+					)}
+				</section>
+			</section>
 			{testCases.length > 0 && allowRefinement && (
-				<div className="feedback-section">
+				<section className="feedback-section">
 					<h3>Human Feedback</h3>
-					<p className="feedback-description">Provide feedback on the generated test cases. The AI will refine them based on your input.</p>
+					<label htmlFor={feedbackId}>Changes to the test suite</label>
 					<textarea
+						id={feedbackId}
 						className="feedback-textarea"
-						placeholder="Enter your feedback here... e.g., 'Add more negative test cases for upload feature', 'TC-003 needs more detailed steps', 'Include security test cases', etc."
+						placeholder="Describe the changes needed…"
 						value={feedback}
 						onChange={(event) => onFeedbackChange(event.target.value)}
 						rows={4}
 					/>
-					<div className="feedback-actions">
-						<button
-							onClick={onRefineTestCases}
-							disabled={!feedback.trim() || isGenerating || testCaseActionDisabled}
-							className="feedback-button"
-						>
-							{isGenerating ? "⏳ Updating Test Cases..." : "🔄 Implement Changes"}
-						</button>
-					</div>
-				</div>
+					<button onClick={onRefineTestCases} disabled={!feedback.trim() || isGenerating || testCaseActionDisabled}>
+						{isGenerating ? "Updating test cases…" : "Implement Changes"}
+					</button>
+				</section>
 			)}
 		</>
 	);

--- a/frontend/src/components/generation/TestCaseQualitySummary.jsx
+++ b/frontend/src/components/generation/TestCaseQualitySummary.jsx
@@ -1,0 +1,31 @@
+import { CircleAlert, CircleCheck } from "lucide-react";
+
+export default function TestCaseQualitySummary({ review, meta, exportLocked }) {
+	if (!review) return null;
+	const Icon = review.approved ? CircleCheck : CircleAlert;
+	const findings = [...new Set([...(review.blocking_issues || []), ...(review.unmet_criteria || [])])];
+	return (
+		<section className={`test-quality-summary ${review.approved ? "approved" : "attention"}`} aria-label="Test case quality">
+			<Icon size={28} aria-hidden="true" />
+			<div>
+				<strong>{review.approved ? "Machine quality check passed" : "Needs refinement"}</strong>
+				<p>
+					{meta.scoreLabel}
+					{meta.thresholdLabel ? ` · ${meta.thresholdLabel}` : ""}
+					{exportLocked ? " · Export is blocked." : ""}
+				</p>
+				<details className="test-quality-findings">
+					<summary>View findings</summary>
+					<p>{review.summary || "No review summary available."}</p>
+					{findings.length > 0 && (
+						<ul>
+							{findings.map((issue) => (
+								<li key={issue}>{issue}</li>
+							))}
+						</ul>
+					)}
+				</details>
+			</div>
+		</section>
+	);
+}

--- a/frontend/src/components/layout/ProjectPageHeader.jsx
+++ b/frontend/src/components/layout/ProjectPageHeader.jsx
@@ -1,0 +1,23 @@
+import RouteLink from "../../app/RouteLink";
+
+export default function ProjectPageHeader({ title, project, navigate, titleId, actions, children }) {
+	return (
+		<header className="project-page-header">
+			<nav className="project-breadcrumb" aria-label="Breadcrumb">
+				<RouteLink to="/projects" navigate={navigate}>
+					Projects
+				</RouteLink>
+				<span aria-hidden="true">/</span>
+				<span aria-current="page">{title}</span>
+			</nav>
+			<div className="project-page-title-row">
+				<h1 id={titleId}>{title}</h1>
+				{actions}
+			</div>
+			<p>
+				{project?.name || "Project"} · Revision {project?.current_revision ?? 0}
+			</p>
+			{children}
+		</header>
+	);
+}

--- a/frontend/src/components/layout/WorkflowNavigationDrawer.jsx
+++ b/frontend/src/components/layout/WorkflowNavigationDrawer.jsx
@@ -2,8 +2,8 @@ import {
 	BookOpen,
 	Bot,
 	ClipboardCheck,
-	CloudUpload,
-	Download,
+	FileText,
+	ChartNoAxesColumnIncreasing,
 	LayoutGrid,
 	PanelLeftClose,
 	PanelLeftOpen,
@@ -11,7 +11,7 @@ import {
 } from "lucide-react";
 import { useRef } from "react";
 
-import StatusBadge from "../workflow/StatusBadge";
+import { Circle, LockKeyhole } from "lucide-react";
 
 const STATE_LABELS = {
 	active: "Current",
@@ -22,12 +22,12 @@ const STATE_LABELS = {
 };
 
 const WORKFLOW_ICONS = {
-	0: CloudUpload,
+	0: FileText,
 	1: BookOpen,
 	2: LayoutGrid,
 	3: WandSparkles,
 	4: Bot,
-	5: Download,
+	5: ChartNoAxesColumnIncreasing,
 	6: ClipboardCheck,
 };
 
@@ -77,8 +77,7 @@ export default function WorkflowNavigationDrawer({
 		>
 			<div className="workflow-navigation-header">
 				<div>
-					<span>Workflow</span>
-					<strong>{tabs.find((tab) => tab.id === activeTab)?.label || "Workspace"}</strong>
+					<span>Project</span>
 				</div>
 				<button
 					ref={toggleRef}
@@ -97,7 +96,15 @@ export default function WorkflowNavigationDrawer({
 				{tabs.map((tab) => {
 					const isActive = activeTab === tab.id;
 					const state = statusByTabId[tab.id] || "pending";
-					const stateLabel = isActive ? STATE_LABELS.active : STATE_LABELS[state] || STATE_LABELS.pending;
+					const stateLabel =
+						tab.id === 7
+							? ""
+							: state === "attention" && tab.id === 6
+								? "Awaiting review"
+								: state === "attention" && tab.id === 3
+									? "Needs refinement"
+									: STATE_LABELS[state] || STATE_LABELS.pending;
+					const StatusIcon = state === "blocked" ? LockKeyhole : Circle;
 					const WorkflowIcon = WORKFLOW_ICONS[tab.id] || LayoutGrid;
 					const itemContent = (
 						<>
@@ -106,11 +113,13 @@ export default function WorkflowNavigationDrawer({
 							</span>
 							<span className="workflow-navigation-copy">
 								<strong>{tab.label}</strong>
-								<span>{tab.title}</span>
+								{stateLabel && !isCollapsed && (
+									<span className={`nav-workflow-status ${state}`}>
+										<StatusIcon size={10} aria-hidden="true" fill={state === "blocked" ? "none" : "currentColor"} />
+										{stateLabel}
+									</span>
+								)}
 							</span>
-							{!isCollapsed && (
-								<StatusBadge className="workflow-navigation-state" status={isActive ? "active" : state} label={stateLabel} />
-							)}
 						</>
 					);
 					const itemClassName = `workflow-navigation-item ${state} ${isActive ? "active" : ""}`;
@@ -129,8 +138,8 @@ export default function WorkflowNavigationDrawer({
 									handleSelection(tab.id);
 								}}
 								aria-current={isActive ? "page" : undefined}
-								aria-label={`${tab.label}, ${stateLabel}`}
-								title={isCollapsed ? [tab.label, stateLabel].join(" — ") : undefined}
+								aria-label={[tab.label, stateLabel].filter(Boolean).join(", ")}
+								title={isCollapsed ? [tab.label, stateLabel].filter(Boolean).join(" — ") : undefined}
 							>
 								{itemContent}
 							</a>
@@ -144,8 +153,8 @@ export default function WorkflowNavigationDrawer({
 							className={itemClassName}
 							onClick={() => handleSelection(tab.id)}
 							aria-current={isActive ? "page" : undefined}
-							aria-label={`${tab.label}, ${stateLabel}`}
-							title={isCollapsed ? [tab.label, stateLabel].join(" — ") : undefined}
+							aria-label={[tab.label, stateLabel].filter(Boolean).join(", ")}
+							title={isCollapsed ? [tab.label, stateLabel].filter(Boolean).join(" — ") : undefined}
 						>
 							{itemContent}
 						</button>

--- a/frontend/src/components/projects/OrchestratorCockpitPanel.jsx
+++ b/frontend/src/components/projects/OrchestratorCockpitPanel.jsx
@@ -28,7 +28,7 @@ export default function OrchestratorCockpitPanel({
 		return null;
 	}
 
-	return (
+	const content = (
 		<section className="contextual-task-region" aria-label="Contextual task">
 			{error ? (
 				<div className="orchestrator-error" role="alert">
@@ -49,5 +49,13 @@ export default function OrchestratorCockpitPanel({
 				/>
 			) : null}
 		</section>
+	);
+	return !primaryAction && !error ? (
+		<details className="optional-workflow-actions">
+			<summary>More actions</summary>
+			{content}
+		</details>
+	) : (
+		content
 	);
 }

--- a/frontend/src/components/reviews/ReviewInbox.jsx
+++ b/frontend/src/components/reviews/ReviewInbox.jsx
@@ -2,6 +2,7 @@ import { CircleAlert, CircleCheck, ClipboardCheck, Info, ListChecks, Sparkles, W
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import {
+	formatWorkItemCount,
 	formatWorkspaceDate,
 	formatWorkspaceLabel,
 	formatWorkspaceStatus,
@@ -52,6 +53,7 @@ export const isActionableReviewItem = (item) =>
 	item?.enabled === true && item?.kind !== "information" && !COMPLETED_STATUSES.has(item?.status);
 
 const formatCount = (item) => {
+	if (item?.stage === "use_cases") return formatWorkItemCount(item);
 	if (!Number.isInteger(item?.count)) return "";
 	const unit = COUNT_UNIT_BY_STAGE[item.stage] || "item";
 	return `${item.count} ${unit}${item.count === 1 ? "" : "s"}`;

--- a/frontend/src/components/reviews/UseCaseReviewWorkbench.jsx
+++ b/frontend/src/components/reviews/UseCaseReviewWorkbench.jsx
@@ -169,17 +169,21 @@ function ArtifactSummary({ project, snapshot, stageState, scenarioTotal, groupTo
 function ScenarioCard({ scenario }) {
 	return (
 		<li className="use-case-scenario-card">
-			<div className="use-case-scenario-heading">
-				<div>
-					<span className="use-case-scenario-type">{formatWorkspaceLabel(scenario.scenario_type, "Scenario")}</span>
-					<h4>{scenario.title || scenario.objective || "Untitled scenario"}</h4>
+			<details className="scenario-details">
+				<summary>
+					<span className="scenario-summary-copy">
+						<span className="use-case-scenario-type">{scenario.id || formatWorkspaceLabel(scenario.scenario_type, "Scenario")}</span>
+						<strong>{scenario.title || scenario.objective || "Untitled scenario"}</strong>
+					</span>
+				</summary>
+				<div className="scenario-expanded-content">
+					<p>{scenario.objective || "No additional objective provided."}</p>
+					<span>
+						{formatWorkspaceLabel(scenario.scenario_type, "Scenario")} · {formatWorkspaceLabel(scenario.priority, "Unprioritized")} ·{" "}
+						{scenario.must_have ? "Must have" : "Recommended"}
+					</span>
 				</div>
-				<div className="use-case-scenario-badges" aria-label="Scenario priority">
-					<span>{formatWorkspaceLabel(scenario.priority, "Unprioritized")}</span>
-					<span className={scenario.must_have ? "required" : "recommended"}>{scenario.must_have ? "Must have" : "Recommended"}</span>
-				</div>
-			</div>
-			{scenario.objective && scenario.objective !== scenario.title ? <p>{scenario.objective}</p> : null}
+			</details>
 		</li>
 	);
 }
@@ -287,7 +291,7 @@ function ReviewDecisionPanel({ stageState, snapshot, review }) {
 			<div className="use-case-decision-heading">
 				<div>
 					<span className="use-case-section-kicker">Human decision</span>
-					<h2>Complete this review</h2>
+					<h2>Review decision</h2>
 					<p>{humanMeta.label}. Your decision applies only to the current immutable artifact.</p>
 				</div>
 			</div>
@@ -419,8 +423,14 @@ function ReviewDecisionPanel({ stageState, snapshot, review }) {
 						? "Your feedback will be recorded with the decision."
 						: "Approval advances the durable project review state."}
 				</p>
-				<button type="submit" disabled={formDisabled || (review.decision === "approve" && approvalBlocked)}>
-					{review.isSubmitting ? "Saving decision…" : review.decision === "request_changes" ? "Request changes" : "Approve Use Cases"}
+				<button type="submit" disabled={!review.decision || formDisabled || (review.decision === "approve" && approvalBlocked)}>
+					{review.isSubmitting
+						? "Saving decision…"
+						: !review.decision
+							? "Choose a decision"
+							: review.decision === "request_changes"
+								? "Request changes"
+								: "Approve Use Cases"}
 				</button>
 			</div>
 		</form>
@@ -497,139 +507,151 @@ export default function UseCaseReviewWorkbench({ project, snapshot, stageState, 
 
 	return (
 		<div className="use-case-review-workbench">
-			<ArtifactSummary
-				project={project}
-				snapshot={snapshot}
-				stageState={effectiveStageState}
-				scenarioTotal={scenarioTotal}
-				groupTotal={coveragePlan.length}
-				machineReview={machineReview}
-				humanReview={humanReview}
-			/>
-
-			<section className="use-case-coverage-metrics" aria-label="Coverage metrics">
-				{coverageMetrics.map((metric) => (
-					<div key={metric.label}>
-						<span>{metric.label}</span>
-						<strong>{metric.value}</strong>
-					</div>
-				))}
-			</section>
-
-			{machineIssues.length ? (
-				<section className="use-case-machine-issues" aria-labelledby="use-case-machine-issues-title">
-					<h2 id="use-case-machine-issues-title">Machine review findings</h2>
-					<ul>
-						{machineIssues.map((issue) => (
-							<li key={issue}>{issue}</li>
-						))}
-					</ul>
-				</section>
-			) : null}
-
-			<section className="use-case-collection" aria-labelledby="use-case-collection-title">
-				<div className="use-case-collection-heading">
-					<div>
-						<span className="use-case-section-kicker">Review artifact</span>
-						<h2 id="use-case-collection-title">Use case scenarios</h2>
-						<p role="status" aria-live="polite">
-							Showing {visibleScenarioTotal} of {scenarioTotal} scenarios across {filteredGroups.length} of {coveragePlan.length}{" "}
-							requirement groups.
-						</p>
-					</div>
-					<div className="use-case-search-field">
-						<label htmlFor={searchId}>Search use cases</label>
-						<input
-							id={searchId}
-							type="search"
-							value={query}
-							ref={searchRef}
-							onChange={(event) => updateQuery(event.target.value)}
-							placeholder="Requirement, scenario, risk, or constraint"
-						/>
-					</div>
+			<div className="use-case-meta-row">
+				<div className="use-case-compact-summary">
+					<strong>{scenarioTotal} scenarios</strong>
+					<span>{coveragePlan.length} requirement groups</span>
+					<span>Use Cases v{snapshot.version ?? stageState?.version ?? "—"}</span>
+					<span>{effectiveStageState?.stale ? "Stale artifact" : "Current artifact"}</span>
 				</div>
+				<details className="use-case-supporting-details">
+					<summary>Quality, coverage and review history</summary>
+					<ArtifactSummary
+						project={project}
+						snapshot={snapshot}
+						stageState={effectiveStageState}
+						scenarioTotal={scenarioTotal}
+						groupTotal={coveragePlan.length}
+						machineReview={machineReview}
+						humanReview={humanReview}
+					/>
 
-				{filteredGroups.length > 1 ? (
-					<div className="use-case-group-toolbar">
-						<button type="button" className="use-case-group-toggle-all" onClick={() => setAllGroupsExpanded(!groupsExpandedByDefault)}>
-							{groupsExpandedByDefault ? "Collapse all groups" : "Expand all groups"}
-						</button>
+					<section className="use-case-coverage-metrics" aria-label="Coverage metrics">
+						{coverageMetrics.map((metric) => (
+							<div key={metric.label}>
+								<span>{metric.label}</span>
+								<strong>{metric.value}</strong>
+							</div>
+						))}
+					</section>
+
+					{machineIssues.length ? (
+						<section className="use-case-machine-issues" aria-labelledby="use-case-machine-issues-title">
+							<h2 id="use-case-machine-issues-title">Machine review findings</h2>
+							<ul>
+								{machineIssues.map((issue) => (
+									<li key={issue}>{issue}</li>
+								))}
+							</ul>
+						</section>
+					) : null}
+				</details>
+			</div>
+			<div className="artifact-review-columns">
+				<section className="use-case-collection" aria-labelledby="use-case-collection-title">
+					<div className="use-case-collection-heading">
+						<div>
+							<span className="use-case-section-kicker">Review artifact</span>
+							<h2 id="use-case-collection-title">Use case scenarios</h2>
+							<p role="status" aria-live="polite">
+								Showing {visibleScenarioTotal} of {scenarioTotal} scenarios across {filteredGroups.length} of {coveragePlan.length}{" "}
+								requirement groups.
+							</p>
+						</div>
+						<div className="use-case-search-field">
+							<label htmlFor={searchId}>Search use cases</label>
+							<input
+								id={searchId}
+								type="search"
+								value={query}
+								ref={searchRef}
+								onChange={(event) => updateQuery(event.target.value)}
+								placeholder="Requirement, scenario, risk, or constraint"
+							/>
+						</div>
 					</div>
-				) : null}
 
-				{filteredGroups.length ? (
-					<div className="use-case-group-list" aria-label="Use Case groups">
-						{filteredGroups.map((group, groupIndex) => {
-							const groupKey = group.requirement_id || normalizeText(group.requirement_text) || `group-${groupIndex}`;
-							const titleId = `use-case-group-${groupIndex}-${`${group.requirement_id || "requirement"}`.replace(/[^a-zA-Z0-9_-]/g, "-")}`;
-							const isOpen = groupToggles[groupKey] ?? groupsExpandedByDefault;
-							return (
-								<section
-									className="use-case-group"
-									aria-label={`${group.requirement_id || "Unidentified"} · ${group.requirement_text || "Requirement coverage"}`}
-									key={groupKey}
-								>
-									<details
-										className="use-case-group-details"
-										open={isOpen}
-										onToggle={(event) => {
-											const nextOpen = event.currentTarget.open;
-											if (nextOpen !== isOpen) {
-												setGroupToggles((previous) => ({ ...previous, [groupKey]: nextOpen }));
-											}
-										}}
+					{filteredGroups.length > 1 ? (
+						<div className="use-case-group-toolbar">
+							<button type="button" className="use-case-group-toggle-all" onClick={() => setAllGroupsExpanded(!groupsExpandedByDefault)}>
+								{groupsExpandedByDefault ? "Collapse all groups" : "Expand all groups"}
+							</button>
+						</div>
+					) : null}
+
+					{filteredGroups.length ? (
+						<div className="use-case-group-list" aria-label="Use Case groups">
+							{filteredGroups.map((group, groupIndex) => {
+								const groupKey = group.requirement_id || normalizeText(group.requirement_text) || `group-${groupIndex}`;
+								const titleId = `use-case-group-${groupIndex}-${`${group.requirement_id || "requirement"}`.replace(/[^a-zA-Z0-9_-]/g, "-")}`;
+								const isOpen = groupToggles[groupKey] ?? groupsExpandedByDefault;
+								return (
+									<section
+										className="use-case-group"
+										aria-label={`${group.requirement_id || "Unidentified"} · ${group.requirement_text || "Requirement coverage"}`}
+										key={groupKey}
 									>
-										<summary className="use-case-group-heading">
-											<div>
-												<span>Source requirement {group.requirement_id || "Unidentified"}</span>
-												<h3 id={titleId}>{group.requirement_text || "Requirement coverage"}</h3>
-											</div>
-											<strong>
-												{group.scenarios.length} scenario{group.scenarios.length === 1 ? "" : "s"}
-											</strong>
-										</summary>
-										{group.scenarios.length ? (
-											<ul
-												className="use-case-scenario-list"
-												aria-label={`Scenarios for ${group.requirement_id || "unidentified requirement"}`}
-											>
-												{group.scenarios.map((scenario, scenarioIndex) => (
-													<ScenarioCard key={scenario.id || `${group.requirement_id}-${scenarioIndex}`} scenario={scenario} />
-												))}
-											</ul>
-										) : (
-											<p className="use-case-context-empty">No scenarios were generated for this requirement.</p>
-										)}
-										<details className="use-case-coverage-context">
-											<summary aria-label={`Coverage context for ${group.requirement_id || "unidentified requirement"}`}>
-												Coverage context
+										<details
+											className="use-case-group-details"
+											open={isOpen}
+											onToggle={(event) => {
+												const nextOpen = event.currentTarget.open;
+												if (nextOpen !== isOpen) {
+													setGroupToggles((previous) => ({ ...previous, [groupKey]: nextOpen }));
+												}
+											}}
+										>
+											<summary className="use-case-group-heading">
+												<div>
+													<span>Source requirement {group.requirement_id || "Unidentified"}</span>
+													<h3 id={titleId}>{group.requirement_text || "Requirement coverage"}</h3>
+												</div>
+												<strong>
+													{group.scenarios.length} scenario{group.scenarios.length === 1 ? "" : "s"}
+												</strong>
 											</summary>
-											<CoverageContext analysis={group.analysis} />
+											{group.scenarios.length ? (
+												<ul
+													className="use-case-scenario-list"
+													aria-label={`Scenarios for ${group.requirement_id || "unidentified requirement"}`}
+												>
+													{group.scenarios.map((scenario, scenarioIndex) => (
+														<ScenarioCard key={scenario.id || `${group.requirement_id}-${scenarioIndex}`} scenario={scenario} />
+													))}
+												</ul>
+											) : (
+												<p className="use-case-context-empty">No scenarios were generated for this requirement.</p>
+											)}
+											<details className="use-case-coverage-context">
+												<summary aria-label={`Coverage context for ${group.requirement_id || "unidentified requirement"}`}>
+													Coverage context
+												</summary>
+												<CoverageContext analysis={group.analysis} />
+											</details>
 										</details>
-									</details>
-								</section>
-							);
-						})}
-					</div>
-				) : (
-					<div className="use-case-search-empty" role="status">
-						<strong>No use cases match “{query}”.</strong>
-						<button
-							type="button"
-							className="secondary"
-							onClick={() => {
-								updateQuery("");
-								window.requestAnimationFrame(() => searchRef.current?.focus());
-							}}
-						>
-							Clear search
-						</button>
-					</div>
-				)}
-			</section>
+									</section>
+								);
+							})}
+						</div>
+					) : (
+						<div className="use-case-search-empty" role="status">
+							<strong>No use cases match “{query}”.</strong>
+							<button
+								type="button"
+								className="secondary"
+								onClick={() => {
+									updateQuery("");
+									window.requestAnimationFrame(() => searchRef.current?.focus());
+								}}
+							>
+								Clear search
+							</button>
+						</div>
+					)}
+				</section>
 
-			<ReviewDecisionPanel stageState={effectiveStageState} snapshot={snapshot} review={review} />
+				<ReviewDecisionPanel stageState={effectiveStageState} snapshot={snapshot} review={review} />
+			</div>
 
 			<details className="use-case-provenance">
 				<summary>Details</summary>

--- a/frontend/src/components/workspace/HomeWorkspaceSections.jsx
+++ b/frontend/src/components/workspace/HomeWorkspaceSections.jsx
@@ -3,6 +3,7 @@ import { Activity, ClipboardCheck, FileText, FolderKanban, PlayCircle } from "lu
 
 import { PROJECT_DESTINATIONS } from "../../app/workflowRoutes";
 import {
+	formatWorkItemCount,
 	formatWorkspaceDate,
 	formatWorkspaceLabel,
 	getProjectDestination,
@@ -37,7 +38,7 @@ export function ContinueWorkingSection({
 						</div>
 						<h3>{getWorkItemTitle(item)}</h3>
 						<p>{item.reason}</p>
-						{Number.isInteger(item.count) ? <span className="workspace-count">{item.count} items</span> : null}
+						{formatWorkItemCount(item) ? <span className="workspace-count">{formatWorkItemCount(item)}</span> : null}
 						<ProjectProgress completed={project?.completed_stage_count} total={project?.total_stage_count} />
 					</div>
 					<ProjectOpenLink
@@ -115,7 +116,7 @@ export function MyWorkSection({
 												</div>
 												<strong>{getWorkItemTitle(item)}</strong>
 												<p>{item.reason}</p>
-												{Number.isInteger(item.count) ? <span className="workspace-count">{item.count} items</span> : null}
+												{formatWorkItemCount(item) ? <span className="workspace-count">{formatWorkItemCount(item)}</span> : null}
 											</div>
 											<ProjectOpenLink projectId={item.project_id} destination={getWorkItemDestination(item)} onOpenProject={onOpenProject}>
 												Open

--- a/frontend/src/components/workspace/workspacePresentation.js
+++ b/frontend/src/components/workspace/workspacePresentation.js
@@ -111,3 +111,13 @@ export const matchesWorkspaceQuery = (query, ...values) => {
 export function getProjectPath(projectId, destination = PROJECT_DESTINATIONS.OVERVIEW) {
 	return buildProjectPath(projectId, destination);
 }
+
+export const formatWorkItemCount = (item) => {
+	if (item?.stage !== "use_cases") return Number.isInteger(item?.count) ? `${item.count} items` : "";
+	const parts = [];
+	if (Number.isInteger(item.count)) parts.push(`${item.count} scenario${item.count === 1 ? "" : "s"}`);
+	if (Number.isInteger(item.requirement_group_count)) {
+		parts.push(`${item.requirement_group_count} requirement group${item.requirement_group_count === 1 ? "" : "s"}`);
+	}
+	return parts.join(" · ");
+};

--- a/frontend/src/hooks/useUseCaseReview.js
+++ b/frontend/src/hooks/useUseCaseReview.js
@@ -38,7 +38,7 @@ export default function useUseCaseReview({
 	const projectScopeRef = useRef("");
 	const requestScopeRef = useRef("");
 	const scopeContextRef = useRef(null);
-	const [decision, setDecisionState] = useState("approve");
+	const [decision, setDecisionState] = useState("");
 	const [comment, setCommentState] = useState("");
 	const [outcome, setOutcome] = useState(initialOutcome);
 
@@ -70,7 +70,7 @@ export default function useUseCaseReview({
 		retryIdentityRef.current = null;
 
 		if (projectChanged) {
-			setDecisionState("approve");
+			setDecisionState("");
 			setCommentState("");
 			setOutcome(initialOutcome());
 			return;
@@ -120,7 +120,7 @@ export default function useUseCaseReview({
 	}, []);
 
 	const submit = useCallback(async () => {
-		if (submittingRef.current) {
+		if (submittingRef.current || !["approve", "request_changes"].includes(decision)) {
 			return null;
 		}
 		const normalizedComment = `${comment || ""}`.trim();

--- a/frontend/src/pages/UseCaseReviewPage.jsx
+++ b/frontend/src/pages/UseCaseReviewPage.jsx
@@ -1,3 +1,4 @@
+import ProjectPageHeader from "../components/layout/ProjectPageHeader";
 import RouteLink from "../app/RouteLink";
 import { PROJECT_DESTINATIONS, buildProjectPath } from "../app/workflowRoutes";
 import UseCaseReviewWorkbench from "../components/reviews/UseCaseReviewWorkbench";
@@ -45,23 +46,24 @@ export default function UseCaseReviewPage({ project, identity, request, navigate
 			aria-busy={review.isSubmitting || review.isReloading || undefined}
 			tabIndex={-1}
 		>
-			<header className="use-case-review-page-header">
-				<div>
-					<span className="use-case-page-kicker">{project?.name || "Project"}</span>
-					<h1 id="use-case-review-title">Use Cases</h1>
-					<p>Review the current scenario artifact and record a durable human decision.</p>
-				</div>
-				{snapshot ? (
-					<div className="use-case-page-status-actions">
-						<span className={`use-case-page-freshness ${reviewStatus.tone}`} role="status" aria-label="Current human review status">
-							{reviewStatus.label}
-						</span>
-						<a className="use-case-skip-review-link" href="#use-case-review-decision">
-							Skip to review decision
-						</a>
-					</div>
-				) : null}
-			</header>
+			<ProjectPageHeader
+				title="Use Cases"
+				titleId="use-case-review-title"
+				project={project}
+				navigate={navigate}
+				actions={
+					snapshot ? (
+						<div className="use-case-page-status-actions">
+							<span className={`use-case-page-freshness ${reviewStatus.tone}`} role="status" aria-label="Current human review status">
+								{reviewStatus.label}
+							</span>
+							<a className="use-case-skip-review-link" href="#use-case-review-decision">
+								Skip to review decision
+							</a>
+						</div>
+					) : null
+				}
+			/>
 
 			{snapshot ? (
 				<UseCaseReviewWorkbench project={project} snapshot={snapshot} stageState={stageState} review={review} />

--- a/frontend/src/styles/forms.css
+++ b/frontend/src/styles/forms.css
@@ -68,7 +68,7 @@ input::placeholder {
 
 /* Buttons */
 button {
-	background: linear-gradient(180deg, #3b82f6 0%, var(--primary) 55%, var(--primary-hover) 100%);
+	background: var(--primary);
 	color: white;
 	border: none;
 	padding: 0.8rem 1.4rem;
@@ -91,7 +91,7 @@ button {
 }
 
 button:hover:not(:disabled) {
-	background: linear-gradient(180deg, #2f76f2 0%, var(--primary-hover) 55%, var(--primary-strong) 100%);
+	background: var(--primary-hover);
 	box-shadow:
 		inset 0 1px 0 rgb(255 255 255 / 0.18),
 		0 2px 4px rgb(15 28 51 / 0.14),

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -19,3 +19,5 @@
 @import "./use-case-review.css";
 @import "./review-inbox.css";
 @import "./activity-index.css";
+
+@import "./project-design.css";

--- a/frontend/src/styles/project-design.css
+++ b/frontend/src/styles/project-design.css
@@ -1,0 +1,982 @@
+/* Shared project design, issue #239. Route content keeps its own workflow. */
+:root {
+	--bg-color: #fff;
+	--radius-md: 10px;
+	--radius-lg: 12px;
+}
+body {
+	background: #fff;
+	font-size: 15px;
+}
+.page {
+	padding: 0;
+}
+.global-app-shell {
+	gap: 0;
+}
+.global-app-shell-header {
+	border: 0;
+	border-bottom: 1px solid var(--border-color);
+	border-radius: 0;
+	padding: 12px 28px;
+	min-height: 76px;
+	background: #fff;
+	box-shadow: none;
+}
+.global-navigation-link {
+	font-size: 15px;
+	font-weight: 650;
+	border: 0;
+}
+.global-navigation-link.active {
+	background: var(--primary-tonal);
+}
+.command-project-trigger {
+	box-shadow: none;
+}
+.workflow-shell {
+	--workflow-nav-column: 260px;
+	gap: 0;
+	align-items: stretch;
+}
+.workflow-shell.nav-collapsed {
+	--workflow-nav-column: 72px;
+}
+.workflow-navigation-drawer {
+	border: 0;
+	border-right: 1px solid var(--border-color);
+	border-radius: 0;
+	box-shadow: none;
+	background: #f8fafd;
+	backdrop-filter: none;
+	padding: 20px 16px;
+	gap: 16px;
+	min-height: calc(100vh - 76px);
+	align-content: start;
+	top: 0;
+}
+.workflow-navigation-header {
+	display: flex;
+	justify-content: space-between;
+	padding: 0 10px;
+}
+.workflow-navigation-header > div {
+	display: block;
+}
+.workflow-navigation-header span {
+	font-size: 12px;
+	color: var(--text-muted);
+}
+.workflow-navigation-toggle {
+	border: 0;
+	box-shadow: none;
+	background: transparent;
+}
+.workflow-navigation-list {
+	gap: 12px;
+}
+.workflow-navigation-item {
+	display: grid;
+	grid-template-columns: 24px minmax(0, 1fr);
+	gap: 16px;
+	min-height: 68px;
+	padding: 12px;
+	border: 0;
+	border-radius: 10px;
+	box-shadow: none;
+	background: transparent;
+	color: var(--text-main);
+}
+.workflow-navigation-item.active {
+	background: var(--primary-tonal);
+	color: var(--primary);
+	box-shadow: none;
+	border: 0;
+}
+.workflow-navigation-item .workflow-navigation-marker,
+.workflow-navigation-item.active .workflow-navigation-marker {
+	width: 24px;
+	height: 24px;
+	padding: 0;
+	background: none;
+	color: inherit;
+	border: 0;
+	border-radius: 0;
+	box-shadow: none;
+}
+.workflow-navigation-marker svg {
+	width: 22px;
+	height: 22px;
+}
+.workflow-navigation-item:not(.active).complete .workflow-navigation-marker,
+.workflow-navigation-item:not(.active).attention .workflow-navigation-marker,
+.workflow-navigation-item:not(.active).blocked .workflow-navigation-marker {
+	color: var(--text-main);
+	background: none;
+}
+.workflow-navigation-copy {
+	gap: 4px;
+}
+.workflow-navigation-copy strong {
+	font-size: 15px;
+	font-weight: 650;
+	white-space: normal;
+	overflow: visible;
+}
+.workflow-navigation-copy .nav-workflow-status {
+	display: flex;
+	align-items: center;
+	gap: 7px;
+	font-size: 13px;
+	line-height: 1.4;
+	white-space: normal;
+	overflow: visible;
+	color: var(--text-muted);
+}
+.nav-workflow-status svg {
+	flex: 0 0 auto;
+}
+.nav-workflow-status.complete svg {
+	color: var(--success);
+}
+.nav-workflow-status.attention svg {
+	color: var(--warning);
+}
+.workflow-main,
+.use-case-review-page,
+.project-overview-page {
+	padding: 28px 36px 48px;
+	background: #fff;
+	border: 0;
+	border-radius: 0;
+	box-shadow: none;
+	min-width: 0;
+}
+.route-page {
+	box-shadow: none;
+	border: 0;
+	border-radius: 0;
+	align-content: start;
+}
+.project-overview-page,
+.use-case-review-page {
+	gap: 24px;
+}
+.project-page-header {
+	display: grid;
+	gap: 12px;
+	margin-bottom: 28px;
+	min-width: 0;
+}
+.project-breadcrumb {
+	display: flex;
+	gap: 14px;
+	font-size: 14px;
+	color: var(--text-muted);
+	margin-bottom: 8px;
+}
+.project-breadcrumb a {
+	text-decoration: none;
+	color: var(--primary);
+}
+.project-page-title-row {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 16px;
+}
+.project-page-header h1 {
+	margin: 0;
+	font-size: 36px;
+	line-height: 1.2;
+	letter-spacing: -0.025em;
+	color: var(--text-main);
+	overflow-wrap: anywhere;
+}
+.project-page-header p {
+	margin: 0;
+	color: var(--text-muted);
+	font-size: 16px;
+}
+.panel {
+	border: 0;
+	border-radius: 0;
+	background: #fff;
+	box-shadow: none;
+	padding: 0;
+}
+button,
+.route-primary-link {
+	border-radius: 8px;
+	box-shadow: none;
+	font-size: 14px;
+}
+button:hover:not(:disabled) {
+	transform: none;
+	box-shadow: none;
+}
+input,
+textarea,
+select {
+	border-radius: 8px;
+	font: inherit;
+}
+.overview-counts {
+	display: grid;
+	grid-template-columns: repeat(3, 1fr);
+	padding: 24px 0;
+	border-bottom: 1px solid var(--border-color);
+}
+.overview-counts > div {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 12px;
+	border-right: 1px solid var(--border-color);
+}
+.overview-counts > div:last-child {
+	border: 0;
+}
+.overview-counts strong {
+	font-size: 28px;
+	color: var(--primary);
+}
+.overview-attention h2 {
+	font-size: 23px;
+	margin: 12px 0 20px;
+}
+.overview-attention-row {
+	display: grid;
+	grid-template-columns: 24px minmax(160px, 0.8fr) minmax(0, 1.2fr) auto;
+	gap: 20px;
+	align-items: center;
+	padding: 22px 0;
+	border-bottom: 1px solid var(--border-color);
+}
+.overview-attention-row svg {
+	color: var(--warning);
+}
+.overview-attention-row p {
+	margin: 0;
+	color: var(--text-muted);
+}
+.overview-attention-row a {
+	color: var(--primary);
+	text-decoration: none;
+}
+.overview-workbenches {
+	margin-top: 20px;
+	color: var(--text-muted);
+}
+.project-overview-page .contextual-task-card {
+	padding: 28px;
+	background: var(--primary-tonal);
+	border: 0;
+	border-radius: 10px;
+	box-shadow: none;
+}
+.project-overview-page .contextual-task-card h2 {
+	font-size: 25px;
+}
+.project-overview-page .contextual-task-card p {
+	font-size: 15px;
+}
+.use-case-page-status-actions {
+	justify-content: flex-start;
+}
+.use-case-compact-summary {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 20px;
+	color: var(--text-muted);
+	padding-bottom: 18px;
+	border-bottom: 1px solid var(--border-color);
+}
+.use-case-supporting-details {
+	color: var(--text-muted);
+}
+.use-case-supporting-details > summary {
+	cursor: pointer;
+	padding: 8px 0;
+}
+.use-case-supporting-details[open] {
+	padding-bottom: 16px;
+}
+.artifact-review-columns {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) 320px;
+	gap: 28px;
+	align-items: start;
+}
+.use-case-review-workbench {
+	gap: 16px;
+}
+.use-case-collection,
+.use-case-decision-panel {
+	min-width: 0;
+}
+.use-case-collection-heading {
+	display: grid;
+	gap: 16px;
+}
+.use-case-collection-heading h2 {
+	font-size: 22px;
+}
+.use-case-collection-heading .use-case-section-kicker,
+.use-case-decision-heading .use-case-section-kicker {
+	display: none;
+}
+.use-case-collection-heading p {
+	font-size: 13px;
+}
+.use-case-search-field {
+	width: 100%;
+	min-width: 0;
+}
+.use-case-group,
+.use-case-scenario-card {
+	box-shadow: none;
+	border-radius: 10px;
+	background: #fff;
+}
+.use-case-group-heading h3 {
+	font-size: 16px;
+	line-height: 1.5;
+}
+.use-case-scenario-card {
+	border: 0;
+	border-bottom: 1px solid var(--border-color);
+	padding: 16px 0;
+	border-radius: 0;
+}
+.use-case-scenario-heading h4 {
+	font-size: 15px;
+}
+.use-case-scenario-badges {
+	font-size: 12px;
+}
+.use-case-decision-panel {
+	background: #f8fafd;
+	border: 1px solid var(--border-color);
+	padding: 24px;
+	border-radius: 10px;
+	box-shadow: none;
+}
+.use-case-decision-heading h2 {
+	font-size: 22px;
+}
+.use-case-decision-options {
+	display: grid;
+	grid-template-columns: 1fr;
+	padding: 0;
+	gap: 14px;
+	border: 0;
+}
+.use-case-decision-options label,
+.use-case-decision-options label.selected {
+	border: 0;
+	background: transparent;
+	padding: 4px 0;
+	box-shadow: none;
+}
+.use-case-decision-options small {
+	display: none;
+}
+.use-case-decision-actions {
+	display: grid;
+}
+.use-case-decision-actions button {
+	width: 100%;
+}
+.use-case-decision-actions p {
+	font-size: 13px;
+}
+.test-cases-section-tabs {
+	background: none;
+	border: 0;
+	padding: 0;
+	margin: -10px 0 20px;
+	box-shadow: none;
+}
+.test-cases-page .contextual-task-region {
+	margin-bottom: 16px;
+}
+.test-generation-panel.has-test-cases > .panel-title,
+.test-generation-panel.has-test-cases > .panel-description {
+	display: none;
+}
+.test-generation-panel.has-test-cases > .generation-gate-card.ready {
+	background: none;
+	border: 0;
+	padding: 0;
+	margin: 0 0 16px;
+}
+.test-generation-panel.has-test-cases > .generation-gate-card.ready strong {
+	font-weight: 500;
+	color: var(--text-muted);
+}
+.test-generation-panel.has-test-cases > .generation-gate-card.ready p {
+	font-size: 13px;
+}
+.test-quality-summary {
+	display: flex;
+	align-items: flex-start;
+	gap: 18px;
+	padding: 18px 22px;
+	border: 1px solid #f5d6a8;
+	background: #fffbf4;
+	border-radius: 10px;
+	margin: 20px 0;
+}
+.test-quality-summary > svg {
+	color: #b86b00;
+	flex-shrink: 0;
+	margin-top: 3px;
+}
+.test-quality-summary.approved {
+	background: var(--success-tonal);
+	border-color: #b6dfd1;
+}
+.test-quality-summary.approved > svg {
+	color: var(--success);
+}
+.test-quality-summary strong {
+	font-size: 18px;
+}
+.test-quality-summary p {
+	margin: 4px 0;
+	color: var(--text-muted);
+}
+.test-quality-findings summary {
+	cursor: pointer;
+	color: var(--primary);
+	margin-top: 8px;
+}
+.test-quality-findings li,
+.test-inline-findings li {
+	overflow-wrap: anywhere;
+}
+.generate-results-workspace {
+	border: 0;
+	border-radius: 0;
+	background: #fff;
+	box-shadow: none;
+}
+.generate-results-header {
+	padding: 0 0 12px;
+	border: 0;
+	background: #fff;
+}
+.generate-results-header h3,
+.generate-results-header p {
+	display: none;
+}
+.generate-results-summary-pill {
+	background: transparent;
+	border: 0;
+	padding: 0;
+	color: var(--text-muted);
+	font-size: 14px;
+}
+.generate-results-tabs {
+	padding: 0;
+	gap: 4px;
+	border-bottom: 1px solid var(--border-color);
+	background: transparent;
+}
+.generate-result-tab {
+	background: transparent;
+	border: 0;
+	border-radius: 0;
+	box-shadow: none;
+	color: var(--text-muted);
+	padding: 14px 12px;
+	font-size: 14px;
+}
+.generate-result-tab.active {
+	color: var(--primary);
+	background: transparent;
+	border-bottom: 3px solid var(--primary);
+	box-shadow: none;
+}
+.generate-result-panel {
+	padding: 22px 0;
+}
+.test-review-workspace {
+	display: grid;
+	grid-template-columns: minmax(240px, 0.85fr) minmax(0, 1.35fr);
+	gap: 28px;
+}
+.test-review-list {
+	min-width: 0;
+	border-right: 1px solid var(--border-color);
+	padding-right: 20px;
+}
+.test-review-list h2 {
+	font-size: 18px;
+	margin: 0 0 12px;
+}
+.test-review-list input {
+	box-sizing: border-box;
+	width: 100%;
+}
+.test-list-count {
+	color: var(--text-muted);
+	font-size: 12px;
+	margin: 8px 0;
+}
+.test-review-items {
+	max-height: 70vh;
+	overflow-y: auto;
+}
+.test-review-item {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	width: 100%;
+	padding: 16px;
+	gap: 12px;
+	text-align: left;
+	border: 0;
+	border-bottom: 1px solid var(--border-color);
+	border-radius: 0;
+	color: var(--text-main);
+	background: transparent;
+}
+.test-review-item.selected {
+	border-radius: 8px;
+	background: var(--primary-tonal);
+}
+.test-review-item:hover:not(:disabled) {
+	background: var(--primary-tonal);
+}
+.test-review-item > span {
+	display: grid;
+	gap: 6px;
+	min-width: 0;
+}
+.test-review-item small,
+.test-review-item span span {
+	font-size: 13px;
+	font-weight: 400;
+	color: var(--text-muted);
+}
+.test-review-item strong {
+	font-size: 15px;
+	line-height: 1.45;
+	overflow-wrap: anywhere;
+}
+.test-review-item svg {
+	flex-shrink: 0;
+	color: var(--text-muted);
+}
+.test-review-detail {
+	min-width: 0;
+	overflow-wrap: anywhere;
+}
+.test-review-detail h2 {
+	margin: 8px 0;
+	font-size: 23px;
+	line-height: 1.3;
+}
+.test-review-detail h3 {
+	margin: 22px 0 8px;
+	font-size: 16px;
+}
+.test-review-detail p {
+	margin: 6px 0 14px;
+	color: var(--text-muted);
+}
+.test-review-detail .test-detail-meta {
+	font-size: 13px;
+	margin: 4px 0;
+}
+.test-inline-findings {
+	margin: 18px 0;
+	background: #fffbf4;
+	border: 1px solid #f5d6a8;
+	border-radius: 8px;
+	padding: 10px 14px;
+}
+.test-inline-findings summary {
+	cursor: pointer;
+}
+.test-steps-heading {
+	display: flex;
+	align-items: baseline;
+	justify-content: space-between;
+	border-top: 1px solid var(--border-color);
+}
+.test-steps-heading > span {
+	color: var(--text-muted);
+	font-size: 13px;
+}
+.test-detail-steps {
+	padding-left: 22px;
+}
+.test-detail-steps li {
+	border-bottom: 1px solid var(--border-color);
+	padding: 12px 0 12px 8px;
+}
+.test-detail-steps p:first-child {
+	color: var(--text-main);
+}
+.test-detail-steps strong {
+	font-size: 13px;
+	margin-right: 10px;
+	font-weight: 500;
+}
+.test-case-metadata {
+	border-top: 1px solid var(--border-color);
+	padding: 20px 0;
+	margin-top: 24px;
+}
+.test-case-metadata summary {
+	cursor: pointer;
+}
+.test-case-metadata dl > div {
+	display: grid;
+	grid-template-columns: 140px minmax(0, 1fr);
+	gap: 16px;
+	padding: 8px 0;
+}
+.test-case-metadata dd {
+	margin: 0;
+	color: var(--text-muted);
+}
+@media (max-width: 1200px) {
+	.artifact-review-columns {
+		grid-template-columns: minmax(0, 1fr);
+	}
+	.use-case-decision-panel {
+		max-width: none;
+	}
+	.overview-attention-row {
+		grid-template-columns: 24px minmax(0, 1fr);
+	}
+	.overview-attention-row p,
+	.overview-attention-row a {
+		grid-column: 2;
+	}
+	.global-app-shell-header {
+		padding: 12px 16px;
+	}
+}
+@media (max-width: 900px) {
+	.workflow-shell,
+	.workflow-shell.nav-collapsed {
+		grid-template-columns: minmax(0, 1fr);
+	}
+	.workflow-navigation-drawer,
+	.workflow-navigation-drawer.compact.collapsed {
+		min-height: 0;
+		border-right: 0;
+		border-bottom: 1px solid var(--border-color);
+		padding: 12px 16px;
+	}
+	.workflow-navigation-list {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+	.workflow-main,
+	.use-case-review-page,
+	.project-overview-page {
+		padding: 24px;
+	}
+	.test-review-workspace {
+		grid-template-columns: minmax(0, 1fr);
+	}
+	.test-review-list {
+		border-right: 0;
+		border-bottom: 1px solid var(--border-color);
+		padding: 0 0 20px;
+	}
+	.test-review-items {
+		max-height: 280px;
+	}
+	.global-app-shell-header {
+		flex-wrap: wrap;
+	}
+	.project-page-header h1 {
+		font-size: 30px;
+	}
+}
+@media (max-width: 480px) {
+	.workflow-main,
+	.use-case-review-page,
+	.project-overview-page {
+		padding: 20px 16px;
+	}
+	.overview-counts > div {
+		flex-direction: column;
+		gap: 4px;
+		font-size: 12px;
+	}
+	.workflow-navigation-list {
+		grid-template-columns: 1fr;
+	}
+	.test-quality-summary {
+		padding: 14px;
+	}
+	.global-navigation-list {
+		gap: 0;
+	}
+	.global-navigation-link {
+		padding: 8px;
+		font-size: 13px;
+	}
+	.test-case-metadata dl > div {
+		grid-template-columns: 1fr;
+		gap: 4px;
+	}
+}
+.workflow-navigation-item.active .workflow-navigation-copy .nav-workflow-status {
+	color: var(--text-muted);
+}
+.tab-content {
+	background: transparent;
+	border: 0;
+	border-radius: 0;
+	box-shadow: none;
+	padding: 0;
+}
+.optional-workflow-actions {
+	margin: 0 0 16px;
+	color: var(--text-muted);
+	font-size: 14px;
+}
+.optional-workflow-actions > summary {
+	cursor: pointer;
+}
+.optional-workflow-actions[open] > .contextual-task-region {
+	margin-top: 12px;
+}
+.test-cases-page .project-page-header {
+	margin-bottom: 20px;
+}
+.test-cases-page .optional-workflow-actions {
+	float: right;
+	margin: 0 0 8px 16px;
+}
+.test-suite-summary {
+	color: var(--text-muted);
+	margin: 0 0 16px;
+}
+.generate-results-header {
+	display: none;
+}
+.test-quality-summary {
+	clear: both;
+}
+.workflow-shell {
+	--workflow-nav-column: 276px;
+}
+@media (max-width: 600px) {
+	.project-page-title-row {
+		flex-wrap: wrap;
+	}
+	.test-cases-page .optional-workflow-actions {
+		float: none;
+		margin: 0 0 12px;
+	}
+}
+.test-quality-summary {
+	position: relative;
+	padding-right: 190px;
+	min-height: 76px;
+	box-sizing: border-box;
+}
+.test-quality-findings > summary {
+	position: absolute;
+	top: 20px;
+	right: 22px;
+	margin: 0;
+	padding: 10px 18px;
+	background: var(--primary);
+	border-radius: 8px;
+	color: white;
+	font-weight: 600;
+	list-style: none;
+}
+.test-quality-findings > summary::-webkit-details-marker {
+	display: none;
+}
+.test-quality-findings[open] {
+	margin-top: 20px;
+}
+@media (max-width: 600px) {
+	.test-quality-summary {
+		padding-right: 14px;
+	}
+	.test-quality-findings > summary {
+		position: static;
+		margin-top: 12px;
+	}
+}
+/* Cancel the former workbench's container-column rules: the inner review grid owns columns. */
+.use-case-review-page .use-case-review-workbench {
+	grid-template-columns: minmax(0, 1fr);
+}
+.artifact-review-columns {
+	grid-column: 1 / -1;
+}
+.artifact-review-columns .use-case-collection {
+	grid-column: 1;
+	border: 0;
+	padding: 0;
+	background: transparent;
+}
+.artifact-review-columns .use-case-decision-panel {
+	grid-column: 2;
+}
+.use-case-collection-heading {
+	grid-template-columns: minmax(0, 1fr);
+}
+.use-case-review-page .project-page-header {
+	margin-bottom: 0;
+}
+.project-overview-page > .contextual-task-region {
+	width: 100%;
+}
+.project-overview-page .contextual-task-card {
+	min-height: 160px;
+	box-sizing: border-box;
+}
+.workflow-navigation-item.active .workflow-navigation-copy strong {
+	color: var(--primary);
+}
+.workflow-navigation-item:not(.active) {
+	background: transparent;
+}
+@media (max-width: 1200px) {
+	.artifact-review-columns .use-case-decision-panel {
+		grid-column: 1;
+		position: static;
+	}
+}
+@media (min-width: 1201px) {
+	.command-project-control {
+		width: 300px;
+		flex-basis: 300px;
+	}
+}
+@media (min-width: 901px) and (max-width: 1100px) {
+	.global-app-shell-header {
+		gap: 8px;
+		padding: 12px;
+	}
+	.global-navigation-link {
+		font-size: 14px;
+		padding: 8px 10px;
+	}
+	.command-project-control {
+		width: 180px;
+		flex-basis: 180px;
+	}
+}
+.artifact-review-columns .use-case-decision-panel {
+	position: static;
+}
+.scenario-details > summary {
+	cursor: pointer;
+	font-size: 15px;
+	display: flex;
+	align-items: baseline;
+	gap: 12px;
+}
+.scenario-summary-copy {
+	display: grid;
+	grid-template-columns: minmax(80px, auto) minmax(0, 1fr);
+	gap: 16px;
+	align-items: baseline;
+}
+.scenario-summary-copy .use-case-scenario-type {
+	font-size: 12px;
+	text-transform: none;
+	letter-spacing: 0;
+	font-weight: 500;
+	color: var(--text-muted);
+}
+.scenario-summary-copy strong {
+	font-size: 15px;
+	line-height: 1.5;
+	font-weight: 550;
+}
+.scenario-expanded-content {
+	padding: 12px 0;
+	color: var(--text-muted);
+}
+.scenario-expanded-content > span {
+	font-size: 13px;
+}
+@media (max-width: 600px) {
+	.scenario-summary-copy {
+		grid-template-columns: 1fr;
+		gap: 4px;
+	}
+}
+.workflow-navigation-copy strong,
+.workflow-navigation-copy .nav-workflow-status {
+	overflow-wrap: anywhere;
+}
+.use-case-meta-row {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: baseline;
+	gap: 12px 24px;
+	padding-bottom: 12px;
+	border-bottom: 1px solid var(--border-color);
+}
+.use-case-compact-summary {
+	flex: 1 1 auto;
+	padding: 0;
+	border: 0;
+}
+.use-case-supporting-details {
+	flex: 0 1 auto;
+}
+.use-case-supporting-details[open] {
+	flex-basis: 100%;
+}
+.use-case-collection-heading {
+	grid-template-columns: minmax(0, 1fr) minmax(180px, 240px);
+	align-items: end;
+}
+.use-case-group-toggle-all {
+	border: 0;
+	background: transparent;
+	padding: 6px 0;
+	box-shadow: none;
+}
+.project-page-title-row .use-case-page-status-actions {
+	justify-content: flex-end;
+}
+.use-case-page-freshness.pending {
+	background: var(--warning-tonal);
+	color: #8b5500;
+}
+@media (max-width: 1200px) {
+	.project-page-title-row .use-case-page-status-actions {
+		flex-wrap: wrap;
+	}
+}
+@media (max-width: 600px) {
+	.use-case-collection-heading {
+		grid-template-columns: minmax(0, 1fr);
+	}
+	.project-page-title-row .use-case-page-status-actions {
+		justify-content: flex-start;
+	}
+}
+
+.use-case-meta-row > * {
+	min-width: 0;
+	max-width: 100%;
+	overflow-wrap: anywhere;
+}
+@media (max-width: 600px) {
+	.project-page-title-row .use-case-page-status-actions {
+		flex: 1 1 100%;
+		min-width: 0;
+		max-width: 100%;
+	}
+}


### PR DESCRIPTION
## Change

Closes #239. Project screens used inconsistent headers and large stacked panels, making artifact review harder to scan. Overview now prioritizes the next action, counts and blockers; Use Cases groups scenarios beside an explicit decision form; Test Cases provides a searchable selectable list with complete case details and compact quality findings.

The shared header, navigation, typography and spacing extend across project destinations. Route selection stays separate from workflow status. Existing review persistence, stale-version protection, generation, export gates and template formats are preserved. Review decisions now require an explicit choice.

## Validation

- Frontend lint, formatting and production build passed.
- Full required frontend browser suite: **143 passed**, including accessibility, mobile reflow, export overrides, generation preservation, retries, persisted review decisions and double-submit protection.
- Live desktop/mobile comparison against all three selected designs passed; see `design-qa.md` and `docs/project-design.md`.
- Existing build warning: 578.06 kB JavaScript chunk. Backend code is unchanged.

## Dependency

Stacked on #238 (`codex/issue-237-scenario-counts`) to preserve the preceding scenario-count correction. Retarget to main after #238 merges. Screenshots remain local and are not committed. No live reviews or exports were submitted during UI verification.
