### PR TITLE
Adopt shared controls across product surfaces (#245)

### DIFF
--- a/backend/app/contracts/workspace.py
+++ b/backend/app/contracts/workspace.py
@@ -40,6 +40,7 @@ class WorkspaceWorkItem(BaseModel):
     enabled: bool = False
     primary: bool = False
     count: Optional[int] = Field(default=None, ge=0)
+    requirement_group_count: Optional[int] = Field(default=None, ge=0)
     reason: str
     current_snapshot_id: Optional[str] = None
     updated_at: datetime

--- a/backend/app/services/workflow_project_service.py
+++ b/backend/app/services/workflow_project_service.py
@@ -227,8 +227,11 @@ def list_projects(*, actor: AuthUser, include_archived: bool = False) -> list[Qa
     return projects
 
 
-def _workspace_snapshot_for(project_id: str, snapshot_id: str) -> Optional[QaProjectStageSnapshot]:
-    payload = _document_to_dict(_get_project_doc(project_id).collection("snapshots").document(snapshot_id).get(field_paths=WORKSPACE_SNAPSHOT_FIELDS))
+def _workspace_snapshot_for(project_id: str, snapshot_id: str, stage: ProjectStageName) -> Optional[QaProjectStageSnapshot]:
+    # Coverage plans are arrays, so Firestore cannot project just nested scenario IDs.
+    # Read the current use-case plan to count legacy artifacts without rewriting them.
+    fields = WORKSPACE_SNAPSHOT_FIELDS + (("payload.coverage_plan",) if stage == "use_cases" else ())
+    payload = _document_to_dict(_get_project_doc(project_id).collection("snapshots").document(snapshot_id).get(field_paths=fields))
     if not payload:
         return None
     snapshot = QaProjectStageSnapshot.model_validate(payload)
@@ -331,7 +334,7 @@ def list_workspace_projects(
         for stage, state in summary.stage_state.items():
             if not state.current_snapshot_id:
                 continue
-            current_snapshot = _workspace_snapshot_for(summary.project_id, state.current_snapshot_id)
+            current_snapshot = _workspace_snapshot_for(summary.project_id, state.current_snapshot_id, stage)
             if current_snapshot is not None and current_snapshot.stage == stage:
                 current_snapshots[stage] = current_snapshot
 

--- a/backend/app/services/workspace_summary_service.py
+++ b/backend/app/services/workspace_summary_service.py
@@ -78,6 +78,8 @@ def _work_item_count(
     snapshot_count = _snapshot_count(snapshot, stage_state.stage)
     if snapshot_count is not None:
         return snapshot_count
+    if stage_state.stage == "use_cases":
+        return None
     return _first_count(
         dict(stage_state.summary or {}),
         (
@@ -91,6 +93,14 @@ def _work_item_count(
             "evidence_count",
         ),
     )
+
+
+def _requirement_group_count(project: QaProjectDetail, stage: OrchestratorStageName) -> Optional[int]:
+    if stage != "use_cases":
+        return None
+    snapshot = project.current_snapshots.get(stage)
+    plan = snapshot.payload.get("coverage_plan") if snapshot else None
+    return len(plan) if isinstance(plan, list) else None
 
 
 def _work_item_kind(action: OrchestratorActionRecommendation) -> str:
@@ -124,6 +134,7 @@ def _work_item_for(
         enabled=action.enabled,
         primary=action.primary,
         count=_work_item_count(project, stage_state),
+        requirement_group_count=_requirement_group_count(project, stage_state.stage),
         reason=reason,
         current_snapshot_id=snapshot_id,
         updated_at=updated_at,
@@ -150,6 +161,7 @@ def _informational_work_item_for(
         enabled=False,
         primary=False,
         count=_work_item_count(project, stage_state),
+        requirement_group_count=_requirement_group_count(project, stage_state.stage),
         reason=reason,
         current_snapshot_id=stage_state.current_snapshot_id,
         updated_at=stage_state.updated_at or project.updated_at,

--- a/backend/tests/test_workspace_summary_service.py
+++ b/backend/tests/test_workspace_summary_service.py
@@ -137,8 +137,23 @@ class FakeDocument:
         self.query_log = query_log
 
     def get(self, field_paths: Optional[tuple[str, ...]] = None) -> FakeSnapshot:
-        del field_paths
-        return FakeSnapshot(self.store.get(self.path), self.path.rsplit("/", 1)[-1])
+        payload = self.store.get(self.path)
+        if payload is not None and field_paths is not None:
+            projected = {}
+            for field in field_paths:
+                parts = field.split(".")
+                source = payload
+                for part in parts:
+                    if not isinstance(source, dict) or part not in source:
+                        break
+                    source = source[part]
+                else:
+                    target = projected
+                    for part in parts[:-1]:
+                        target = target.setdefault(part, {})
+                    target[parts[-1]] = source
+            payload = projected
+        return FakeSnapshot(payload, self.path.rsplit("/", 1)[-1])
 
     def collection(self, name: str) -> "FakeCollection":
         return FakeCollection(f"{self.path}/{name}", self.store, self.query_log)
@@ -288,6 +303,55 @@ class WorkspaceSummaryServiceTests(unittest.TestCase):
         self.assertIn("approved", review_item.reason.lower())
         self.assertEqual(result.projects[0].current_stage, "use_cases")
         self.assertEqual(result.projects[0].current_status, "attention_required")
+
+    def test_persisted_use_case_counts_follow_current_snapshot_and_refresh(self) -> None:
+        plan = [{"requirement_id": f"REQ-{i}", "scenarios": [{"id": f"SCN-{i}-{j}"} for j in range(4 if i < 4 else 3)]} for i in range(8)]
+        actor = AuthUser(sub="user-1", email="user@example.com", name="User")
+        snapshot = _snapshot(
+            project_id="counts",
+            stage="use_cases",
+            snapshot_id="use-cases-1",
+            created_at=BASE_TIME,
+            payload={"coverage_plan": plan, "private_unneeded_payload": "not projected"},
+            metadata={"coverage_plan_count": 8},
+        )
+        project = _project(
+            "counts",
+            stage_state={
+                "requirements": _stage_state("requirements-1", updated_at=BASE_TIME, approved=True),
+                "use_cases": _stage_state(snapshot.snapshot_id, updated_at=BASE_TIME, metadata={"coverage_plan_count": 8}),
+            },
+        )
+        project_data = project.model_dump(exclude={"current_snapshots", "timeline", "execution_runs"})
+        store = {
+            "qa_projects/counts": project_data,
+            "qa_projects/counts/snapshots/use-cases-1": snapshot.model_dump(),
+        }
+        collection = FakeCollection("qa_projects", store, [])
+        with patch("app.services.workflow_project_service.get_required_firestore_collection", return_value=collection):
+            for version, payload, expected_count, expected_groups in [
+                (1, {"coverage_plan": plan}, 28, 8),
+                (2, {"coverage_plan": [{"scenarios": [{"id": "new"}]}]}, 1, 1),
+                (3, {"coverage_plan": []}, 0, 0),
+                (4, {}, None, None),
+            ]:
+                with self.subTest(version=version):
+                    snapshot_id = f"use-cases-{version}"
+                    store[f"qa_projects/counts/snapshots/{snapshot_id}"] = {
+                        **snapshot.model_dump(),
+                        "snapshot_id": snapshot_id,
+                        "payload": {**payload, "private_unneeded_payload": "not projected"},
+                    }
+                    project_data["stage_state"]["use_cases"]["current_snapshot_id"] = snapshot_id
+                    projects = list_workspace_projects(actor=actor, include_archived=False, project_limit=20, execution_run_limit=20)
+                    result = build_workspace_summary(projects, work_items_limit=50, runs_limit=20, reports_limit=20)
+                    item = next(item for item in result.work_items if item.stage == "use_cases")
+                    self.assertEqual(item.current_snapshot_id, snapshot_id)
+                    self.assertEqual(item.count, expected_count)
+                    self.assertEqual(item.requirement_group_count, expected_groups)
+                    self.assertEqual(result.continue_working.count, expected_count)
+                    self.assertNotIn("coverage_plan", item.model_dump())
+                    self.assertNotIn("private_unneeded_payload", projects[0].current_snapshots["use_cases"].payload)
 
     def test_work_items_are_deduplicated_ranked_and_used_for_continue_working(self) -> None:
         enabled_project = _project("project-a", updated_at=BASE_TIME)

--- a/design-qa.md
+++ b/design-qa.md
@@ -1,72 +1,65 @@
-# Collapsed Workflow Rail Design QA
+# Design QA — issue #239
 
-- Source visual truth: `/Users/m1/Documents/Screenshot 2026-09-02 at 23.58.34.png`
-- Implementation screenshot: `/tmp/issue-229-collapsed-after.png`
-- Combined comparison: `/tmp/issue-229-design-qa-comparison.png`
-- Browser and state: Codex in-app browser, authenticated local E2E account, project overview, desktop rail collapsed
-- CSS viewport: 1440 × 900 at `deviceScaleFactor: 1`
-- Source pixels: 234 × 1594 at approximately 2× density
-- Implementation pixels: 1440 × 900 at 1× density
-- Density normalization: source downsampled to 117 × 797; implementation cropped to the same 117 × 797 CSS-pixel rail region before horizontal comparison
-
-## Full-view comparison evidence
-
-The browser-rendered desktop view shows the global app bar, collapsed workflow
-rail, project heading, contextual task, and workbench cards together. The rail
-contains one primary icon for each of the seven destinations, its active state
-remains clear, the workspace gains vertical breathing room, and no content is
-hidden by the change.
-
-## Focused comparison evidence
-
-The normalized side-by-side rail comparison was required because the source is
-a narrow 2× crop rather than a full viewport. The source shows a second circular
-status icon below every stage icon. The implementation removes those repeated
-tokens and preserves a single centered stage icon per destination. The active
-Overview tile shrinks to the same one-icon rhythm instead of grouping two
-control-like shapes.
-
-## Required fidelity surfaces
-
-- Fonts and typography: no typography changed; expanded labels and status copy retain the existing family, weights, line heights, truncation, and hierarchy.
-- Spacing and layout rhythm: the collapsed rail keeps its 72-pixel column and existing padding, while each destination now occupies one compact icon row. The intentional reduction in rail height is the selected design change.
-- Colors and visual tokens: existing active blue, success green, warning amber, pending neutral, borders, radii, and shadows remain mapped to the primary stage markers.
-- Image quality and asset fidelity: the reference contains only standard UI icons. The implementation keeps the existing Lucide icon set and does not introduce raster, placeholder, custom SVG, or CSS-drawn assets.
-- Copy and content: no user-facing destination or status copy was removed. Collapsed accessible names and native hover text still expose values such as “Requirements — Complete.”
+final result: passed
 
 ## Findings
 
-No actionable P0, P1, or P2 mismatch remains. The visible difference from the
-source—the removal of every circled status token—is the requested design change.
+No remaining actionable P0/P1/P2 visual findings in the selected project screens. This implements the selected design direction using the existing product typography and real artifact content; it is not a literal copy of illustrative mock text.
+
+## Visual truth and captures
+
+Reference directory: `/Users/m1/.codex/generated_images/01a08b92-58ae-7fd2-94e0-74fc99835662/`.
+
+- Overview: `exec-2f4f6154-22f4-4acb-9041-0be6ddbf0d5e.png`, 1487 × 1058 pixels.
+- Use Cases: `exec-750c4586-cb4c-4cd8-a6fb-55f453771438.png`, 1489 × 1056 pixels.
+- Test Cases: `exec-cf5f5851-48a8-412d-a04c-39614b53259d.png`, 1489 × 1056 pixels.
+
+Implementation directory: `/Users/m1/.codex/visualizations/2026/09/10/01a08b92-58ae-7fd2-94e0-74fc99835662/overview-design/`.
+
+- `implemented-overview-final.png`: Overview, next action and attention rows.
+- `implemented-use-cases-final.png`: first requirement expanded, no review decision selected.
+- `implemented-test-cases-final.png`: generated cases tab, TC-001 selected, two steps visible.
+- `use-cases-mobile.png` and `test-cases-mobile.png`: narrow layout evidence.
+
+Desktop CSS viewport was 1488 × 1056, devicePixelRatio 1. Browser screenshot output is a JPEG encoded at 1477 × 1048 despite its .png filename. Reference and capture were compared at equivalent display size; the approximately 0.7% capture scaling was treated as transport scaling, not a typography or spacing defect. Mobile CSS viewport was 390 × 844; expanded Use Cases details were also checked at 320 × 900. Screenshots are local review artifacts and are not committed.
+
+## Comparison evidence and fidelity surfaces
+
+The reference and final capture for each screen were opened together in the same visual comparison input. Full views show the shared 76px header, approximately 276px sidebar, aligned content start, flat white surface, blue route selection, and restrained semantic states. Text and controls were readable in the combined full-size comparisons; additional crops were unnecessary. Live DOM checks supplemented visual review for font metrics, full field content and narrow-width containment.
+
+- **Typography:** retained Inter/system fallback and the shared production scale (36px desktop page headings, 30px narrow headings). The illustrative images use larger display text. This is an intentional consistency choice based on the shared design direction, rather than changing fonts independently per page. Long real requirement and case titles wrap instead of becoming shortened mock labels.
+- **Spacing/layout:** Overview has one next action, a slim count strip and attention rows. Use Cases has grouped scenarios and a decision panel. Test Cases has a list and detail workspace below a compact quality strip. Columns stack on smaller widths. Search and preserved metadata disclosures add useful product controls beyond the simplified references.
+- **Colors/tokens:** existing blue primary, pale selected surface, neutral borders and muted text are reused. Primary button gradients were removed. Approval, refinement and blocked states retain explicit words and icons; selected navigation no longer masks workflow status.
+- **Assets:** standard Lucide icons fit the selected outline icon family. No custom imagery, raster artwork, synthetic logos or placeholder assets were needed. The existing account image is preserved.
+- **Copy/content:** actual 8 requirements, 28 scenarios and 25 cases are retained. The server-provided next task remains “Approve Use Cases” with “Open workbench”; it opens the review workbench and does not approve automatically. Quality score 65/100, threshold 90 and blocked export remain truthful. Full findings, expected results, test data and metadata are available through disclosures.
 
 ## Comparison history
 
-1. First post-change capture showed seven centered workflow icons, zero
-   collapsed status tokens, and no overflow. The normalized focused comparison
-   confirmed that the duplicate icon row was removed without altering the rail's
-   visual language, so no corrective visual iteration was required.
+1. P2: initial Test Cases layout repeated generation/readiness panels above the selected artifact. Reduced duplicate headings, condensed quality findings and placed optional actions in More actions. Evidence: `implemented-test-cases-v1.png`, `implemented-test-cases-v2.png`, then final capture.
+2. P2: Use Cases inherited an enclosing grid that squeezed both review columns. Removed the conflicting composition, aligned the columns and compacted summary/history. Evidence: `implemented-use-cases-v1.png`, `implemented-use-cases-v2.png`, then final capture.
+3. P2: active sidebar status contrast and collapsed badges conflicted with the reference. Separated route selection from workflow status, hid status text in icon-only mode and allowed long labels to wrap. Confirmed final captures and responsive tests.
+4. P2: Overview next task was constrained to a narrow card. Expanded it across the content column and aligned counts and attention rows. Evidence: `implemented-overview-v1.png`, then final capture.
+5. P2: narrow Use Cases status actions and expanded metadata could overflow. Added wrapping, zero intrinsic minimum widths and bounded flex children. Confirmed live 320px expanded details and automated 320–1920px reflow checks.
+6. Capture correction: rapid hard navigation produced transient Failed to fetch recovery screens during live capture. Backend health and CORS responded successfully; normal Projects → Open navigation loaded the real project. Replaced recovery/scroll-offset captures with loaded, top-of-page captures. Prior console fetch errors remain in browser history; no claim is made that the full historical console is empty.
 
-## Interaction and responsive evidence
+## Validation
 
-- Collapsed desktop: seven destinations, one visible SVG per destination, zero status tokens.
-- Expanded desktop: seven status tokens restored and visible.
-- Compact boundary at 900 pixels: navigation begins closed, opens from its named button, restores seven visible status tokens, and has no horizontal overflow.
-- Accessible names retain destination plus status, and collapsed items expose matching hover text.
-- Selecting the collapsed Requirements icon navigates to its canonical workbench and preserves the one-icon collapsed state; returning to Overview does the same.
-- Browser console showed no runtime errors after authenticated navigation and interaction. The expected local warning about incomplete Firebase web configuration remains and does not affect the stored E2E session or this workflow.
+- `npm run lint`: passed.
+- `npm run format:check`: passed.
+- `npm run build`: passed; existing bundle-size warning remains (578.06 kB JavaScript chunk).
+- `npm run test:e2e:home-first -- --workers=4 --retries=0 --timeout=45000`: **143 passed**. Covers focused design interactions, navigation, mobile reflow, WCAG serious/critical checks, export override gates, generation preservation, persisted decisions, stale responses, retries and double submission.
+- `git diff --check`: passed.
+- Live manual checks: project navigation, first requirement expansion, supporting-history disclosure, narrow overflow, case search, selection fallback, all steps and metadata. No live approval, generation or export was submitted.
+
+## Open questions and follow-up polish
+
+No blocking questions. P3: mobile result tabs retain the existing stacked layout; a future dedicated mobile interaction pass could compare a horizontal tab strip. Existing bundle splitting remains separate from this design issue.
 
 ## Implementation checklist
 
-- [x] One visible icon per collapsed workflow destination
-- [x] No separate collapsed status token
-- [x] Expanded desktop status tokens preserved
-- [x] Opened compact navigation status tokens preserved
-- [x] Accessible destination and status names preserved
-- [x] Hover status text preserved
-- [x] Desktop and compact overflow checks passed
-
-## Follow-up polish
-
-No P3 follow-up is required for this scope.
-
-final result: passed
+- [x] Reuse the shared shell and page header.
+- [x] Implement the three selected layouts with real content.
+- [x] Preserve review/export gates and complete artifact details.
+- [x] Verify responsive, keyboard and core workflow behavior.
+- [x] Compare final browser captures against all selected references.
+- [x] Keep the local Test Cases preview open.

--- a/docs/codebase/CONVENTIONS.md
+++ b/docs/codebase/CONVENTIONS.md
@@ -233,3 +233,13 @@ work.
 - `frontend/eslint.config.js`
 - `frontend/.prettierrc.json`
 - `frontend/package.json`
+
+### Workspace use-case counts (#237)
+
+For `use_cases` work items, `count` is the total number of nested scenarios in
+`coverage_plan`; `requirement_group_count` is the number of groups in that plan.
+Home and Reviews show both units. Empty plans yield zero; unavailable plans yield
+null counts rather than falling back to `coverage_plan_count` (a group count).
+Workspace reads project the current use-case coverage plan internally so existing
+snapshots need no migration or regeneration. Raw plans are not returned in the
+workspace summary API. Other stages keep their existing count semantics.

--- a/docs/github-issues-backlog.md
+++ b/docs/github-issues-backlog.md
@@ -2,6 +2,10 @@
 
 This file contains issue-ready drafts for the implementation plan in `docs/implementation-plan.md`.
 
+## UI/UX audit follow-up
+
+- In progress: [#237](https://github.com/lumensparkxy/agentic_test_case_generator/issues/237) — Correct use-case scenario counts in workspace summaries. Count nested scenarios separately from requirement groups and keep Home, Reviews, and the current artifact consistent.
+
 ## Created GitHub issues
 
 The original Phase 0 through Phase 2 issues in this section are historical

--- a/docs/github-issues-backlog.md
+++ b/docs/github-issues-backlog.md
@@ -4,6 +4,8 @@ This file contains issue-ready drafts for the implementation plan in `docs/imple
 
 ## UI/UX audit follow-up
 
+- In progress: [#239](https://github.com/lumensparkxy/agentic_test_case_generator/issues/239) — Implement the selected shared design across Overview, Use Cases and Test Cases, preserving review gates and responsive access. Builds on #237.
+
 - In progress: [#237](https://github.com/lumensparkxy/agentic_test_case_generator/issues/237) — Correct use-case scenario counts in workspace summaries. Count nested scenarios separately from requirement groups and keep Home, Reviews, and the current artifact consistent.
 
 ## Created GitHub issues

--- a/docs/github-issues-backlog.md
+++ b/docs/github-issues-backlog.md
@@ -1,5 +1,7 @@
 # GitHub Issue Backlog for Test Case Engine Improvements
 
+- In progress: #241 — Shared design system across all application screens. Stories: #242 foundations, #243 artifact collections, #244 workspace, #245 remaining surfaces, #246 consolidation. Builds on #239 / PR #240.
+
 This file contains issue-ready drafts for the implementation plan in `docs/implementation-plan.md`.
 
 ## UI/UX audit follow-up

--- a/docs/project-design.md
+++ b/docs/project-design.md
@@ -27,4 +27,4 @@ The internal library lives in `frontend/src/components/ui/`. Import directly fro
 - `TabList`, `Tab`, `TabPanel` provide arrow/Home/End activation and roving tab stops. Selected values and panel IDs remain controlled by features.
 - `Dialog` supports opt-in focus trapping/restoration and Escape callbacks. Existing specialized popovers retain their feature-owned keyboard behavior; modal consumers use managed focus unless they already own it.
 
-Migration checklist: #242 foundations in progress; #243 artifacts pending; #244 workspace pending; #245 other surfaces pending; #246 consolidation and full validation pending. Visual review uses actual application pages, not a separate gallery.
+Migration checklist: #242 foundations implemented (PR #247); #243 artifacts implemented; #244 workspace pending; #245 other surfaces pending; #246 consolidation and full validation pending. Visual review uses actual application pages, not a separate gallery.

--- a/docs/project-design.md
+++ b/docs/project-design.md
@@ -27,4 +27,4 @@ The internal library lives in `frontend/src/components/ui/`. Import directly fro
 - `TabList`, `Tab`, `TabPanel` provide arrow/Home/End activation and roving tab stops. Selected values and panel IDs remain controlled by features.
 - `Dialog` supports opt-in focus trapping/restoration and Escape callbacks. Existing specialized popovers retain their feature-owned keyboard behavior; modal consumers use managed focus unless they already own it.
 
-Migration checklist: #242 foundations implemented (PR #247); #243 artifacts implemented; #244 workspace implemented; #245 other surfaces pending; #246 consolidation and full validation pending. Visual review uses actual application pages, not a separate gallery.
+Migration checklist: #242 foundations implemented (PR #247); #243 artifacts implemented; #244 workspace implemented; #245 other surfaces implemented; #246 consolidation and full validation pending. Visual review uses actual application pages, not a separate gallery.

--- a/docs/project-design.md
+++ b/docs/project-design.md
@@ -13,3 +13,18 @@ Test Cases presents a searchable selectable list alongside the current case, wit
 On narrow screens the review columns stack, navigation becomes a disclosure, and long labels wrap. Desktop navigation can still collapse to icons. Focus, status announcements and semantic labels remain part of the interaction contract.
 
 Validation: frontend build, lint, formatting, and the `test:e2e:home-first` suite, including the focused `shared-project-design.spec.js` checks. Visual comparison evidence and known constraints are recorded in the root `design-qa.md`.
+
+
+## Application component library (epic #241)
+
+The internal library lives in `frontend/src/components/ui/`. Import directly from controls, surfaces, collections, tabs or dialog. It uses React and native semantic HTML; features own data, filtering, API calls and mutations.
+
+- `Button`: primary/secondary/danger/plain variants, normal/compact sizes, optional busy state. Default type is button; form submissions must explicitly use type="submit".
+- `Input`, `Select`, `Textarea`, `Checkbox`, `Radio`: controlled native props and refs pass through. `Field` connects its single control to label, hint and error text; children-only mode supports existing compound fields.
+- `Badge`: explicit tone and label with a library icon; domain adapters decide the meaning of status. `Surface`, `Alert`, `Disclosure`, `Progress`, `Menu` share visual treatment while retaining semantic roles and existing handlers.
+- `Table` uses native table children; `TableScroll` provides a labeled keyboard-scrollable region. Density is comfortable by default, compact when specified. Features keep column content, sorting, selection and bulk-action logic.
+- `List`, `ListItem`, `SelectableItem`, `ListDetail`, `CollectionToolbar`, `ResultCount`, `CollectionState` share collection composition and accessible states. List variants are plain, collection, grouped and selectable; a navigation row is a link, a selected row is a button, and grouped content uses Disclosure.
+- `TabList`, `Tab`, `TabPanel` provide arrow/Home/End activation and roving tab stops. Selected values and panel IDs remain controlled by features.
+- `Dialog` supports opt-in focus trapping/restoration and Escape callbacks. Existing specialized popovers retain their feature-owned keyboard behavior; modal consumers use managed focus unless they already own it.
+
+Migration checklist: #242 foundations in progress; #243 artifacts pending; #244 workspace pending; #245 other surfaces pending; #246 consolidation and full validation pending. Visual review uses actual application pages, not a separate gallery.

--- a/docs/project-design.md
+++ b/docs/project-design.md
@@ -20,11 +20,11 @@ Validation: frontend build, lint, formatting, and the `test:e2e:home-first` suit
 The internal library lives in `frontend/src/components/ui/`. Import directly from controls, surfaces, collections, tabs or dialog. It uses React and native semantic HTML; features own data, filtering, API calls and mutations.
 
 - `Button`: primary/secondary/danger/plain variants, normal/compact sizes, optional busy state. Default type is button; form submissions must explicitly use type="submit".
-- `Input`, `Select`, `Textarea`, `Checkbox`, `Radio`: controlled native props and refs pass through. `Field` connects its single control to label, hint and error text; children-only mode supports existing compound fields.
+- `Input`, `Select`, `Textarea`, `Checkbox`, `Radio`, `SearchField`: controlled native props and refs pass through. `Field` connects its single control to label, hint and error text; children-only mode supports existing compound fields.
 - `Badge`: explicit tone and label with a library icon; domain adapters decide the meaning of status. `Surface`, `Alert`, `Disclosure`, `Progress`, `Menu` share visual treatment while retaining semantic roles and existing handlers.
 - `Table` uses native table children; `TableScroll` provides a labeled keyboard-scrollable region. Density is comfortable by default, compact when specified. Features keep column content, sorting, selection and bulk-action logic.
 - `List`, `ListItem`, `SelectableItem`, `ListDetail`, `CollectionToolbar`, `ResultCount`, `CollectionState` share collection composition and accessible states. List variants are plain, collection, grouped and selectable; a navigation row is a link, a selected row is a button, and grouped content uses Disclosure.
 - `TabList`, `Tab`, `TabPanel` provide arrow/Home/End activation and roving tab stops. Selected values and panel IDs remain controlled by features.
 - `Dialog` supports opt-in focus trapping/restoration and Escape callbacks. Existing specialized popovers retain their feature-owned keyboard behavior; modal consumers use managed focus unless they already own it.
 
-Migration checklist: #242 foundations implemented (PR #247); #243 artifacts implemented; #244 workspace pending; #245 other surfaces pending; #246 consolidation and full validation pending. Visual review uses actual application pages, not a separate gallery.
+Migration checklist: #242 foundations implemented (PR #247); #243 artifacts implemented; #244 workspace implemented; #245 other surfaces pending; #246 consolidation and full validation pending. Visual review uses actual application pages, not a separate gallery.

--- a/docs/project-design.md
+++ b/docs/project-design.md
@@ -1,0 +1,15 @@
+# Shared project design
+
+Tracked by [#239](https://github.com/lumensparkxy/agentic_test_case_generator/issues/239), based on the selected Overview, Use Cases and Test Cases designs. Builds on scenario-count correction #237.
+
+Project destinations share `ProjectPageHeader`, the project navigation, and existing color and typography tokens through `project-design.css`. Route selection is independent of workflow status. Overview has no invented completion status; other destinations retain text and icons for their current state.
+
+Overview prioritizes the server-provided next action, artifact counts, and actionable review/export blockers. Additional workbenches remain available in a disclosure.
+
+Use Cases groups scenarios by requirement. Scenario objectives and metadata, machine quality findings, coverage and review history remain available through disclosures. The decision form starts without a selected option; the reviewer explicitly chooses Approve or Request changes. Existing comment requirements, version checks, retries and persistence continue to apply.
+
+Test Cases presents a searchable selectable list alongside the current case, with steps, expected results, test data and full metadata. Search covers IDs, titles and linked requirement IDs. The first matching case is selected when the existing selection disappears. Quality findings are expandable. Template setup controls the export format independently of the review presentation. Traceability, coverage, analysis, diagnostics, refinement and export controls remain available.
+
+On narrow screens the review columns stack, navigation becomes a disclosure, and long labels wrap. Desktop navigation can still collapse to icons. Focus, status announcements and semantic labels remain part of the interaction contract.
+
+Validation: frontend build, lint, formatting, and the `test:e2e:home-first` suite, including the focused `shared-project-design.spec.js` checks. Visual comparison evidence and known constraints are recorded in the root `design-qa.md`.

--- a/frontend/e2e/accessibility-navigation.spec.js
+++ b/frontend/e2e/accessibility-navigation.spec.js
@@ -17,7 +17,7 @@ const surfaceRoutes = {
 const surfaceHeadings = {
 	"empty Home": "Home",
 	"populated Home": "Home",
-	"project Overview": "Mercury Checkout",
+	"project Overview": "Overview",
 	"Use Cases": "Use Cases",
 	Automation: "Automation",
 };
@@ -32,7 +32,7 @@ async function openSurface(page, surface, width) {
 	}
 	await seedAuthenticatedSession(page);
 	await page.goto(surfaceRoutes[surface]);
-	await expect(page.getByRole("heading", { name: surfaceHeadings[surface], level: surface === "Automation" ? 2 : 1 })).toBeVisible({
+	await expect(page.getByRole("heading", { name: surfaceHeadings[surface], level: 1 })).toBeVisible({
 		timeout: 30_000,
 	});
 	if (surface === "empty Home") {
@@ -97,7 +97,7 @@ test("moves focus to each SPA destination through links, Back, and Forward", asy
 	await expect(page.locator("#main-content")).toBeFocused();
 
 	const projectNavigation = page.getByRole("navigation", { name: /^Project navigation$/i });
-	await projectNavigation.getByRole("link", { name: /^Overview,/i }).click();
+	await projectNavigation.getByRole("link", { name: /^Overview$/i }).click();
 	await expect(page).toHaveURL(buildProjectPath(USE_CASE_PROJECT_ID));
 	await expect(page.locator("#main-content")).toBeFocused();
 

--- a/frontend/e2e/automation-preview-consistency.spec.js
+++ b/frontend/e2e/automation-preview-consistency.spec.js
@@ -534,7 +534,7 @@ test.describe("Automation preview consistency", () => {
 		const requests = await installApi(page, scenario);
 		await openAutomation(page);
 
-		const panel = page.locator("section.panel").filter({ has: page.getByRole("heading", { name: /^Automation$/i }) });
+		const panel = page.locator("section.panel").filter({ has: page.getByRole("heading", { name: /^Execution setup$/i }) });
 		const previewButton = page.getByRole("button", { name: /^Preview Execution$/ });
 		await previewButton.click({ noWaitAfter: true });
 		await expect.poll(() => requests.previews).toBe(1);

--- a/frontend/e2e/contextual-next-action.spec.js
+++ b/frontend/e2e/contextual-next-action.spec.js
@@ -364,11 +364,11 @@ test.describe("Contextual next task", () => {
 		}
 
 		await page.goto(buildProjectPath(PROJECT_ID, "test-cases"));
-		await page.getByRole("tab", { name: /^Template setup$/i }).click();
+		await page.getByRole("button", { name: /^Template setup$/i }).click();
 		await expect(page.getByLabel("Contextual task")).toHaveCount(0);
 
 		scenario.status = statusFixture([]);
-		await page.getByRole("tab", { name: /^Generate and review$/i }).click();
+		await page.getByRole("button", { name: /^Generate and review$/i }).click();
 		await page.reload();
 		await expect(page.getByLabel("Contextual task")).toHaveCount(0);
 		await expect(page.getByRole("button", { name: /Analyze Impact for/i })).toBeVisible();
@@ -469,6 +469,7 @@ test.describe("Contextual next task", () => {
 		await openTestCases(page);
 
 		const optionalTask = page.getByLabel("Contextual task");
+		await page.getByText("More actions", { exact: true }).first().click();
 		await expect(optionalTask.getByRole("heading", { name: /^Optional test suite actions$/i })).toBeVisible();
 		await expect(optionalTask.locator(".contextual-task-controls > button")).toHaveCount(0);
 		await optionalTask.getByText(/^Details$/i).click();
@@ -480,7 +481,7 @@ test.describe("Contextual next task", () => {
 		scenario.project.stage_state.use_cases.metadata = {};
 		scenario.status.has_baseline_test_suite = true;
 		await page.reload();
-		await expect(page.getByRole("row", { name: new RegExp(OLD_CASE_TITLE, "i") })).toBeVisible();
+		await expect(page.getByRole("button", { name: new RegExp(OLD_CASE_TITLE, "i") })).toBeVisible();
 		await expect(page.getByRole("button", { name: /Implement Changes/i })).toHaveCount(0);
 		expect(requests.generation).toBe(0);
 	});
@@ -503,8 +504,8 @@ test.describe("Contextual next task", () => {
 		const scenario = { project: projectFixture(), status: statusFixture(staleActions()), generationGate, statusAfterGeneration };
 		const requests = await installApi(page, scenario);
 		await openTestCases(page);
-		const oldCaseRow = page.getByRole("row", { name: new RegExp(OLD_CASE_TITLE, "i") });
-		const newCaseRow = page.getByRole("row", { name: new RegExp(NEW_CASE_TITLE, "i") });
+		const oldCaseRow = page.getByRole("button", { name: new RegExp(OLD_CASE_TITLE, "i") });
+		const newCaseRow = page.getByRole("button", { name: new RegExp(NEW_CASE_TITLE, "i") });
 		await expect(oldCaseRow).toBeVisible();
 
 		const task = page.getByLabel("Contextual task");
@@ -566,8 +567,8 @@ test.describe("Contextual next task", () => {
 		await expect(dialog.getByRole("alert")).toContainText(/current suite was preserved/i);
 		await expect(dialog.getByRole("button", { name: /^Confirm regeneration$/i })).toBeEnabled();
 		await expect(dialog.getByRole("button", { name: /^Confirm regeneration$/i })).toBeFocused();
-		await expect(page.getByRole("row", { name: new RegExp(OLD_CASE_TITLE, "i") })).toBeVisible();
-		await expect(page.getByRole("row", { name: new RegExp(NEW_CASE_TITLE, "i") })).toHaveCount(0);
+		await expect(page.getByRole("button", { name: new RegExp(OLD_CASE_TITLE, "i") })).toBeVisible();
+		await expect(page.getByRole("button", { name: new RegExp(NEW_CASE_TITLE, "i") })).toHaveCount(0);
 		expect(requests.generation).toBe(1);
 	});
 });

--- a/frontend/e2e/export-approval-gate.spec.js
+++ b/frontend/e2e/export-approval-gate.spec.js
@@ -274,9 +274,11 @@ test.describe("Export approval gate", () => {
 		await page.getByRole("button", { name: /^Next$/ }).click();
 		await expect(page).toHaveURL(testCasesPath);
 		await page.getByRole("button", { name: /generate from \d+ approved/i }).click();
+		await page.getByText("View findings", { exact: true }).click();
 		await expect(page.getByText(/Needs additional negative coverage/i)).toBeVisible();
 		await page.getByRole("tab", { name: /test cases/i }).click();
-		await expect(page.getByRole("region", { name: "Generated test cases table" })).toHaveAttribute("tabindex", "0");
+		await expect(page.getByRole("region", { name: "Generated test cases", exact: true })).toBeVisible();
+		await expect(page.getByRole("region", { name: "Selected test case", exact: true })).toBeVisible();
 		await page.getByRole("tab", { name: /traceability/i }).click();
 		await expect(page.getByRole("region", { name: "Requirement traceability table" })).toHaveAttribute("tabindex", "0");
 		await page.getByRole("tab", { name: /diagnostics/i }).click();

--- a/frontend/e2e/home-workspace.spec.js
+++ b/frontend/e2e/home-workspace.spec.js
@@ -681,7 +681,8 @@ test.describe("Authenticated Projects experience", () => {
 		await expect.poll(() => api.requests.projectCreate.length).toBe(1);
 		expect(api.requests.projectCreate[0].payload).toEqual({ name: createdProject.name });
 		await expect(page).toHaveURL(buildProjectPath(createdProject.project_id));
-		await expect(page.getByRole("heading", { name: new RegExp(`^${createdProject.name}$`, "i") })).toBeVisible({ timeout: 30_000 });
+		await expect(page.getByRole("heading", { name: "Overview", exact: true })).toBeVisible({ timeout: 30_000 });
+		await expect(page.locator(".project-page-header")).toContainText(createdProject.name);
 		await expect
 			.poll(() => page.evaluate((key) => window.localStorage.getItem(key), STORAGE_CURRENT_PROJECT_ID))
 			.toBe(createdProject.project_id);

--- a/frontend/e2e/impact-update-flow.spec.js
+++ b/frontend/e2e/impact-update-flow.spec.js
@@ -500,7 +500,7 @@ test.describe("Impact update flow", () => {
 
 		await page.getByRole("button", { name: /Apply 3 Accepted Recommendations/i }).click();
 		await expect(page.getByText(/Impact update applied: 1 preserved, 2 updated, 0 added, 0 deprecated/i)).toBeVisible();
-		await expect(page.getByText(/3 test cases/i)).toBeVisible();
+		await expect(page.locator(".test-suite-summary")).toContainText("3 test cases");
 		await expect(task.getByRole("button", { name: /^Start analysis$/i })).toHaveCount(0);
 	});
 });

--- a/frontend/e2e/responsive-reflow.spec.js
+++ b/frontend/e2e/responsive-reflow.spec.js
@@ -230,7 +230,7 @@ test.describe("Responsive project shell", () => {
 			expect(mainBox).not.toBeNull();
 			expect(appBarBox.height).toBeGreaterThanOrEqual(68);
 			expect(appBarBox.height).toBeLessThanOrEqual(76);
-			expect(Math.round(mainBox.y - (appBarBox.y + appBarBox.height))).toBe(16);
+			expect(Math.round(mainBox.y - (appBarBox.y + appBarBox.height))).toBe(0);
 			await expect(projectMenuTrigger).toContainText(PROJECT_NAME);
 			await expect(projectMenuTrigger).toContainText("revision 12");
 			await expect(page.getByRole("button", { name: /^Open system health details$/i })).toBeVisible();
@@ -244,12 +244,13 @@ test.describe("Responsive project shell", () => {
 	for (const viewport of viewports) {
 		test(`contains project content at ${viewport.width}px (${viewport.label})`, async ({ page }) => {
 			await openResponsiveProject(page, viewport);
-			const heading = page.locator(".route-page-header h1");
+			const heading = page.locator(".project-page-header h1");
 			const routePage = page.locator(".route-page");
 			const globalNavigation = page.getByRole("navigation", { name: "Global navigation" });
 			const projectNavigation = page.getByRole("navigation", { name: "Project navigation" });
 
-			await expect(heading).toHaveText(PROJECT_NAME);
+			await expect(heading).toHaveText("Overview");
+			await expect(page.locator(".project-page-header")).toContainText(PROJECT_NAME);
 			await expect(page.getByLabel("Contextual task").getByRole("button", { name: /^Open workbench$/i })).toBeVisible();
 			await expect(page.getByLabel("Project information rail")).toHaveCount(0);
 			await expectExactlyOneCurrent(globalNavigation);
@@ -265,7 +266,7 @@ test.describe("Responsive project shell", () => {
 				await expect(projectNavigation.locator(".workflow-navigation-list")).toBeHidden();
 			} else {
 				await expect(page.getByRole("button", { name: /^Open workspace controls$/i })).toHaveCount(0);
-				await expect(projectNavigation.getByRole("link", { name: /^Overview, Current$/i })).toBeVisible();
+				await expect(projectNavigation.getByRole("link", { name: /^Overview$/i })).toBeVisible();
 			}
 
 			if ([390, 760].includes(viewport.width)) {
@@ -306,7 +307,7 @@ test.describe("Responsive project shell", () => {
 			await projectToggle.focus();
 			await page.keyboard.press(width === 760 ? "Space" : "Enter");
 			await expect(projectNavigation.locator(".workflow-navigation-list")).toBeVisible();
-			await expect(projectNavigation.locator(".workflow-navigation-state")).toHaveCount(7);
+			await expect(projectNavigation.locator(".nav-workflow-status")).toHaveCount(6);
 			await expect(projectNavigation.getByRole("button", { name: /^Close project navigation$/i })).toHaveAttribute("aria-expanded", "true");
 			await page.keyboard.press("Tab");
 			await expect(projectNavigation.getByRole("link").first()).toBeFocused();
@@ -326,18 +327,23 @@ test.describe("Responsive project shell", () => {
 		await expect(globalNavigation.locator('[aria-current="page"]')).toContainText("Projects");
 
 		const expectedStates = [
-			{ name: "Overview, Current", tone: "active" },
+			{ name: "Overview", tone: "active" },
 			{ name: "Requirements, Complete", tone: "complete" },
 			{ name: "Context, Pending", tone: "pending" },
-			{ name: "Use Cases, Needs attention", tone: "attention" },
+			{ name: "Use Cases, Awaiting review", tone: "attention" },
 			{ name: "Automation, Blocked", tone: "blocked" },
 		];
 		for (const expectedState of expectedStates) {
 			const item = projectNavigation.getByRole("link", { name: expectedState.name });
-			const badge = item.locator(".workflow-navigation-state");
+			const badge = item.locator(".nav-workflow-status");
 			await expect(item).toBeVisible();
-			await expect(badge).toHaveAttribute("data-status-tone", expectedState.tone);
-			await expect(badge.locator("svg")).toBeVisible();
+			if (expectedState.tone === "active") {
+				await expect(item).toHaveAttribute("aria-current", "page");
+				await expect(badge).toHaveCount(0);
+			} else {
+				await expect(badge).toHaveClass(new RegExp(expectedState.tone));
+				await expect(badge.locator("svg")).toBeVisible();
+			}
 		}
 
 		await projectNavigation.getByRole("button", { name: /^Collapse project navigation$/i }).click();
@@ -368,12 +374,12 @@ test.describe("Responsive project shell", () => {
 		await expect(page.getByLabel("Project information rail")).toHaveCount(0);
 		await expectVisuallyContained(workflowLabel, workflowLabel.locator("xpath=.."));
 		await expectVisuallyContained(globalLabel, globalNavigation);
-		expect(await workflowLabel.evaluate((element) => getComputedStyle(element).overflowWrap)).not.toBe("anywhere");
-		expect(await workflowLabel.evaluate((element) => getComputedStyle(element).textOverflow)).toBe("ellipsis");
+		expect(await workflowLabel.evaluate((element) => getComputedStyle(element).overflowWrap)).toBe("anywhere");
+		expect(await workflowLabel.evaluate((element) => getComputedStyle(element).whiteSpace)).toBe("normal");
 		await expectNoDocumentOverflow(page, "long expanded shell labels");
 
 		await page.setViewportSize({ width: 320, height: 900 });
-		const heading = page.locator(".route-page-header h1");
+		const heading = page.locator(".project-page-header h1");
 		await heading.evaluate((element) => {
 			element.textContent = "InternationalizedQualityAssuranceWorkspaceWithoutNaturalBreakpoints";
 		});

--- a/frontend/e2e/review-inbox.spec.js
+++ b/frontend/e2e/review-inbox.spec.js
@@ -2,7 +2,7 @@ import { expect, test } from "@playwright/test";
 
 import { buildProjectPath } from "../src/app/workflowRoutes.js";
 import { seedAuthenticatedSession } from "./support/auth.js";
-import { installUseCaseReviewApi, useCaseProjectFixture } from "./support/use-case-review.js";
+import { installUseCaseReviewApi, useCaseProjectFixture, useCaseSnapshotFixture } from "./support/use-case-review.js";
 import {
 	createDeferred,
 	installWorkspaceApi,
@@ -488,4 +488,30 @@ test.describe("Global Review Inbox", () => {
 		await expect.poll(() => api.requests.workspaceSummary.length).toBeGreaterThanOrEqual(3);
 		expect(api.requests.review).toHaveLength(1);
 	});
+});
+
+test("scenario counts agree across Home, Reviews, and the current artifact after refresh", async ({ page }) => {
+	const snapshot = useCaseSnapshotFixture();
+	snapshot.payload.coverage_plan = Array.from({ length: 8 }, (_, i) => ({
+		requirement_id: `REQ-${i}`,
+		requirement_text: `Requirement ${i}`,
+		scenarios: Array.from({ length: i < 4 ? 4 : 3 }, (_, j) => ({
+			id: `SCN-${i}-${j}`,
+			title: `Scenario ${i}-${j}`,
+			objective: "Verify the requirement",
+			priority: "High",
+		})),
+	}));
+	const project = useCaseProjectFixture({ snapshot });
+	await installUseCaseReviewApi(page, { initialProject: project });
+	await seedAuthenticatedSession(page);
+	await page.goto("/");
+	await expect(page.getByRole("region", { name: "Continue working" })).toContainText("28 scenarios · 8 requirement groups");
+	await page.getByRole("navigation", { name: "Global navigation" }).getByRole("link", { name: "Reviews", exact: true }).click();
+	await expect(inboxList(page)).toContainText("28 scenarios · 8 requirement groups");
+	await page.getByRole("button", { name: "Refresh reviews" }).click();
+	await expect(inboxList(page)).toContainText("28 scenarios · 8 requirement groups");
+	await inboxList(page).getByRole("link").click();
+	await expect(page.getByRole("heading", { name: "28 scenarios", exact: true })).toBeVisible();
+	await expect(page.getByRole("region", { name: "28 scenarios", exact: true })).toContainText("8 requirement groups");
 });

--- a/frontend/e2e/review-inbox.spec.js
+++ b/frontend/e2e/review-inbox.spec.js
@@ -475,6 +475,7 @@ test.describe("Global Review Inbox", () => {
 
 		await expect(page).toHaveURL(buildProjectPath(project.project_id, "use-cases"));
 		await expect(page.getByRole("heading", { name: /^Use Cases$/i, level: 1 })).toBeVisible({ timeout: 30_000 });
+		await page.getByRole("radio", { name: /^Approve/i }).check();
 		await page.getByRole("button", { name: /^Approve Use Cases$/i }).click();
 		await expect(page.getByRole("form", { name: /^Human review decision$/i }).getByRole("status")).toContainText(/approved/i);
 
@@ -512,6 +513,7 @@ test("scenario counts agree across Home, Reviews, and the current artifact after
 	await page.getByRole("button", { name: "Refresh reviews" }).click();
 	await expect(inboxList(page)).toContainText("28 scenarios · 8 requirement groups");
 	await inboxList(page).getByRole("link").click();
-	await expect(page.getByRole("heading", { name: "28 scenarios", exact: true })).toBeVisible();
+	await expect(page.locator(".use-case-compact-summary")).toContainText("28 scenarios");
+	await page.getByText("Quality, coverage and review history", { exact: true }).click();
 	await expect(page.getByRole("region", { name: "28 scenarios", exact: true })).toContainText("8 requirement groups");
 });

--- a/frontend/e2e/shared-project-design.spec.js
+++ b/frontend/e2e/shared-project-design.spec.js
@@ -1,0 +1,109 @@
+import { expect, test } from "@playwright/test";
+import { seedAuthenticatedSession } from "./support/auth.js";
+import { installUseCaseReviewApi, useCaseProjectFixture, USE_CASE_PROJECT_ID } from "./support/use-case-review.js";
+
+const caseFixture = (id, title) => ({
+	id,
+	title,
+	description: `Objective for ${title}`,
+	priority: "High",
+	type: "Functional",
+	status: "Draft",
+	preconditions: "Signed in",
+	expected_result: `Result for ${id}`,
+	test_data: "Fixture test data",
+	estimated_time: "3 minutes",
+	automation_status: "Manual",
+	component: "Checkout",
+	tags: ["REQ-101"],
+	steps: [1, 2, 3].map((n) => ({
+		step: n,
+		action: `${id} action ${n}`,
+		expected: `${id} expectation ${n}`,
+		test_data: n === 3 ? "Step-specific data" : "",
+	})),
+});
+
+async function openCases(page, testCases = [caseFixture("TC-001", "Valid checkout"), caseFixture("TC-002", "Declined card")]) {
+	const project = useCaseProjectFixture();
+	project.current_snapshots.test_cases = {
+		snapshot_id: "cases-v1",
+		project_id: USE_CASE_PROJECT_ID,
+		stage: "test_cases",
+		version: 1,
+		project_revision: 7,
+		payload: {
+			test_cases: testCases,
+			review: {
+				approved: false,
+				score: 65,
+				threshold: 90,
+				blocking_issues: ["TC-001 requires a grounded button label."],
+				summary: "Grounded UI details required.",
+			},
+		},
+	};
+	project.stage_state.test_cases = { current_snapshot_id: "cases-v1", approved: false, stale: false, version: 1 };
+	await installUseCaseReviewApi(page, { initialProject: project });
+	await seedAuthenticatedSession(page);
+	await page.goto(`/projects/${USE_CASE_PROJECT_ID}/test-cases`);
+	await expect(page.getByRole("heading", { name: "Test Cases", exact: true, level: 1 })).toBeVisible();
+	return project;
+}
+
+test("selects cases, expands steps and preserves all case metadata while searching", async ({ page }) => {
+	await openCases(page);
+	const detail = page.getByRole("region", { name: "Selected test case" });
+	await expect(detail.getByRole("heading", { name: "Valid checkout" })).toBeVisible();
+	await expect(detail).not.toContainText("TC-001 action 3");
+	await detail.getByRole("button", { name: "Show all 3 steps" }).click();
+	await expect(detail).toContainText("TC-001 action 3");
+	await expect(detail).toContainText("Step-specific data");
+	await detail.getByText("Test data and metadata", { exact: true }).click();
+	await expect(detail).toContainText("Fixture test data");
+	await expect(detail).toContainText("Manual");
+	await page.getByRole("button", { name: /TC-002 Declined card/ }).click();
+	await expect(detail.getByRole("heading", { name: "Declined card" })).toBeVisible();
+	await expect(detail).toContainText("Result for TC-002");
+	await expect(detail).not.toContainText("TC-001 action");
+	await page.getByRole("searchbox", { name: "Search test cases" }).fill("Valid");
+	await expect(detail.getByRole("heading", { name: "Valid checkout" })).toBeVisible();
+	await page.getByRole("searchbox", { name: "Search test cases" }).fill("unmatched");
+	await expect(page.getByText("No test cases match your search.")).toBeVisible();
+	await expect(detail).toContainText("Select a test case");
+	await page.getByRole("searchbox", { name: "Search test cases" }).fill("");
+	await expect(detail.getByRole("heading", { name: "Declined card" })).toBeVisible();
+	await page.getByRole("region", { name: "Test case quality" }).getByText("View findings", { exact: true }).click();
+	await expect(page.getByRole("region", { name: "Test case quality" })).toContainText("TC-001 requires a grounded button label.");
+	await page.getByRole("button", { name: "Template setup", exact: true }).click();
+	await page.getByRole("button", { name: "Generate and review", exact: true }).click();
+	await expect(page.getByRole("heading", { name: "Generated Test Cases", exact: true })).toBeVisible();
+});
+
+test("requires an explicit human decision and keeps navigation status separate", async ({ page }) => {
+	const api = await installUseCaseReviewApi(page);
+	await seedAuthenticatedSession(page);
+	await page.goto(`/projects/${USE_CASE_PROJECT_ID}/use-cases`);
+	const form = page.getByRole("form", { name: "Human review decision" });
+	await expect(form.getByRole("radio", { name: /^Approve/ })).not.toBeChecked();
+	await expect(form.getByRole("radio", { name: /^Request changes/ })).not.toBeChecked();
+	await expect(form.getByRole("button", { name: "Choose a decision" })).toBeDisabled();
+	const nav = page.getByRole("navigation", { name: "Project navigation", exact: true });
+	await expect(nav.getByRole("link", { name: "Use Cases, Awaiting review" })).toHaveAttribute("aria-current", "page");
+	await form.getByRole("radio", { name: /^Request changes/ }).check();
+	await form.getByRole("button", { name: "Request changes", exact: true }).click();
+	await expect(form.getByRole("alert")).toContainText("Comment required");
+	expect(api.requests.review).toHaveLength(0);
+});
+
+for (const width of [390, 901, 1488]) {
+	test(`test-case review reflows without document overflow at ${width}px`, async ({ page }) => {
+		await page.setViewportSize({ width, height: 1056 });
+		await openCases(page);
+		await expect(page.getByRole("region", { name: "Selected test case" })).toBeVisible();
+		expect(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth)).toBe(true);
+		const input = page.getByRole("searchbox", { name: "Search test cases" });
+		await input.fill("Declined");
+		await expect(page.getByRole("region", { name: "Selected test case" })).toContainText("Declined card");
+	});
+}

--- a/frontend/e2e/shared-project-design.spec.js
+++ b/frontend/e2e/shared-project-design.spec.js
@@ -121,3 +121,36 @@ test("shared template fields expose labels, help text and controlled values", as
 	await page.getByRole("button", { name: "Generate and review", exact: true }).click();
 	await expect(page.getByRole("region", { name: "Selected test case" })).toBeVisible();
 });
+
+test("shared result tabs support arrow navigation and a keyboard-scrollable table", async ({ page }) => {
+	await openCases(page);
+	const casesTab = page.getByRole("tab", { name: /^Generated Test Cases/ });
+	await casesTab.focus();
+	await page.keyboard.press("ArrowRight");
+	const traceability = page.getByRole("tab", { name: /^Traceability Matrix/ });
+	await expect(traceability).toBeFocused();
+	await expect(traceability).toHaveAttribute("aria-selected", "true");
+	await expect(casesTab).toHaveAttribute("tabindex", "-1");
+	const table = page.getByRole("region", { name: "Requirement traceability table" });
+	await table.focus();
+	await expect(table).toBeFocused();
+	await expect(table.getByRole("columnheader", { name: "Requirement", exact: true })).toHaveAttribute("scope", "col");
+});
+
+test("shared settings dialog traps focus, labels integration fields and restores its trigger", async ({ page }) => {
+	await openCases(page);
+	const trigger = page.getByRole("button", { name: "Open settings", exact: true });
+	await trigger.click();
+	const dialog = page.getByRole("dialog", { name: "Settings", exact: true });
+	const close = dialog.getByRole("button", { name: "Close settings dialog", exact: true });
+	await expect(close).toBeFocused();
+	await page.keyboard.press("Shift+Tab");
+	await expect.poll(() => dialog.evaluate((element) => element.contains(document.activeElement))).toBe(true);
+	await dialog.getByRole("tab", { name: "Workflow tuning", exact: true }).focus();
+	await page.keyboard.press("ArrowRight");
+	await expect(dialog.getByRole("tab", { name: "Integrations", exact: true })).toHaveAttribute("aria-selected", "true");
+	await expect(dialog.getByRole("textbox", { name: "JIRA base URL", exact: true })).toBeVisible();
+	await page.keyboard.press("Escape");
+	await expect(dialog).toHaveCount(0);
+	await expect(trigger).toBeFocused();
+});

--- a/frontend/e2e/shared-project-design.spec.js
+++ b/frontend/e2e/shared-project-design.spec.js
@@ -107,3 +107,17 @@ for (const width of [390, 901, 1488]) {
 		await expect(page.getByRole("region", { name: "Selected test case" })).toContainText("Declined card");
 	});
 }
+
+test("shared template fields expose labels, help text and controlled values", async ({ page }) => {
+	await openCases(page);
+	await page.getByRole("button", { name: "Template setup", exact: true }).click();
+	const name = page.getByRole("textbox", { name: "Template name", exact: true });
+	await name.fill("Regression suite");
+	await expect(name).toHaveValue("Regression suite");
+	const format = page.getByRole("combobox", { name: "Template format", exact: true });
+	await expect(format).toHaveAttribute("aria-describedby", /hint$/);
+	await format.focus();
+	await expect(format).toBeFocused();
+	await page.getByRole("button", { name: "Generate and review", exact: true }).click();
+	await expect(page.getByRole("region", { name: "Selected test case" })).toBeVisible();
+});

--- a/frontend/e2e/support/use-case-review.js
+++ b/frontend/e2e/support/use-case-review.js
@@ -398,6 +398,7 @@ export function useCaseWorkspaceSummaryFixture(project, overrides = {}) {
 				enabled: action.enabled,
 				primary: action.primary,
 				count: action.stage === "use_cases" ? useCaseScenarioTotal(project) : null,
+				requirement_group_count: action.stage === "use_cases" ? (snapshot?.payload?.coverage_plan?.length ?? null) : null,
 				reason: action.reason,
 				current_snapshot_id: snapshot?.snapshot_id || null,
 				updated_at: project.updated_at,

--- a/frontend/e2e/use-case-review.spec.js
+++ b/frontend/e2e/use-case-review.spec.js
@@ -23,11 +23,11 @@ function reviewMain(page) {
 }
 
 function machineReviewRegion(page) {
-	return reviewMain(page).getByRole("region", { name: /^Machine quality review$/i });
+	return reviewMain(page).getByRole("region", { name: /^Machine quality review$/i, includeHidden: true });
 }
 
 function humanReviewRegion(page) {
-	return reviewMain(page).getByRole("region", { name: /^Human review status$/i });
+	return reviewMain(page).getByRole("region", { name: /^Human review status$/i, includeHidden: true });
 }
 
 function decisionPanel(page) {
@@ -67,6 +67,10 @@ async function openUseCaseReview(page, options = {}) {
 	await seedAuthenticatedSession(page);
 	await page.goto(buildProjectPath(USE_CASE_PROJECT_ID, "use-cases"));
 	await expect(page.getByRole("heading", { name: /^Use Cases$/i, level: 1 })).toBeVisible({ timeout: 30_000 });
+	if (await page.getByText("Quality, coverage and review history", { exact: true }).count()) {
+		await page.getByText("Quality, coverage and review history", { exact: true }).click();
+		if (await approveOption(page).isEnabled()) await approveOption(page).check();
+	}
 	return api;
 }
 
@@ -175,6 +179,7 @@ test.describe("Use Cases review workbench", () => {
 
 		await expect(page).toHaveURL(buildProjectPath(USE_CASE_PROJECT_ID, "use-cases"));
 		await expect(reviewMain(page)).toBeVisible();
+		await page.getByText("Quality, coverage and review history", { exact: true }).click();
 		await expect(machineReviewRegion(page)).toBeVisible();
 		await expect(page.getByRole("heading", { name: /^Upload Requirements$/i })).toHaveCount(0);
 	});
@@ -197,10 +202,10 @@ test.describe("Use Cases review workbench", () => {
 		await expect(reviewMain(page).getByRole("status", { name: "Current human review status" })).toContainText(/Awaiting human review/i);
 		await page
 			.getByRole("navigation", { name: "Project navigation" })
-			.getByRole("link", { name: /^Overview,/i })
+			.getByRole("link", { name: /^Overview$/i })
 			.click();
 		await expect(
-			page.getByRole("navigation", { name: "Project navigation" }).getByRole("link", { name: /^Use Cases, Needs attention$/i })
+			page.getByRole("navigation", { name: "Project navigation" }).getByRole("link", { name: /^Use Cases, Awaiting review$/i })
 		).toBeVisible();
 		await expect(page.getByLabel("Contextual task").getByRole("heading", { name: /^Approve Use Cases$/i })).toBeVisible();
 		await page

--- a/frontend/e2e/workflow-navigation.spec.js
+++ b/frontend/e2e/workflow-navigation.spec.js
@@ -365,20 +365,20 @@ test.describe("Route-driven application shell", () => {
 		await seedAuthenticatedSession(page);
 
 		const destinations = [
-			{ destination: "overview", heading: PROJECT_A.name, active: "Overview" },
-			{ destination: "requirements", heading: "Upload Requirements", active: "Requirements" },
-			{ destination: "context", heading: "Context Inputs", active: "Context" },
+			{ destination: "overview", heading: "Overview", active: "Overview" },
+			{ destination: "requirements", heading: "Requirements", active: "Requirements" },
+			{ destination: "context", heading: "Context", active: "Context" },
 			{ destination: "use-cases", heading: "Use Cases", active: "Use Cases" },
-			{ destination: "test-cases", heading: "Generate Test Cases", active: "Test Cases" },
+			{ destination: "test-cases", heading: "Test Cases", active: "Test Cases" },
 			{ destination: "automation", heading: "Automation", active: "Automation" },
-			{ destination: "reports", heading: "Export Test Cases", active: "Reports" },
+			{ destination: "reports", heading: "Reports", active: "Reports" },
 		];
 
 		for (const destination of destinations) {
 			const path = buildProjectPath(PROJECT_A.project_id, destination.destination);
 			await page.goto(path);
 			await expect(page).toHaveURL(new RegExp(`${path}/?$`));
-			await expect(page.getByRole("heading", { name: new RegExp(`^${destination.heading}$`, "i") })).toBeVisible({
+			await expect(page.getByRole("heading", { name: new RegExp(`^${destination.heading}$`, "i"), level: 1 })).toBeVisible({
 				timeout: 30_000,
 			});
 			await expect(page.getByRole("button", { name: "Open QA project menu" })).toContainText(PROJECT_A.name);
@@ -533,7 +533,7 @@ test.describe("Route-driven application shell", () => {
 		await page.getByRole("button", { name: "Open QA project menu" }).click();
 		await page.getByRole("button", { name: `Open QA project ${PROJECT_B.name}` }).click();
 		await expect(page).toHaveURL(buildProjectPath(PROJECT_B.project_id));
-		await expect(page.getByRole("heading", { name: new RegExp(`^${PROJECT_B.name}$`, "i") })).toBeVisible({ timeout: 30_000 });
+		await expect(page.getByRole("heading", { name: /^Overview$/i })).toBeVisible({ timeout: 30_000 });
 		await expect(page.getByRole("button", { name: "Open QA project menu" })).toContainText(PROJECT_B.name);
 
 		const parseResponse = page.waitForResponse(
@@ -579,10 +579,10 @@ test.describe("Route-driven application shell", () => {
 
 		await page.getByRole("button", { name: "Open QA project menu" }).click();
 		await page.getByRole("button", { name: `Open QA project ${PROJECT_B.name}` }).click();
-		await expect(page.getByRole("heading", { name: new RegExp(`^${PROJECT_B.name}$`, "i") })).toBeVisible({ timeout: 30_000 });
+		await expect(page.getByRole("heading", { name: /^Overview$/i })).toBeVisible({ timeout: 30_000 });
 		await page.getByRole("button", { name: "Open QA project menu" }).click();
 		await page.getByRole("button", { name: `Open QA project ${PROJECT_A.name}` }).click();
-		await expect(page.getByRole("heading", { name: new RegExp(`^${PROJECT_A.name}$`, "i") })).toBeVisible({ timeout: 30_000 });
+		await expect(page.getByRole("heading", { name: /^Overview$/i })).toBeVisible({ timeout: 30_000 });
 		await page
 			.getByRole("navigation", { name: "Project navigation" })
 			.getByRole("link", { name: /^Requirements(?:,|$)/i })

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,7 @@
     "format:check": "prettier --check \"src/**/*.{js,jsx,css}\" \"e2e/**/*.{js,mjs}\" \"*.js\"",
     "preview": "vite preview",
     "test:e2e": "playwright test",
-    "test:e2e:home-first": "playwright test e2e/export-approval-gate.spec.js e2e/home-workspace.spec.js e2e/workflow-navigation.spec.js e2e/contextual-next-action.spec.js e2e/use-case-review.spec.js e2e/review-inbox.spec.js e2e/automation-preview-consistency.spec.js e2e/multi-environment-execution.spec.js e2e/responsive-reflow.spec.js e2e/runs-reports-index.spec.js e2e/accessibility-navigation.spec.js",
+    "test:e2e:home-first": "playwright test e2e/shared-project-design.spec.js e2e/export-approval-gate.spec.js e2e/home-workspace.spec.js e2e/workflow-navigation.spec.js e2e/contextual-next-action.spec.js e2e/use-case-review.spec.js e2e/review-inbox.spec.js e2e/automation-preview-consistency.spec.js e2e/multi-environment-execution.spec.js e2e/responsive-reflow.spec.js e2e/runs-reports-index.spec.js e2e/accessibility-navigation.spec.js",
     "test:e2e:headed": "playwright test --headed"
   },
   "dependencies": {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,3 +1,4 @@
+import { TableScroll, Table, List, ListItem, CollectionState } from "./components/ui/collections";
 import ProjectPageHeader from "./components/layout/ProjectPageHeader";
 import TestCaseQualitySummary from "./components/generation/TestCaseQualitySummary";
 import { useEffect, useRef, useState } from "react";
@@ -890,8 +891,13 @@ export default function App() {
 				</div>
 
 				{requirementReportStats.length > 0 && (
-					<div className="requirement-report-table-wrapper" role="region" aria-label="Requirement review summary table" tabIndex={0}>
-						<table className="requirement-report-table">
+					<TableScroll
+						className="requirement-report-table-wrapper"
+						role="region"
+						aria-label="Requirement review summary table"
+						tabIndex={0}
+					>
+						<Table className="requirement-report-table">
 							<thead>
 								<tr>
 									{requirementReportStats.map((stat) => (
@@ -910,8 +916,8 @@ export default function App() {
 									))}
 								</tr>
 							</tbody>
-						</table>
-					</div>
+						</Table>
+					</TableScroll>
 				)}
 
 				{requirementReportDetailCount > 0 && (
@@ -926,33 +932,33 @@ export default function App() {
 							{requirementBlockingIssues.length > 0 && (
 								<div className="requirement-report-detail-block issue">
 									<strong>Blocking issues</strong>
-									<ul>
+									<List>
 										{requirementBlockingIssues.slice(0, 4).map((issue) => (
-											<li key={issue}>{issue}</li>
+											<ListItem key={issue}>{issue}</ListItem>
 										))}
-									</ul>
+									</List>
 								</div>
 							)}
 
 							{requirementWarnings.length > 0 && (
 								<div className="requirement-report-detail-block warning">
 									<strong>Warnings</strong>
-									<ul>
+									<List>
 										{requirementWarnings.map((warning) => (
-											<li key={warning}>{warning}</li>
+											<ListItem key={warning}>{warning}</ListItem>
 										))}
-									</ul>
+									</List>
 								</div>
 							)}
 
 							{requirementParserFailures.length > 0 && (
 								<div className="requirement-report-detail-block alert">
 									<strong>Parser issues</strong>
-									<ul>
+									<List>
 										{requirementParserFailures.map((failure) => (
-											<li key={failure}>{failure}</li>
+											<ListItem key={failure}>{failure}</ListItem>
 										))}
-									</ul>
+									</List>
 								</div>
 							)}
 						</div>
@@ -3664,14 +3670,14 @@ export default function App() {
 				{changedItems.length > 0 && (
 					<div className="impact-table-block">
 						<h4>Changed Inputs</h4>
-						<div className="selection-table-wrapper" role="region" aria-label="Changed inputs table" tabIndex={0}>
-							<table className="selection-table impact-table">
+						<TableScroll className="selection-table-wrapper" role="region" aria-label="Changed inputs table" tabIndex={0}>
+							<Table className="selection-table impact-table">
 								<thead>
 									<tr>
-										<th>Item</th>
-										<th>Type</th>
-										<th>Change</th>
-										<th>Approval</th>
+										<th scope="col">Item</th>
+										<th scope="col">Type</th>
+										<th scope="col">Change</th>
+										<th scope="col">Approval</th>
 									</tr>
 								</thead>
 								<tbody>
@@ -3687,15 +3693,15 @@ export default function App() {
 										</tr>
 									))}
 								</tbody>
-							</table>
-						</div>
+							</Table>
+						</TableScroll>
 					</div>
 				)}
 
 				{impactedCases.length > 0 && (
 					<div className="impact-table-block">
 						<h4>Impacted Test Cases</h4>
-						<div className="impact-case-list">
+						<List as="div" variant="grouped" className="impact-case-list">
 							{impactedCases.slice(0, 8).map((testCase) => (
 								<div key={`${testCase.impact_source}-${testCase.test_case_id}`} className="impact-case-row">
 									<div>
@@ -3705,13 +3711,13 @@ export default function App() {
 									<span className={`impact-source-badge ${testCase.impact_source}`}>{testCase.impact_source.replace("_", " ")}</span>
 								</div>
 							))}
-						</div>
+						</List>
 					</div>
 				)}
 
 				<div className="impact-table-block">
 					<h4>Recommendations</h4>
-					<div className="impact-recommendation-list">
+					<List as="div" variant="grouped" className="impact-recommendation-list">
 						{recommendations.map((recommendation) => (
 							<div key={recommendation.recommendation_id} className={`impact-recommendation ${recommendation.action}`}>
 								<div>
@@ -3725,7 +3731,7 @@ export default function App() {
 								</div>
 							</div>
 						))}
-					</div>
+					</List>
 				</div>
 
 				{impactApplyBlockedByApproval && (
@@ -4248,21 +4254,21 @@ export default function App() {
 														</div>
 
 														{jiraIssueResults.length > 0 ? (
-															<div
+															<TableScroll
 																className="selection-table-wrapper"
 																role="region"
 																aria-label="Jira issue search results table"
 																tabIndex={0}
 															>
-																<table className="selection-table">
+																<Table className="selection-table">
 																	<thead>
 																		<tr>
-																			<th>Select</th>
-																			<th>Issue</th>
-																			<th>Summary</th>
-																			<th>Type</th>
-																			<th>Status</th>
-																			<th>Parent</th>
+																			<th scope="col">Select</th>
+																			<th scope="col">Issue</th>
+																			<th scope="col">Summary</th>
+																			<th scope="col">Type</th>
+																			<th scope="col">Status</th>
+																			<th scope="col">Parent</th>
 																		</tr>
 																	</thead>
 																	<tbody>
@@ -4294,8 +4300,8 @@ export default function App() {
 																			);
 																		})}
 																	</tbody>
-																</table>
-															</div>
+																</Table>
+															</TableScroll>
 														) : (
 															<span className="helper-text">Search visible issues in the selected project to choose an import source.</span>
 														)}
@@ -4396,21 +4402,21 @@ export default function App() {
 														</div>
 
 														{azureDevOpsWorkItemResults.length > 0 ? (
-															<div
+															<TableScroll
 																className="selection-table-wrapper"
 																role="region"
 																aria-label="Azure DevOps work item search results table"
 																tabIndex={0}
 															>
-																<table className="selection-table">
+																<Table className="selection-table">
 																	<thead>
 																		<tr>
-																			<th>Select</th>
-																			<th>Work item</th>
-																			<th>Title</th>
-																			<th>Type</th>
-																			<th>State</th>
-																			<th>Parent</th>
+																			<th scope="col">Select</th>
+																			<th scope="col">Work item</th>
+																			<th scope="col">Title</th>
+																			<th scope="col">Type</th>
+																			<th scope="col">State</th>
+																			<th scope="col">Parent</th>
 																		</tr>
 																	</thead>
 																	<tbody>
@@ -4442,8 +4448,8 @@ export default function App() {
 																			);
 																		})}
 																	</tbody>
-																</table>
-															</div>
+																</Table>
+															</TableScroll>
 														) : (
 															<span className="helper-text">
 																Search visible work items in the selected project to choose an import source.
@@ -4562,7 +4568,7 @@ export default function App() {
 																	Skipped {(jiraSyncPreview.skipped_requirement_ids || []).length}
 																</span>
 															</div>
-															<div className="jira-sync-preview-list">
+															<List as="div" variant="grouped" className="jira-sync-preview-list">
 																{jiraSyncPreview.issues?.map((issue) => (
 																	<div key={issue.issue_key} className={`jira-sync-preview-card ${issue.status}`}>
 																		<div className="jira-sync-preview-header">
@@ -4594,13 +4600,13 @@ export default function App() {
 																		</div>
 																	</div>
 																))}
-															</div>
+															</List>
 															{jiraSyncPreview.warnings?.length > 0 && (
-																<ul className="jira-sync-warning-list">
+																<List className="jira-sync-warning-list">
 																	{jiraSyncPreview.warnings.map((warning) => (
-																		<li key={warning}>{warning}</li>
+																		<ListItem key={warning}>{warning}</ListItem>
 																	))}
-																</ul>
+																</List>
 															)}
 														</div>
 													)}
@@ -4608,14 +4614,14 @@ export default function App() {
 													{jiraSyncResults && (
 														<div className="jira-sync-results-summary">
 															<h4>Last sync result</h4>
-															<ul className="jira-sync-apply-list">
+															<List className="jira-sync-apply-list">
 																{jiraSyncResults.results?.map((result) => (
-																	<li key={`${result.issue_key}-${result.status}`}>
+																	<ListItem key={`${result.issue_key}-${result.status}`}>
 																		<strong>{result.issue_key}</strong> — {result.status}
 																		{result.message ? `: ${result.message}` : ""}
-																	</li>
+																	</ListItem>
 																))}
-															</ul>
+															</List>
 														</div>
 													)}
 												</div>
@@ -4678,7 +4684,7 @@ export default function App() {
 																	Skipped {(azureDevOpsSyncPreview.skipped_requirement_ids || []).length}
 																</span>
 															</div>
-															<div className="jira-sync-preview-list">
+															<List as="div" variant="grouped" className="jira-sync-preview-list">
 																{azureDevOpsSyncPreview.work_items?.map((workItem) => (
 																	<div key={workItem.work_item_id} className={`jira-sync-preview-card ${workItem.status}`}>
 																		<div className="jira-sync-preview-header">
@@ -4712,13 +4718,13 @@ export default function App() {
 																		</div>
 																	</div>
 																))}
-															</div>
+															</List>
 															{azureDevOpsSyncPreview.warnings?.length > 0 && (
-																<ul className="jira-sync-warning-list">
+																<List className="jira-sync-warning-list">
 																	{azureDevOpsSyncPreview.warnings.map((warning) => (
-																		<li key={warning}>{warning}</li>
+																		<ListItem key={warning}>{warning}</ListItem>
 																	))}
-																</ul>
+																</List>
 															)}
 														</div>
 													)}
@@ -4726,14 +4732,14 @@ export default function App() {
 													{azureDevOpsSyncResults && (
 														<div className="jira-sync-results-summary">
 															<h4>Last sync result</h4>
-															<ul className="jira-sync-apply-list">
+															<List className="jira-sync-apply-list">
 																{azureDevOpsSyncResults.results?.map((result) => (
-																	<li key={`${result.work_item_id}-${result.status}`}>
+																	<ListItem key={`${result.work_item_id}-${result.status}`}>
 																		<strong>#{result.work_item_id}</strong> — {result.status}
 																		{result.message ? `: ${result.message}` : ""}
-																	</li>
+																	</ListItem>
 																))}
-															</ul>
+															</List>
 														</div>
 													)}
 												</div>
@@ -4917,10 +4923,10 @@ export default function App() {
 																appliedTestCaseWorkflowSettings,
 																testCaseIterationHistory
 															) || (
-																<div className="generate-result-empty">
+																<CollectionState as="div" kind="empty" className="generate-result-empty">
 																	<h3>Diagnostics</h3>
 																	<p>No workflow diagnostics are available for this run.</p>
-																</div>
+																</CollectionState>
 															))}
 
 														{activeGenerateResultTab === "coverage" && (

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,3 +1,5 @@
+import ProjectPageHeader from "./components/layout/ProjectPageHeader";
+import TestCaseQualitySummary from "./components/generation/TestCaseQualitySummary";
 import { useEffect, useRef, useState } from "react";
 import { onAuthStateChanged, signInWithPopup, signOut } from "firebase/auth";
 import GlobalAppShell from "./app/GlobalAppShell";
@@ -4060,6 +4062,16 @@ export default function App() {
 							<ProjectOverviewPage
 								project={currentProject}
 								status={orchestratorStatus}
+								counts={{
+									requirements: requirements.length,
+									scenarios: (currentProject.current_snapshots?.use_cases?.payload?.coverage_plan || []).reduce(
+										(sum, group) => sum + (group.scenarios?.length || 0),
+										0
+									),
+									testCases: testCases.length,
+								}}
+								testCaseReview={testCaseReview}
+								exportLocked={exportGateLocked}
 								navigate={navigate}
 								contextualTask={
 									<OrchestratorCockpitPanel
@@ -4089,20 +4101,23 @@ export default function App() {
 							<main
 								id="main-content"
 								ref={workflowMainRef}
-								className="workflow-main"
+								className={`workflow-main ${route.destination === "test-cases" ? "test-cases-page" : ""}`}
 								aria-label={`Workflow workspace: ${activeProjectDestinationLabel}`}
 								tabIndex={-1}
 							>
-								{route.destination === "test-cases" ? (
-									<div className="test-cases-section-tabs" role="tablist" aria-label="Test Cases sections">
-										<button type="button" role="tab" aria-selected={activeTab === 2} onClick={() => selectWorkflowTab(2)}>
-											Template setup
-										</button>
-										<button type="button" role="tab" aria-selected={activeTab === 3} onClick={() => selectWorkflowTab(3)}>
-											Generate and review
-										</button>
-									</div>
-								) : null}
+								<ProjectPageHeader
+									title={activeProjectDestinationLabel}
+									project={currentProject}
+									navigate={navigate}
+									actions={
+										route.destination === "test-cases" ? (
+											<button className="secondary" onClick={() => selectWorkflowTab(activeTab === 2 ? 3 : 2)}>
+												{activeTab === 2 ? "Generate and review" : "Template setup"}
+											</button>
+										) : null
+									}
+								/>
+
 								<OrchestratorCockpitPanel
 									currentProject={currentProject}
 									status={orchestratorStatus}
@@ -4794,36 +4809,37 @@ export default function App() {
 									)}
 
 									{activeTab === 3 && (
-										<section className="panel">
+										<section className={`panel test-generation-panel ${testCases.length ? "has-test-cases" : ""}`}>
 											<h2 className="panel-title">Generate Test Cases</h2>
 											<p className="panel-description">
 												Generate structured test cases, or analyze impact against an existing suite when upstream inputs change.
 											</p>
-											{requirements.length > 0 && (
-												<div className={`generation-gate-card ${canGenerateFromApprovedRequirements ? "ready" : "blocked"}`}>
-													<div>
-														<strong>
-															{upstreamChangedForImpact
-																? "Existing suite needs impact analysis"
-																: canGenerateFromApprovedRequirements
-																	? "Ready for approved-requirement generation"
-																	: "Approval required before generation"}
-														</strong>
-														<p>
-															{approvedRequirementCount} approved • {reviewPendingRequirementCount} pending review •{" "}
-															{rejectedRequirementCount} rejected
-															{upstreamChangedForImpact
-																? ". The current suite is preserved while impact analysis reviews changed inputs."
-																: ". Only approved requirements are sent to the test-case agents."}
-														</p>
+											{requirements.length > 0 &&
+												(!testCases.length || !canGenerateFromApprovedRequirements || upstreamChangedForImpact) && (
+													<div className={`generation-gate-card ${canGenerateFromApprovedRequirements ? "ready" : "blocked"}`}>
+														<div>
+															<strong>
+																{upstreamChangedForImpact
+																	? "Existing suite needs impact analysis"
+																	: canGenerateFromApprovedRequirements
+																		? "Ready for approved-requirement generation"
+																		: "Approval required before generation"}
+															</strong>
+															<p>
+																{approvedRequirementCount} approved • {reviewPendingRequirementCount} pending review •{" "}
+																{rejectedRequirementCount} rejected
+																{upstreamChangedForImpact
+																	? ". The current suite is preserved while impact analysis reviews changed inputs."
+																	: ". Only approved requirements are sent to the test-case agents."}
+															</p>
+														</div>
+														{!canGenerateFromApprovedRequirements && (
+															<button type="button" className="secondary small" onClick={() => selectWorkflowTab(0)}>
+																Review requirements
+															</button>
+														)}
 													</div>
-													{!canGenerateFromApprovedRequirements && (
-														<button type="button" className="secondary small" onClick={() => selectWorkflowTab(0)}>
-															Review requirements
-														</button>
-													)}
-												</div>
-											)}
+												)}
 											{!contextualTestCaseTask &&
 											allowLegacyTestCaseMutations &&
 											(!hasExistingTestCaseBaseline || upstreamChangedForImpact) ? (
@@ -4849,27 +4865,10 @@ export default function App() {
 
 											{renderImpactAnalysisPanel()}
 
-											{testCaseReview && (
-												<div className={`review-banner ${testCaseReview.approved ? "review-approved" : "review-needs-work"}`}>
-													<div className="review-banner-header">
-														<strong>{testCaseReview.approved ? "Approved for export" : "Needs refinement"}</strong>
-														<div className="review-banner-metrics">
-															<span className="review-metric-pill review-metric-pill-strong">{testCaseReviewMeta.scoreLabel}</span>
-															{testCaseReviewMeta.thresholdLabel && (
-																<span className="review-metric-pill">{testCaseReviewMeta.thresholdLabel}</span>
-															)}
-														</div>
-													</div>
-													<p>{testCaseReview.summary || "The review loop completed without a summary."}</p>
-													{!testCaseReview.approved && testCaseReview.blocking_issues?.length > 0 && (
-														<ul className="review-issues">
-															{testCaseReview.blocking_issues.slice(0, 3).map((issue) => (
-																<li key={issue}>{issue}</li>
-															))}
-														</ul>
-													)}
-												</div>
-											)}
+											<p className="test-suite-summary">
+												{testCases.length} test cases · {approvedRequirementCount} approved requirements
+											</p>
+											<TestCaseQualitySummary review={testCaseReview} meta={testCaseReviewMeta} exportLocked={exportGateLocked} />
 
 											{hasGenerateResults ? (
 												<div className="generate-results-workspace">
@@ -4959,7 +4958,7 @@ export default function App() {
 														{activeGenerateResultTab === "test-cases" && (
 															<GeneratedTestCasesView
 																testCases={testCases}
-																templateFormat={templateFormat}
+																qualityIssues={testCaseReview?.blocking_issues || []}
 																expandedRows={expandedRows}
 																onToggleRowExpansion={toggleRowExpansion}
 																feedback={feedback}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,3 +1,6 @@
+import { Disclosure, Surface } from "./components/ui/surfaces";
+import { Button, Link, Radio, Field, Input, Select, Textarea } from "./components/ui/controls";
+import { TabList, Tab, TabPanel } from "./components/ui/tabs";
 import { TableScroll, Table, List, ListItem, CollectionState } from "./components/ui/collections";
 import ProjectPageHeader from "./components/layout/ProjectPageHeader";
 import TestCaseQualitySummary from "./components/generation/TestCaseQualitySummary";
@@ -37,7 +40,6 @@ import useAppSessionState from "./hooks/useAppSessionState";
 import useBillingStatus from "./hooks/useBillingStatus";
 import useBrowserNavigation from "./hooks/useBrowserNavigation";
 import useContextWorkflowState from "./hooks/useContextWorkflowState";
-import useEscapeToClose from "./hooks/useEscapeToClose";
 import useExecutionWorkflowState from "./hooks/useExecutionWorkflowState";
 import useExportWorkflowState from "./hooks/useExportWorkflowState";
 import useIntegrationWorkflowState from "./hooks/useIntegrationWorkflowState";
@@ -921,7 +923,7 @@ export default function App() {
 				)}
 
 				{requirementReportDetailCount > 0 && (
-					<details className="requirement-report-details">
+					<Disclosure className="requirement-report-details">
 						<summary>
 							<span>Workflow notes</span>
 							<span className="requirement-report-details-count">
@@ -962,7 +964,7 @@ export default function App() {
 								</div>
 							)}
 						</div>
-					</details>
+					</Disclosure>
 				)}
 			</div>
 		);
@@ -1286,9 +1288,6 @@ export default function App() {
 			accountEmail: prev.accountEmail || currentUser.email,
 		}));
 	}, [currentUser?.email, azureDevOpsConnected]);
-
-	useEscapeToClose(isSignInDialogOpen, closeSignInDialog);
-	useEscapeToClose(isSettingsDialogOpen, closeSettingsDialog);
 
 	const apiRequest = async (path, options = {}, authRequired = true) => {
 		const headers = ensureRequestIdHeader(options.headers || {});
@@ -3741,11 +3740,11 @@ export default function App() {
 					</div>
 				)}
 				<div className="panel-form button-row impact-actions">
-					<button onClick={applyImpactUpdate} disabled={!canApplyImpactUpdate || testCaseActionDisabled}>
+					<Button onClick={applyImpactUpdate} disabled={!canApplyImpactUpdate || testCaseActionDisabled}>
 						{isApplyingImpactUpdate
 							? "⏳ Applying..."
 							: `Apply ${acceptedImpactRecommendationIds.length} Accepted Recommendation${acceptedImpactRecommendationIds.length === 1 ? "" : "s"}`}
-					</button>
+					</Button>
 				</div>
 				{impactUpdateMessage && (
 					<div className="impact-update-result" role="status">
@@ -3933,9 +3932,9 @@ export default function App() {
 
 	return (
 		<div className="page">
-			<a className="skip-link" href="#main-content">
+			<Link className="skip-link" href="#main-content">
 				Skip to main content
-			</a>
+			</Link>
 			<div className="sr-only" role="status" aria-live="polite" aria-atomic="true" data-testid="application-live-status">
 				{applicationLiveStatus}
 			</div>
@@ -4117,9 +4116,9 @@ export default function App() {
 									navigate={navigate}
 									actions={
 										route.destination === "test-cases" ? (
-											<button className="secondary" onClick={() => selectWorkflowTab(activeTab === 2 ? 3 : 2)}>
+											<Button className="secondary" onClick={() => selectWorkflowTab(activeTab === 2 ? 3 : 2)}>
 												{activeTab === 2 ? "Generate and review" : "Template setup"}
-											</button>
+											</Button>
 										) : null
 									}
 								/>
@@ -4140,7 +4139,7 @@ export default function App() {
 
 								<div className="tab-content">
 									{activeTab === 0 && (
-										<section className="panel">
+										<Surface as="section" className="panel">
 											<h2 className="panel-title">Upload Requirements</h2>
 											<p className="panel-description">
 												Choose a source for requirements, extract them into the review loop, and optionally push approved updates back to
@@ -4149,7 +4148,7 @@ export default function App() {
 											<div className="choice-group source-choice-group" role="radiogroup" aria-label="Requirement source selector">
 												{REQUIREMENT_SOURCE_OPTIONS.map((option) => (
 													<label key={option.value} className={`choice-card ${requirementSourceMode === option.value ? "selected" : ""}`}>
-														<input
+														<Radio
 															type="radio"
 															name="requirement-source"
 															value={option.value}
@@ -4165,13 +4164,13 @@ export default function App() {
 
 											{requirementSourceMode === "file" ? (
 												<div className="panel-form">
-													<div className="form-group">
+													<Field className="form-group">
 														<label>Requirements file</label>
-														<input type="file" accept=".md,.docx,.xlsx" onChange={(e) => setFile(e.target.files?.[0] || null)} />
-													</div>
-													<button onClick={() => parseRequirements(false)} disabled={!file || isParsing || requirementActionDisabled}>
+														<Input type="file" accept=".md,.docx,.xlsx" onChange={(e) => setFile(e.target.files?.[0] || null)} />
+													</Field>
+													<Button onClick={() => parseRequirements(false)} disabled={!file || isParsing || requirementActionDisabled}>
 														{isParsing ? "⏳ Parsing..." : "Parse Requirements"}
-													</button>
+													</Button>
 												</div>
 											) : requirementSourceMode === "jira" ? (
 												<div className="jira-workflow-panel">
@@ -4185,19 +4184,19 @@ export default function App() {
 															</div>
 														</div>
 														<div className="panel-form two-cols jira-search-grid">
-															<div className="form-group">
+															<Field className="form-group">
 																<label>Project search</label>
-																<input
+																<Input
 																	placeholder="Search JIRA projects"
 																	value={jiraProjectQuery}
 																	onChange={(event) => setJiraProjectQuery(event.target.value)}
 																	disabled={!jiraConnected}
 																/>
-															</div>
+															</Field>
 															<div className="form-group jira-inline-action">
 																<label>Project</label>
 																<div className="jira-inline-controls">
-																	<select
+																	<Select
 																		value={selectedJiraProjectKey}
 																		onChange={(event) => setSelectedJiraProjectKey(event.target.value)}
 																		disabled={!jiraConnected || !jiraProjects.length}
@@ -4208,19 +4207,19 @@ export default function App() {
 																				{project.key} — {project.name}
 																			</option>
 																		))}
-																	</select>
-																	<button
+																	</Select>
+																	<Button
 																		className="secondary"
 																		onClick={() => loadJiraProjects(jiraProjectQuery)}
 																		disabled={!jiraConnected || isLoadingJiraProjects}
 																	>
 																		{isLoadingJiraProjects ? "⏳" : "Load"}
-																	</button>
+																	</Button>
 																</div>
 															</div>
-															<div className="form-group">
+															<Field className="form-group">
 																<label>Issue type</label>
-																<select
+																<Select
 																	value={jiraIssueType}
 																	onChange={(event) => setJiraIssueType(event.target.value)}
 																	disabled={!jiraConnected || isLoadingJiraIssueTypes}
@@ -4231,24 +4230,24 @@ export default function App() {
 																			{issueTypeName}
 																		</option>
 																	))}
-																</select>
-															</div>
+																</Select>
+															</Field>
 															<div className="form-group jira-inline-action">
 																<label>Issue search</label>
 																<div className="jira-inline-controls">
-																	<input
+																	<Input
 																		placeholder={`Search ${(jiraIssueType || "issue").toLowerCase()} summaries`}
 																		value={jiraIssueQuery}
 																		onChange={(event) => setJiraIssueQuery(event.target.value)}
 																		disabled={!jiraConnected}
 																	/>
-																	<button
+																	<Button
 																		className="secondary"
 																		onClick={searchJiraIssues}
 																		disabled={!jiraConnected || !selectedJiraProjectKey || isSearchingJiraIssues}
 																	>
 																		{isSearchingJiraIssues ? "⏳" : "Search"}
-																	</button>
+																	</Button>
 																</div>
 															</div>
 														</div>
@@ -4281,7 +4280,7 @@ export default function App() {
 																					onClick={() => setSelectedJiraIssueKey(issue.key)}
 																				>
 																					<td>
-																						<input
+																						<Radio
 																							type="radio"
 																							name="jira-issue-selection"
 																							checked={selected}
@@ -4307,12 +4306,12 @@ export default function App() {
 														)}
 
 														<div className="panel-form button-row jira-import-actions">
-															<button
+															<Button
 																onClick={importRequirementsFromJira}
 																disabled={!selectedJiraIssueKey || isImportingFromJira || requirementActionDisabled}
 															>
 																{isImportingFromJira ? "⏳ Importing..." : `Import ${selectedJiraIssue?.key || jiraIssueType || "issue"}`}
-															</button>
+															</Button>
 															{selectedJiraIssue ? (
 																<span className="helper-text">
 																	Selected source: {selectedJiraIssue.key} — {selectedJiraIssue.summary}
@@ -4333,19 +4332,19 @@ export default function App() {
 															</div>
 														</div>
 														<div className="panel-form two-cols jira-search-grid">
-															<div className="form-group">
+															<Field className="form-group">
 																<label>Project search</label>
-																<input
+																<Input
 																	placeholder="Search Azure DevOps projects"
 																	value={azureDevOpsProjectQuery}
 																	onChange={(event) => setAzureDevOpsProjectQuery(event.target.value)}
 																	disabled={!azureDevOpsConnected}
 																/>
-															</div>
+															</Field>
 															<div className="form-group jira-inline-action">
 																<label>Project</label>
 																<div className="jira-inline-controls">
-																	<select
+																	<Select
 																		value={selectedAzureDevOpsProject}
 																		onChange={(event) => setSelectedAzureDevOpsProject(event.target.value)}
 																		disabled={!azureDevOpsConnected || !azureDevOpsProjects.length}
@@ -4356,19 +4355,19 @@ export default function App() {
 																				{project.name}
 																			</option>
 																		))}
-																	</select>
-																	<button
+																	</Select>
+																	<Button
 																		className="secondary"
 																		onClick={() => loadAzureDevOpsProjects(azureDevOpsProjectQuery)}
 																		disabled={!azureDevOpsConnected || isLoadingAzureDevOpsProjects}
 																	>
 																		{isLoadingAzureDevOpsProjects ? "⏳" : "Load"}
-																	</button>
+																	</Button>
 																</div>
 															</div>
-															<div className="form-group">
+															<Field className="form-group">
 																<label>Work item type</label>
-																<select
+																<Select
 																	value={azureDevOpsWorkItemType}
 																	onChange={(event) => setAzureDevOpsWorkItemType(event.target.value)}
 																	disabled={!azureDevOpsConnected || isLoadingAzureDevOpsWorkItemTypes}
@@ -4379,24 +4378,24 @@ export default function App() {
 																			{workItemTypeName}
 																		</option>
 																	))}
-																</select>
-															</div>
+																</Select>
+															</Field>
 															<div className="form-group jira-inline-action">
 																<label>Work item search</label>
 																<div className="jira-inline-controls">
-																	<input
+																	<Input
 																		placeholder={`Search ${(azureDevOpsWorkItemType || "work item").toLowerCase()} titles/descriptions`}
 																		value={azureDevOpsWorkItemQuery}
 																		onChange={(event) => setAzureDevOpsWorkItemQuery(event.target.value)}
 																		disabled={!azureDevOpsConnected}
 																	/>
-																	<button
+																	<Button
 																		className="secondary"
 																		onClick={searchAzureDevOpsWorkItems}
 																		disabled={!azureDevOpsConnected || !selectedAzureDevOpsProject || isSearchingAzureDevOpsWorkItems}
 																	>
 																		{isSearchingAzureDevOpsWorkItems ? "⏳" : "Search"}
-																	</button>
+																	</Button>
 																</div>
 															</div>
 														</div>
@@ -4429,7 +4428,7 @@ export default function App() {
 																					onClick={() => setSelectedAzureDevOpsWorkItemId(`${workItem.work_item_id}`)}
 																				>
 																					<td>
-																						<input
+																						<Radio
 																							type="radio"
 																							name="azure-devops-work-item-selection"
 																							checked={selected}
@@ -4457,14 +4456,14 @@ export default function App() {
 														)}
 
 														<div className="panel-form button-row jira-import-actions">
-															<button
+															<Button
 																onClick={importRequirementsFromAzureDevOps}
 																disabled={!selectedAzureDevOpsWorkItemId || isImportingFromAzureDevOps || requirementActionDisabled}
 															>
 																{isImportingFromAzureDevOps
 																	? "⏳ Importing..."
 																	: `Import ${selectedAzureDevOpsWorkItem ? `#${selectedAzureDevOpsWorkItem.work_item_id}` : azureDevOpsWorkItemType || "work item"}`}
-															</button>
+															</Button>
 															{selectedAzureDevOpsWorkItem ? (
 																<span className="helper-text">
 																	Selected source: #{selectedAzureDevOpsWorkItem.work_item_id} — {selectedAzureDevOpsWorkItem.title}
@@ -4477,7 +4476,7 @@ export default function App() {
 
 											{rawText && (
 												<div className="result-section compact-result-section">
-													<details className="collapsible-panel raw-text-panel">
+													<Disclosure className="collapsible-panel raw-text-panel">
 														<summary className="collapsible-panel-summary">
 															<span className="collapsible-panel-copy">
 																<span className="collapsible-panel-title">Raw extracted text</span>
@@ -4495,7 +4494,7 @@ export default function App() {
 																{rawText}
 															</pre>
 														</div>
-													</details>
+													</Disclosure>
 												</div>
 											)}
 
@@ -4534,28 +4533,28 @@ export default function App() {
 														</div>
 													</div>
 													<div className="panel-form two-cols jira-sync-controls">
-														<div className="form-group">
+														<Field className="form-group">
 															<label>Managed section title</label>
-															<input
+															<Input
 																value={jiraManagedSectionTitle}
 																onChange={(event) => setJiraManagedSectionTitle(event.target.value)}
 																placeholder={DEFAULT_JIRA_SYNC_SECTION_TITLE}
 															/>
-														</div>
+														</Field>
 														<div className="feedback-actions jira-sync-actions">
-															<button
+															<Button
 																className="secondary"
 																onClick={() => previewJiraSync()}
 																disabled={authActionDisabled || isPreviewingJiraSync || isApplyingJiraSync}
 															>
 																{isPreviewingJiraSync ? "⏳ Previewing..." : "Preview JIRA Update"}
-															</button>
-															<button
+															</Button>
+															<Button
 																onClick={applyJiraSync}
 																disabled={authActionDisabled || isApplyingJiraSync || !jiraSyncPreview || !jiraPreviewHasReadyIssue}
 															>
 																{isApplyingJiraSync ? "⏳ Syncing..." : "Push Ready Updates"}
-															</button>
+															</Button>
 														</div>
 													</div>
 
@@ -4581,9 +4580,9 @@ export default function App() {
 																		<div className="jira-sync-preview-meta">
 																			<span>Requirements: {(issue.requirement_ids || []).join(", ") || "—"}</span>
 																			{issue.issue_url ? (
-																				<a href={issue.issue_url} target="_blank" rel="noreferrer">
+																				<Link href={issue.issue_url} target="_blank" rel="noreferrer">
 																					Open in JIRA ↗
-																				</a>
+																				</Link>
 																			) : null}
 																		</div>
 																		{issue.conflict_reason ? <p className="jira-sync-preview-warning">{issue.conflict_reason}</p> : null}
@@ -4645,23 +4644,23 @@ export default function App() {
 														</div>
 													</div>
 													<div className="panel-form two-cols jira-sync-controls">
-														<div className="form-group">
+														<Field className="form-group">
 															<label>Managed section title</label>
-															<input
+															<Input
 																value={azureDevOpsManagedSectionTitle}
 																onChange={(event) => setAzureDevOpsManagedSectionTitle(event.target.value)}
 																placeholder={DEFAULT_AZURE_DEVOPS_SYNC_SECTION_TITLE}
 															/>
-														</div>
+														</Field>
 														<div className="feedback-actions jira-sync-actions">
-															<button
+															<Button
 																className="secondary"
 																onClick={() => previewAzureDevOpsSync()}
 																disabled={authActionDisabled || isPreviewingAzureDevOpsSync || isApplyingAzureDevOpsSync}
 															>
 																{isPreviewingAzureDevOpsSync ? "⏳ Previewing..." : "Preview Azure DevOps Update"}
-															</button>
-															<button
+															</Button>
+															<Button
 																onClick={applyAzureDevOpsSync}
 																disabled={
 																	authActionDisabled ||
@@ -4671,7 +4670,7 @@ export default function App() {
 																}
 															>
 																{isApplyingAzureDevOpsSync ? "⏳ Syncing..." : "Push Ready Updates"}
-															</button>
+															</Button>
 														</div>
 													</div>
 
@@ -4697,9 +4696,9 @@ export default function App() {
 																		<div className="jira-sync-preview-meta">
 																			<span>Requirements: {(workItem.requirement_ids || []).join(", ") || "—"}</span>
 																			{workItem.work_item_url ? (
-																				<a href={workItem.work_item_url} target="_blank" rel="noreferrer">
+																				<Link href={workItem.work_item_url} target="_blank" rel="noreferrer">
 																					Open in Azure DevOps ↗
-																				</a>
+																				</Link>
 																			) : null}
 																		</div>
 																		{workItem.conflict_reason ? (
@@ -4753,7 +4752,7 @@ export default function App() {
 													<p className="feedback-description">
 														Provide feedback on the extracted requirements. The AI will refine them based on your input.
 													</p>
-													<textarea
+													<Textarea
 														className="feedback-textarea"
 														placeholder="Enter your feedback here... e.g., 'Merge REQ-003 and REQ-004 into one', 'Split REQ-001 into multiple requirements', 'REQ-005 is too vague, make it more specific', 'Add a requirement for error handling', etc."
 														value={reqFeedback}
@@ -4761,23 +4760,23 @@ export default function App() {
 														rows={4}
 													/>
 													<div className="feedback-actions">
-														<button
+														<Button
 															onClick={() => parseRequirements(true)}
 															disabled={!reqFeedback.trim() || isParsing || requirementActionDisabled}
 															className="feedback-button"
 														>
 															{isParsing ? "⏳ Refining Requirements..." : "🔄 Implement Changes"}
-														</button>
+														</Button>
 													</div>
 												</div>
 											)}
 
 											<div className="panel-nav">
-												<button onClick={goNext} className="secondary">
+												<Button onClick={goNext} className="secondary">
 													Next
-												</button>
+												</Button>
 											</div>
-										</section>
+										</Surface>
 									)}
 
 									{activeTab === 1 && (
@@ -4840,9 +4839,9 @@ export default function App() {
 															</p>
 														</div>
 														{!canGenerateFromApprovedRequirements && (
-															<button type="button" className="secondary small" onClick={() => selectWorkflowTab(0)}>
+															<Button type="button" className="secondary small" onClick={() => selectWorkflowTab(0)}>
 																Review requirements
-															</button>
+															</Button>
 														)}
 													</div>
 												)}
@@ -4851,20 +4850,20 @@ export default function App() {
 											(!hasExistingTestCaseBaseline || upstreamChangedForImpact) ? (
 												<div className="panel-form button-row">
 													{upstreamChangedForImpact ? (
-														<button onClick={analyzeImpact} disabled={!canAnalyzeImpact || isAnalyzingImpact || testCaseActionDisabled}>
+														<Button onClick={analyzeImpact} disabled={!canAnalyzeImpact || isAnalyzingImpact || testCaseActionDisabled}>
 															{isAnalyzingImpact
 																? "⏳ Analyzing impact..."
 																: impactChangedItemCount
 																	? `Analyze Impact for ${impactChangedItemCount} Changed Item${impactChangedItemCount === 1 ? "" : "s"}`
 																	: "Analyze Impact for Changed Items"}
-														</button>
+														</Button>
 													) : (
-														<button
+														<Button
 															onClick={() => generateTestCases(false)}
 															disabled={!canGenerateFromApprovedRequirements || isGenerating || testCaseActionDisabled}
 														>
 															{isGenerating ? "⏳ Generating..." : `Generate from ${approvedRequirementCount || 0} Approved`}
-														</button>
+														</Button>
 													)}
 												</div>
 											) : null}
@@ -4890,9 +4889,9 @@ export default function App() {
 															{testCases.length} test case{testCases.length === 1 ? "" : "s"}
 														</span>
 													</div>
-													<div className="generate-results-tabs" role="tablist" aria-label="Generation result sections">
+													<TabList className="generate-results-tabs" role="tablist" aria-label="Generation result sections">
 														{generateResultTabs.map((tab) => (
-															<button
+															<Tab
 																type="button"
 																key={tab.id}
 																className={`generate-result-tab ${activeGenerateResultTab === tab.id ? "active" : ""} ${tab.variant ? `generate-result-tab-${tab.variant}` : ""}`}
@@ -4907,10 +4906,10 @@ export default function App() {
 																>
 																	{tab.badge}
 																</span>
-															</button>
+															</Tab>
 														))}
-													</div>
-													<div
+													</TabList>
+													<TabPanel
 														id="generate-result-panel"
 														className="generate-result-panel"
 														role="tabpanel"
@@ -4975,25 +4974,25 @@ export default function App() {
 																allowRefinement={allowLegacyTestCaseMutations}
 															/>
 														)}
-													</div>
+													</TabPanel>
 												</div>
 											) : (
-												<div className="result-section">
+												<Surface as="div" className="result-section">
 													<h3>Generated Test Cases</h3>
 													<span className="helper-text">
 														No generation run yet. Generate from approved requirements to view test cases, traceability, coverage, analysis,
 														and diagnostics.
 													</span>
-												</div>
+												</Surface>
 											)}
 
 											<div className="panel-nav">
-												<button onClick={goPrev} className="secondary">
+												<Button onClick={goPrev} className="secondary">
 													Back
-												</button>
-												<button onClick={goNext} disabled={testCases.length === 0}>
+												</Button>
+												<Button onClick={goNext} disabled={testCases.length === 0}>
 													Next
-												</button>
+												</Button>
 											</div>
 										</section>
 									)}

--- a/frontend/src/api/generated/api-contracts.d.ts
+++ b/frontend/src/api/generated/api-contracts.d.ts
@@ -1034,6 +1034,7 @@ export interface WorkspaceWorkItem {
 	project_name: string;
 	project_revision: number;
 	reason: string;
+	requirement_group_count?: number | null;
 	stage: "requirements" | "context" | "use_cases" | "impact_analysis" | "test_cases" | "automation" | "execution" | "review" | "reports";
 	status: "not_started" | "ready" | "blocked" | "completed" | "stale" | "failed" | "attention_required";
 	updated_at: string;

--- a/frontend/src/app/GlobalAppShell.jsx
+++ b/frontend/src/app/GlobalAppShell.jsx
@@ -1,3 +1,4 @@
+import { Button } from "../components/ui/controls";
 import { SlidersHorizontal } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 
@@ -30,7 +31,7 @@ export default function GlobalAppShell({ route, navigate, controls = null, compa
 			>
 				<GlobalNavigation route={route} navigate={navigate} />
 				{controls && compactControls ? (
-					<button
+					<Button
 						ref={controlsToggleRef}
 						type="button"
 						className="global-app-shell-controls-toggle secondary"
@@ -40,7 +41,7 @@ export default function GlobalAppShell({ route, navigate, controls = null, compa
 					>
 						<SlidersHorizontal aria-hidden="true" size={16} strokeWidth={2.2} />
 						{areControlsOpen ? "Close workspace controls" : "Open workspace controls"}
-					</button>
+					</Button>
 				) : null}
 				{controls ? (
 					<div id={controlsId} className="global-app-shell-controls" hidden={compactControls && !areControlsOpen}>

--- a/frontend/src/app/GlobalNavigation.jsx
+++ b/frontend/src/app/GlobalNavigation.jsx
@@ -1,3 +1,4 @@
+import { List, ListItem } from "../components/ui/collections";
 import RouteLink from "./RouteLink";
 import { GLOBAL_DESTINATIONS, GLOBAL_NAV_ITEMS } from "./workflowRoutes";
 
@@ -6,11 +7,11 @@ export default function GlobalNavigation({ route, navigate }) {
 
 	return (
 		<nav className="global-navigation" aria-label="Global navigation">
-			<ul className="global-navigation-list">
+			<List className="global-navigation-list">
 				{GLOBAL_NAV_ITEMS.map((item) => {
 					const isActive = activeDestination === item.id;
 					return (
-						<li key={item.id}>
+						<ListItem key={item.id}>
 							<RouteLink
 								to={item.path}
 								navigate={navigate}
@@ -19,10 +20,10 @@ export default function GlobalNavigation({ route, navigate }) {
 							>
 								{item.label}
 							</RouteLink>
-						</li>
+						</ListItem>
 					);
 				})}
-			</ul>
+			</List>
 		</nav>
 	);
 }

--- a/frontend/src/app/RouteLink.jsx
+++ b/frontend/src/app/RouteLink.jsx
@@ -1,3 +1,4 @@
+import { Link } from "../components/ui/controls";
 const shouldNavigateInApp = (event, target) =>
 	!event.defaultPrevented &&
 	event.button === 0 &&
@@ -18,8 +19,8 @@ export default function RouteLink({ to, navigate, replace = false, target, onCli
 	};
 
 	return (
-		<a href={to} target={target} onClick={handleClick} {...props}>
+		<Link href={to} target={target} onClick={handleClick} {...props}>
 			{children}
-		</a>
+		</Link>
 	);
 }

--- a/frontend/src/app/RoutePages.jsx
+++ b/frontend/src/app/RoutePages.jsx
@@ -1,3 +1,5 @@
+import { CircleAlert, LockKeyhole } from "lucide-react";
+import ProjectPageHeader from "../components/layout/ProjectPageHeader";
 import RouteLink from "./RouteLink";
 import { GLOBAL_DESTINATIONS, PROJECT_DESTINATIONS, PROJECT_NAV_ITEMS, buildGlobalPath, buildProjectPath } from "./workflowRoutes";
 
@@ -175,32 +177,77 @@ export function ProjectLoadingPage({ projectId = "" }) {
 	);
 }
 
-export function ProjectOverviewPage({ project, status = null, navigate, contextualTask = null }) {
+export function ProjectOverviewPage({
+	project,
+	status = null,
+	navigate,
+	contextualTask = null,
+	counts = {},
+	testCaseReview,
+	exportLocked,
+}) {
 	const projectId = project?.project_id || "";
-	const currentStage = status?.current_stage || project?.latest_stage || "requirements";
+	const attention = Boolean(testCaseReview && !testCaseReview.approved);
 
 	return (
-		<main id="main-content" className="route-page" aria-labelledby="project-overview-title" tabIndex={-1}>
-			<header className="route-page-header">
-				<span className="route-page-kicker">Project overview</span>
-				<h1 id="project-overview-title">{project?.name || "Project"}</h1>
-				<p>
-					Revision {status?.project_revision ?? project?.current_revision ?? 0} · Current stage {`${currentStage}`.replaceAll("_", " ")}
-				</p>
-			</header>
+		<main id="main-content" className="route-page project-overview-page" aria-labelledby="project-overview-title" tabIndex={-1}>
+			<ProjectPageHeader
+				title="Overview"
+				titleId="project-overview-title"
+				project={{ ...project, current_revision: status?.project_revision ?? project?.current_revision }}
+				navigate={navigate}
+			/>
 			{projectId ? (
 				<>
 					{contextualTask}
-					<ul className="route-workbench-list" aria-label="Project workbenches">
-						{PROJECT_NAV_ITEMS.filter((item) => item.id !== PROJECT_DESTINATIONS.OVERVIEW).map((item) => (
-							<li key={item.id}>
-								<RouteLink to={buildProjectPath(projectId, item.id)} navigate={navigate}>
-									<strong>{item.label}</strong>
-									<span>{item.title}</span>
-								</RouteLink>
-							</li>
+					<div className="overview-counts" aria-label="Project artifact counts">
+						{[
+							["requirements", counts.requirements],
+							["scenarios", counts.scenarios],
+							["test cases", counts.testCases],
+						].map(([label, count]) => (
+							<div key={label}>
+								<strong>{count ?? "—"}</strong>
+								<span>{label}</span>
+							</div>
 						))}
-					</ul>
+					</div>
+					<section className="overview-attention" aria-labelledby="overview-attention-title">
+						<h2 id="overview-attention-title">Needs your attention</h2>
+						{attention && (
+							<div className="overview-attention-row">
+								<CircleAlert aria-hidden="true" />
+								<strong>Test cases need refinement</strong>
+								<p>{testCaseReview.summary || "Review the quality findings before continuing."}</p>
+								<RouteLink to={buildProjectPath(projectId, "test-cases")} navigate={navigate}>
+									View test cases
+								</RouteLink>
+							</div>
+						)}
+						{exportLocked && (
+							<div className="overview-attention-row">
+								<LockKeyhole aria-hidden="true" />
+								<strong>Export is blocked</strong>
+								<p>Complete the required reviews to unlock exports.</p>
+								<RouteLink to={buildProjectPath(projectId, "reports")} navigate={navigate}>
+									View requirements for export
+								</RouteLink>
+							</div>
+						)}
+						{!attention && !exportLocked && <p>No additional issues need your attention.</p>}
+					</section>
+					<details className="overview-workbenches">
+						<summary>All project workbenches</summary>
+						<ul className="route-workbench-list" aria-label="Project workbenches">
+							{PROJECT_NAV_ITEMS.filter((item) => item.id !== PROJECT_DESTINATIONS.OVERVIEW).map((item) => (
+								<li key={item.id}>
+									<RouteLink to={buildProjectPath(projectId, item.id)} navigate={navigate}>
+										{item.label}
+									</RouteLink>
+								</li>
+							))}
+						</ul>
+					</details>
 				</>
 			) : (
 				<RecoveryLinks navigate={navigate} />

--- a/frontend/src/app/RoutePages.jsx
+++ b/frontend/src/app/RoutePages.jsx
@@ -1,3 +1,6 @@
+import { Alert, Disclosure } from "../components/ui/surfaces";
+import { Button } from "../components/ui/controls";
+import { List, ListItem, CollectionState } from "../components/ui/collections";
 import { CircleAlert, LockKeyhole } from "lucide-react";
 import ProjectPageHeader from "../components/layout/ProjectPageHeader";
 import RouteLink from "./RouteLink";
@@ -72,14 +75,14 @@ export function ProjectsRoutePage({ navigate, projects = [], isLoading = false, 
 				<p>Open a QA project at its stable overview and workflow destinations.</p>
 			</header>
 			{error ? (
-				<div className="route-inline-error" role="alert">
+				<Alert as="div" tone="danger" className="route-inline-error" role="alert">
 					<p>{error}</p>
 					{onRetry ? (
-						<button type="button" className="secondary" onClick={onRetry}>
+						<Button type="button" className="secondary" onClick={onRetry}>
 							Retry
-						</button>
+						</Button>
 					) : null}
-				</div>
+				</Alert>
 			) : null}
 			{isLoading ? (
 				<div className="route-project-list" aria-label="Loading projects">
@@ -87,9 +90,9 @@ export function ProjectsRoutePage({ navigate, projects = [], isLoading = false, 
 					<div className="route-project-card route-skeleton" />
 				</div>
 			) : projects.length ? (
-				<ul className="route-project-list" aria-label="QA projects">
+				<List variant="collection" className="route-project-list" aria-label="QA projects">
 					{projects.map((project) => (
-						<li className="route-project-card" key={project.project_id}>
+						<ListItem className="route-project-card" key={project.project_id}>
 							<div>
 								<strong>{project.name}</strong>
 								<span>Revision {project.current_revision ?? 0}</span>
@@ -97,14 +100,14 @@ export function ProjectsRoutePage({ navigate, projects = [], isLoading = false, 
 							<RouteLink className="route-secondary-link" to={buildProjectPath(project.project_id)} navigate={navigate}>
 								Open project
 							</RouteLink>
-						</li>
+						</ListItem>
 					))}
-				</ul>
+				</List>
 			) : (
-				<section className="route-page-card route-empty-state" aria-labelledby="projects-empty-title">
+				<CollectionState as="section" kind="empty" className="route-page-card route-empty-state" aria-labelledby="projects-empty-title">
 					<h2 id="projects-empty-title">No projects yet</h2>
 					<p>Use the project control to create your first QA project.</p>
-				</section>
+				</CollectionState>
 			)}
 		</main>
 	);
@@ -172,7 +175,11 @@ export function ProjectLoadingPage({ projectId = "" }) {
 				<h1 id="project-loading-title">Opening project…</h1>
 				<p>Loading the current workflow, status, and project evidence.</p>
 			</header>
-			{projectId ? <span className="route-loading-detail">Project {projectId}</span> : null}
+			{projectId ? (
+				<CollectionState as="span" kind="loading" className="route-loading-detail">
+					Project {projectId}
+				</CollectionState>
+			) : null}
 		</main>
 	);
 }
@@ -236,18 +243,18 @@ export function ProjectOverviewPage({
 						)}
 						{!attention && !exportLocked && <p>No additional issues need your attention.</p>}
 					</section>
-					<details className="overview-workbenches">
+					<Disclosure className="overview-workbenches">
 						<summary>All project workbenches</summary>
-						<ul className="route-workbench-list" aria-label="Project workbenches">
+						<List variant="collection" className="route-workbench-list" aria-label="Project workbenches">
 							{PROJECT_NAV_ITEMS.filter((item) => item.id !== PROJECT_DESTINATIONS.OVERVIEW).map((item) => (
-								<li key={item.id}>
+								<ListItem key={item.id}>
 									<RouteLink to={buildProjectPath(projectId, item.id)} navigate={navigate}>
 										{item.label}
 									</RouteLink>
-								</li>
+								</ListItem>
 							))}
-						</ul>
-					</details>
+						</List>
+					</Disclosure>
 				</>
 			) : (
 				<RecoveryLinks navigate={navigate} />

--- a/frontend/src/components/automation/AutomationPanel.jsx
+++ b/frontend/src/components/automation/AutomationPanel.jsx
@@ -235,7 +235,7 @@ export default function AutomationPanel({
 
 	return (
 		<section className="panel" aria-busy={isPreviewingExecution || isRunningExecution || undefined}>
-			<h2 className="panel-title">Automation</h2>
+			<h2 className="panel-title">Execution setup</h2>
 			<p className="panel-description">Review executable candidates and run approved browser cases through Playwright.</p>
 			<div className="panel-form two-cols">
 				<div className="form-group">

--- a/frontend/src/components/automation/AutomationPanel.jsx
+++ b/frontend/src/components/automation/AutomationPanel.jsx
@@ -1,3 +1,6 @@
+import { TableScroll, Table, List, ListItem } from "../ui/collections";
+import { Checkbox, Field, Input, Button } from "../ui/controls";
+import { Surface, Alert } from "../ui/surfaces";
 const renderBucketCount = (label, value, tone = "") => (
 	<span className={`workflow-diagnostics-pill ${tone}`.trim()}>
 		{label} {value || 0}
@@ -29,12 +32,12 @@ const renderCandidateTable = ({ candidates, selectedCandidateIds, setSelectedCan
 	};
 
 	return (
-		<div className="selection-table-wrapper" role="region" aria-label="Executable automation candidates table" tabIndex={0}>
-			<table className="selection-table">
+		<TableScroll className="selection-table-wrapper" role="region" aria-label="Executable automation candidates table" tabIndex={0}>
+			<Table className="selection-table">
 				<thead>
 					<tr>
-						<th>
-							<input
+						<th scope="col">
+							<Checkbox
 								ref={(input) => {
 									if (input) input.indeterminate = selectionIsMixed;
 								}}
@@ -46,10 +49,10 @@ const renderCandidateTable = ({ candidates, selectedCandidateIds, setSelectedCan
 								onChange={(event) => setSelectedCandidateIds(event.target.checked ? candidates.map((candidate) => candidate.id) : [])}
 							/>
 						</th>
-						<th>Case</th>
-						<th>Title</th>
-						<th>Spec</th>
-						<th>Traceability</th>
+						<th scope="col">Case</th>
+						<th scope="col">Title</th>
+						<th scope="col">Spec</th>
+						<th scope="col">Traceability</th>
 					</tr>
 				</thead>
 				<tbody>
@@ -61,7 +64,7 @@ const renderCandidateTable = ({ candidates, selectedCandidateIds, setSelectedCan
 						return (
 							<tr key={candidate.id}>
 								<td>
-									<input
+									<Checkbox
 										type="checkbox"
 										aria-label={selectionLabel}
 										checked={selectedIds.has(candidate.id)}
@@ -81,8 +84,8 @@ const renderCandidateTable = ({ candidates, selectedCandidateIds, setSelectedCan
 						);
 					})}
 				</tbody>
-			</table>
-		</div>
+			</Table>
+		</TableScroll>
 	);
 };
 
@@ -92,14 +95,14 @@ const renderManualList = (candidates) => {
 	}
 
 	return (
-		<ul className="jira-sync-apply-list">
+		<List className="jira-sync-apply-list">
 			{candidates.map((candidate) => (
-				<li key={candidate.id}>
+				<ListItem key={candidate.id}>
 					<strong>{candidate.source_test_case_id}</strong> - {candidate.title}
 					{candidate.review_reasons?.length ? `: ${candidate.review_reasons[0]}` : ""}
-				</li>
+				</ListItem>
 			))}
-		</ul>
+		</List>
 	);
 };
 
@@ -109,7 +112,7 @@ const renderUnsupportedList = (candidates, emptyMessage = "No unsupported cases 
 	}
 
 	return (
-		<div className="jira-sync-preview-list">
+		<List as="div" variant="grouped" className="jira-sync-preview-list">
 			{candidates.map((candidate) => (
 				<div key={candidate.id} className="jira-sync-preview-card conflict">
 					<div className="jira-sync-preview-header">
@@ -119,16 +122,16 @@ const renderUnsupportedList = (candidates, emptyMessage = "No unsupported cases 
 						</div>
 						<span className="jira-status-badge conflict">{candidate.status}</span>
 					</div>
-					<ul className="jira-sync-warning-list">
+					<List className="jira-sync-warning-list">
 						{candidate.unsupported_steps?.map((step) => (
-							<li key={`${candidate.id}-${step.step}-${step.reason_code}`}>
+							<ListItem key={`${candidate.id}-${step.step}-${step.reason_code}`}>
 								Step {step.step}: {step.reason_code}. {step.suggested_next_action}
-							</li>
+							</ListItem>
 						))}
-					</ul>
+					</List>
 				</div>
 			))}
-		</div>
+		</List>
 	);
 };
 
@@ -145,7 +148,7 @@ const renderRunResults = (runResult) => {
 	const reportPaths = [...new Set([...directReportPaths, ...resultReportPaths])];
 
 	return (
-		<div className="result-section">
+		<Surface as="div" className="result-section">
 			<div className="generate-results-header">
 				<div>
 					<h3>Execution Results</h3>
@@ -176,14 +179,14 @@ const renderRunResults = (runResult) => {
 				</p>
 			)}
 			{runResult.results?.length > 0 && (
-				<div className="selection-table-wrapper" role="region" aria-label="Execution results table" tabIndex={0}>
-					<table className="selection-table">
+				<TableScroll className="selection-table-wrapper" role="region" aria-label="Execution results table" tabIndex={0}>
+					<Table className="selection-table">
 						<thead>
 							<tr>
-								<th>Case</th>
-								<th>Status</th>
-								<th>Generated spec</th>
-								<th>Artifacts</th>
+								<th scope="col">Case</th>
+								<th scope="col">Status</th>
+								<th scope="col">Generated spec</th>
+								<th scope="col">Artifacts</th>
 							</tr>
 						</thead>
 						<tbody>
@@ -198,10 +201,10 @@ const renderRunResults = (runResult) => {
 								</tr>
 							))}
 						</tbody>
-					</table>
-				</div>
+					</Table>
+				</TableScroll>
 			)}
-		</div>
+		</Surface>
 	);
 };
 
@@ -234,43 +237,43 @@ export default function AutomationPanel({
 	const inputsDisabled = isPreviewingExecution || isRunningExecution || authActionDisabled;
 
 	return (
-		<section className="panel" aria-busy={isPreviewingExecution || isRunningExecution || undefined}>
+		<Surface as="section" className="panel" aria-busy={isPreviewingExecution || isRunningExecution || undefined}>
 			<h2 className="panel-title">Execution setup</h2>
 			<p className="panel-description">Review executable candidates and run approved browser cases through Playwright.</p>
 			<div className="panel-form two-cols">
-				<div className="form-group">
+				<Field className="form-group">
 					<label htmlFor="automation-target-environment">Target environment</label>
-					<input
+					<Input
 						id="automation-target-environment"
 						value={executionTargetEnvironment}
 						onChange={(event) => setExecutionTargetEnvironment(event.target.value)}
 						placeholder="staging, dev, customer-a"
 						disabled={inputsDisabled}
 					/>
-				</div>
-				<div className="form-group">
+				</Field>
+				<Field className="form-group">
 					<label htmlFor="automation-target-base-url">Target base URL</label>
-					<input
+					<Input
 						id="automation-target-base-url"
 						value={executionTargetBaseUrl}
 						onChange={(event) => setExecutionTargetBaseUrl(event.target.value)}
 						placeholder="Use backend default"
 						disabled={inputsDisabled}
 					/>
-				</div>
+				</Field>
 				<div className="feedback-actions">
-					<button className="secondary" onClick={() => previewExecution()} disabled={previewDisabled}>
+					<Button className="secondary" onClick={() => previewExecution()} disabled={previewDisabled}>
 						{isPreviewingExecution ? "Previewing..." : "Preview Execution"}
-					</button>
-					<button onClick={runApprovedExecution} disabled={runDisabled}>
+					</Button>
+					<Button onClick={runApprovedExecution} disabled={runDisabled}>
 						{isRunningExecution ? "Running..." : `Run ${selectedExecutableCount} Candidate${selectedExecutableCount === 1 ? "" : "s"}`}
-					</button>
+					</Button>
 				</div>
 			</div>
 			{executionError ? (
-				<div className="workflow-result-notice warning" role="alert">
+				<Alert as="div" tone="warning" className="workflow-result-notice warning" role="alert">
 					<p>{executionError}</p>
-				</div>
+				</Alert>
 			) : null}
 
 			{executionPreview ? (
@@ -290,12 +293,12 @@ export default function AutomationPanel({
 						{renderBucketCount("Invalid", previewSummary.invalid, "warning")}
 					</div>
 					{!previewIsActionable && (
-						<div className="workflow-result-notice warning" role="alert">
+						<Alert as="div" tone="warning" className="workflow-result-notice warning" role="alert">
 							<p>{executionPreview.consistencyMessage || "This stored preview must be refreshed before execution."}</p>
-						</div>
+						</Alert>
 					)}
 
-					<div className="result-section">
+					<Surface as="div" className="result-section">
 						<h3>Executable</h3>
 						{renderCandidateTable({
 							candidates: executableCandidates,
@@ -303,52 +306,52 @@ export default function AutomationPanel({
 							setSelectedCandidateIds: setSelectedExecutionCandidateIds,
 							selectionDisabled: !previewIsActionable || isPreviewingExecution || isRunningExecution || authActionDisabled,
 						})}
-					</div>
+					</Surface>
 
-					<div className="result-section">
+					<Surface as="div" className="result-section">
 						<h3>Manual</h3>
 						{renderManualList(executionPreview.manual || [])}
-					</div>
+					</Surface>
 
-					<div className="result-section">
+					<Surface as="div" className="result-section">
 						<h3>Unsupported</h3>
 						{renderUnsupportedList(executionPreview.unsupported || [])}
-					</div>
+					</Surface>
 
-					<div className="result-section">
+					<Surface as="div" className="result-section">
 						<h3>Invalid</h3>
 						{renderUnsupportedList(executionPreview.invalid || [], "No invalid cases in the current preview.")}
-					</div>
+					</Surface>
 
 					{executionPreview.warnings?.length > 0 && (
-						<ul className="jira-sync-warning-list">
+						<List className="jira-sync-warning-list">
 							{executionPreview.warnings.map((warning) => (
-								<li key={warning}>{warning}</li>
+								<ListItem key={warning}>{warning}</ListItem>
 							))}
-						</ul>
+						</List>
 					)}
 				</div>
 			) : (
-				<div className="result-section">
+				<Surface as="div" className="result-section">
 					<h3>Execution Preview</h3>
 					<span className="helper-text">
 						{testCases.length
 							? "No preview yet. Preview execution readiness for the current test cases."
 							: "Generate test cases to preview automation readiness."}
 					</span>
-				</div>
+				</Surface>
 			)}
 
 			{renderRunResults(executionRunResult)}
 
 			<div className="panel-nav">
-				<button onClick={goPrev} className="secondary">
+				<Button onClick={goPrev} className="secondary">
 					Back
-				</button>
-				<button onClick={goNext} disabled={testCases.length === 0}>
+				</Button>
+				<Button onClick={goNext} disabled={testCases.length === 0}>
 					Next
-				</button>
+				</Button>
 			</div>
-		</section>
+		</Surface>
 	);
 }

--- a/frontend/src/components/context/ContextInputsPanel.jsx
+++ b/frontend/src/components/context/ContextInputsPanel.jsx
@@ -1,3 +1,6 @@
+import { Surface } from "../ui/surfaces";
+import { Field, Input, Button, Checkbox } from "../ui/controls";
+import { List, ListItem } from "../ui/collections";
 export default function ContextInputsPanel({
 	appLink,
 	setAppLink,
@@ -19,50 +22,50 @@ export default function ContextInputsPanel({
 	goNext,
 }) {
 	return (
-		<section className="panel">
+		<Surface as="section" className="panel">
 			<h2 className="panel-title">Context Inputs</h2>
 			<p className="panel-description">Add links and references to enrich the test case generation context.</p>
 			<div className="panel-form two-cols">
-				<div className="form-group">
+				<Field className="form-group">
 					<label>Application link</label>
-					<input placeholder="https://your-app" value={appLink} onChange={(e) => setAppLink(e.target.value)} />
-				</div>
-				<div className="form-group">
+					<Input placeholder="https://your-app" value={appLink} onChange={(e) => setAppLink(e.target.value)} />
+				</Field>
+				<Field className="form-group">
 					<label>Prototype link</label>
-					<input placeholder="https://prototype" value={prototypeLink} onChange={(e) => setPrototypeLink(e.target.value)} />
-				</div>
-				<div className="form-group">
+					<Input placeholder="https://prototype" value={prototypeLink} onChange={(e) => setPrototypeLink(e.target.value)} />
+				</Field>
+				<Field className="form-group">
 					<label>Diagram links</label>
-					<input placeholder="Link1; Link2" value={diagramLinks} onChange={(e) => setDiagramLinks(e.target.value)} />
-				</div>
-				<div className="form-group">
+					<Input placeholder="Link1; Link2" value={diagramLinks} onChange={(e) => setDiagramLinks(e.target.value)} />
+				</Field>
+				<Field className="form-group">
 					<label>Image links</label>
-					<input placeholder="Link1; Link2" value={imageLinks} onChange={(e) => setImageLinks(e.target.value)} />
-				</div>
+					<Input placeholder="Link1; Link2" value={imageLinks} onChange={(e) => setImageLinks(e.target.value)} />
+				</Field>
 			</div>
 			{hasContextInputs && (
 				<div className="panel-form button-row">
-					<button onClick={analyzeContext} disabled={isAnalyzingContext || authActionDisabled}>
+					<Button onClick={analyzeContext} disabled={isAnalyzingContext || authActionDisabled}>
 						{isAnalyzingContext ? "⏳ Analyzing..." : "Analyze Context"}
-					</button>
+					</Button>
 					{enrichedContext && (
-						<button className="secondary" onClick={resetContextAnalysis}>
+						<Button className="secondary" onClick={resetContextAnalysis}>
 							Clear Analysis
-						</button>
+						</Button>
 					)}
 				</div>
 			)}
 			{enrichedContext?.grounded_context && (
-				<div className="result-section">
+				<Surface as="div" className="result-section">
 					<h3>Grounded Context</h3>
 					{(enrichedContext.grounded_context.artifact_sources || []).length > 0 && (
 						<div className="artifact-sources">
 							<h4>Artifact Sources</h4>
-							<ul className="artifact-source-list">
+							<List className="artifact-source-list">
 								{enrichedContext.grounded_context.artifact_sources.map((source) => (
-									<li key={source.id} className="artifact-source-item">
+									<ListItem key={source.id} className="artifact-source-item">
 										<label>
-											<input
+											<Checkbox
 												type="checkbox"
 												checked={selectedArtifactSourceIds.includes(source.id)}
 												onChange={(e) => {
@@ -74,45 +77,45 @@ export default function ContextInputsPanel({
 											<span>{source.url || source.id}</span>
 											{source.type && <span className="artifact-type">{source.type}</span>}
 										</label>
-									</li>
+									</ListItem>
 								))}
-							</ul>
+							</List>
 						</div>
 					)}
 					<div className="analysis-detail-grid">
 						{(enrichedContext.grounded_context.ui_elements || []).length > 0 && (
 							<div className="analysis-detail-block">
 								<h4>UI Elements</h4>
-								<ul className="analysis-detail-list">
+								<List className="analysis-detail-list">
 									{enrichedContext.grounded_context.ui_elements.slice(0, 6).map((el) => (
-										<li key={el.id}>
+										<ListItem key={el.id}>
 											{el.element_type}: {el.label || el.id}
-										</li>
+										</ListItem>
 									))}
-								</ul>
+								</List>
 							</div>
 						)}
 						{(enrichedContext.grounded_context.workflows || []).length > 0 && (
 							<div className="analysis-detail-block">
 								<h4>Workflows</h4>
-								<ul className="analysis-detail-list">
+								<List className="analysis-detail-list">
 									{enrichedContext.grounded_context.workflows.slice(0, 4).map((workflow) => (
-										<li key={workflow.id}>
+										<ListItem key={workflow.id}>
 											{workflow.name}: {(workflow.transitions || []).join(", ") || workflow.description}
-										</li>
+										</ListItem>
 									))}
-								</ul>
+								</List>
 							</div>
 						)}
 					</div>
-				</div>
+				</Surface>
 			)}
 			<div className="panel-nav">
-				<button onClick={goPrev} className="secondary">
+				<Button onClick={goPrev} className="secondary">
 					Back
-				</button>
-				<button onClick={goNext}>Next</button>
+				</Button>
+				<Button onClick={goNext}>Next</Button>
 			</div>
-		</section>
+		</Surface>
 	);
 }

--- a/frontend/src/components/export/ExportPanel.jsx
+++ b/frontend/src/components/export/ExportPanel.jsx
@@ -1,3 +1,6 @@
+import { List, ListItem, CollectionState } from "../ui/collections";
+import { Surface } from "../ui/surfaces";
+import { Checkbox, Textarea, Button } from "../ui/controls";
 const EXPORT_FORMATS = [
 	{ format: "csv", className: "csv", icon: "📄", label: "CSV", description: "Excel compatible" },
 	{ format: "excel", className: "excel", icon: "📊", label: "Excel", description: "Formatted .xlsx" },
@@ -72,13 +75,13 @@ function PlaywrightExecutionReport({ report }) {
 					{visibleReportPaths.length ? (
 						<>
 							<p className="helper-text">Consolidated report path:</p>
-							<ul className="playwright-report-paths">
+							<List className="playwright-report-paths">
 								{visibleReportPaths.map((path) => (
-									<li key={path}>
+									<ListItem key={path}>
 										<code>{path}</code>
-									</li>
+									</ListItem>
 								))}
-							</ul>
+							</List>
 						</>
 					) : (
 						<p className="helper-text">No Playwright report path was returned for this execution run.</p>
@@ -86,9 +89,9 @@ function PlaywrightExecutionReport({ report }) {
 					{hiddenReportPathCount > 0 && <p className="helper-text">+ {hiddenReportPathCount} additional report paths</p>}
 				</div>
 			) : (
-				<div className="playwright-report-card empty">
+				<CollectionState as="div" kind="empty" className="playwright-report-card empty">
 					<p>No Playwright execution report has been recorded yet.</p>
-				</div>
+				</CollectionState>
 			)}
 		</div>
 	);
@@ -116,7 +119,7 @@ export default function ExportPanel({
 	const executionReport = latestExecutionReport(executionRunResult, currentProject);
 
 	return (
-		<section className="panel">
+		<Surface as="section" className="panel">
 			<h2 className="panel-title">Export Test Cases</h2>
 			<p className="panel-description">Download your generated test cases as CSV, Excel, or JSON.</p>
 			{testCases.length > 0 && (
@@ -136,7 +139,7 @@ export default function ExportPanel({
 					{exportRequiresOverride && (
 						<div className="draft-export-override">
 							<label className="draft-export-toggle">
-								<input
+								<Checkbox
 									type="checkbox"
 									checked={draftExportOverrideRequested}
 									onChange={(event) => setDraftExportOverrideRequested(event.target.checked)}
@@ -144,7 +147,7 @@ export default function ExportPanel({
 								<span>Export draft anyway</span>
 							</label>
 							{draftExportOverrideRequested && (
-								<textarea
+								<Textarea
 									className="draft-export-reason"
 									placeholder="Reason for exporting this draft"
 									aria-label="Reason for exporting this draft"
@@ -167,7 +170,7 @@ export default function ExportPanel({
 				)}
 				<div className="export-buttons">
 					{EXPORT_FORMATS.map((item) => (
-						<button
+						<Button
 							key={item.format}
 							className={`export-btn ${item.className}`}
 							onClick={() => exportToFormat(item.format)}
@@ -176,15 +179,15 @@ export default function ExportPanel({
 							<span className="export-icon">{item.icon}</span>
 							<span className="export-label">{item.label}</span>
 							<span className="export-desc">{item.description}</span>
-						</button>
+						</Button>
 					))}
 				</div>
 			</div>
 			<div className="panel-nav">
-				<button onClick={goPrev} className="secondary">
+				<Button onClick={goPrev} className="secondary">
 					Back
-				</button>
+				</Button>
 			</div>
-		</section>
+		</Surface>
 	);
 }

--- a/frontend/src/components/generation/GeneratedTestCasesView.jsx
+++ b/frontend/src/components/generation/GeneratedTestCasesView.jsx
@@ -1,18 +1,9 @@
+import { useId, useState } from "react";
+import { ChevronRight } from "lucide-react";
 import { getTestCaseLinkedRequirementIds } from "../../utils/requirements";
-
-const getPriorityClass = (priority) => {
-	const map = { Critical: "priority-critical", High: "priority-high", Medium: "priority-medium", Low: "priority-low" };
-	return map[priority] || "";
-};
-
-const getStatusClass = (status) => {
-	const map = { Draft: "status-draft", Ready: "status-ready", "In Review": "status-review", Approved: "status-approved" };
-	return map[status] || "";
-};
 
 export default function GeneratedTestCasesView({
 	testCases,
-	templateFormat,
 	expandedRows,
 	onToggleRowExpansion,
 	feedback,
@@ -21,182 +12,157 @@ export default function GeneratedTestCasesView({
 	isGenerating,
 	testCaseActionDisabled,
 	allowRefinement = true,
+	qualityIssues = [],
 }) {
+	const [selectedId, setSelectedId] = useState(null);
+	const [query, setQuery] = useState("");
+	const searchId = useId();
+	const feedbackId = useId();
+	const cases = testCases.filter((tc) =>
+		[tc.id, tc.title, ...getTestCaseLinkedRequirementIds(tc)].join(" ").toLowerCase().includes(query.toLowerCase().trim())
+	);
+	const selected = cases.find((tc) => tc.id === selectedId) || cases[0];
+	const steps = selected?.steps || [];
+	const expanded = Boolean(expandedRows[selected?.id]);
+	const findings = selected
+		? qualityIssues.filter((issue) => new RegExp(`\\b${selected.id.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\b`).test(issue))
+		: [];
 	return (
 		<>
-			<div className="result-section generate-result-section">
-				<h3>Generated Test Cases</h3>
-				{testCases.length === 0 ? (
-					<span className="helper-text">No test cases generated yet.</span>
-				) : templateFormat === "table" ? (
-					<div className="test-cases-table-wrapper" role="region" aria-label="Generated test cases table" tabIndex={0}>
-						<table className="test-cases-table">
-							<thead>
-								<tr>
-									<th className="col-id">ID</th>
-									<th className="col-title">Title</th>
-									<th className="col-priority">Priority</th>
-									<th className="col-type">Type</th>
-									<th className="col-status">Status</th>
-									<th className="col-preconditions">Preconditions</th>
-									<th className="col-steps">Steps</th>
-									<th className="col-expected">Expected Result</th>
-									<th className="col-testdata">Test Data</th>
-									<th className="col-time">Est. Time</th>
-									<th className="col-automation">Automation</th>
-									<th className="col-component">Component</th>
-									<th className="col-tags">Linked Reqs</th>
-									<th className="col-tags">Tags</th>
-								</tr>
-							</thead>
-							<tbody>
-								{testCases.map((tc) => (
-									<tr key={tc.id} className={expandedRows[tc.id] ? "expanded" : ""} onClick={() => onToggleRowExpansion(tc.id)}>
-										<td className="tc-id">{tc.id}</td>
-										<td className="tc-title">
-											<div className="title-cell">
-												<span className="expand-icon">{expandedRows[tc.id] ? "▼" : "▶"}</span>
-												{tc.title}
-											</div>
-											{tc.description && <div className="tc-description">{tc.description}</div>}
-										</td>
-										<td className="tc-priority">
-											<span className={`priority-badge ${getPriorityClass(tc.priority)}`}>{tc.priority || "Medium"}</span>
-										</td>
-										<td className="tc-type">{tc.type || "Functional"}</td>
-										<td className="tc-status">
-											<span className={`status-badge ${getStatusClass(tc.status)}`}>{tc.status || "Draft"}</span>
-										</td>
-										<td className="tc-preconditions">{tc.preconditions || "-"}</td>
-										<td className="tc-steps">
-											<ol>
-												{tc.steps?.slice(0, expandedRows[tc.id] ? undefined : 2).map((step, index) => (
-													<li key={`${tc.id}-step-${step.step || index + 1}`}>
-														<strong>{step.action}</strong>
-														<span className="step-expected">→ {step.expected}</span>
-														{step.test_data && <span className="step-data">📋 {step.test_data}</span>}
-													</li>
-												))}
-												{!expandedRows[tc.id] && tc.steps?.length > 2 && (
-													<li className="more-steps">+{tc.steps.length - 2} more steps...</li>
-												)}
-											</ol>
-										</td>
-										<td className="tc-expected-result">{tc.expected_result || "-"}</td>
-										<td className="tc-testdata">{tc.test_data || "-"}</td>
-										<td className="tc-time">{tc.estimated_time || "-"}</td>
-										<td className="tc-automation">
-											<span className={`automation-badge ${tc.automation_status?.replace(/\s/g, "-").toLowerCase() || "manual"}`}>
-												{tc.automation_status || "Manual"}
-											</span>
-										</td>
-										<td className="tc-component">{tc.component || "-"}</td>
-										<td className="tc-tags">
-											{getTestCaseLinkedRequirementIds(tc).map((requirementId) => (
-												<span key={`${tc.id}-${requirementId}`} className="tag traceability-case-tag">
-													{requirementId}
-												</span>
-											))}
-										</td>
-										<td className="tc-tags">
-											{tc.tags?.map((tag) => (
-												<span key={tag} className="tag">
-													{tag}
-												</span>
-											))}
-										</td>
-									</tr>
+			<section className="test-review-workspace" aria-label="Generated test cases">
+				<div className="test-review-list">
+					<h2>Generated Test Cases</h2>
+					<label htmlFor={searchId} className="sr-only">
+						Search test cases
+					</label>
+					<input
+						id={searchId}
+						type="search"
+						placeholder="Search test cases"
+						value={query}
+						onChange={(event) => setQuery(event.target.value)}
+					/>
+					<p className="test-list-count" role="status">
+						{cases.length} of {testCases.length} test cases
+					</p>
+					<div className="test-review-items">
+						{cases.map((tc) => (
+							<button
+								key={tc.id}
+								type="button"
+								className={`test-review-item ${selected?.id === tc.id ? "selected" : ""}`}
+								aria-pressed={selected?.id === tc.id}
+								aria-controls="selected-test-case"
+								onClick={() => setSelectedId(tc.id)}
+							>
+								<span>
+									<small>{tc.id}</small>
+									<strong>{tc.title}</strong>
+									<span>
+										{tc.priority || "Medium"} priority · {getTestCaseLinkedRequirementIds(tc).join(", ") || "No linked requirements"}
+									</span>
+								</span>
+								<ChevronRight size={18} aria-hidden="true" />
+							</button>
+						))}
+					</div>
+					{!cases.length && <p>{testCases.length ? "No test cases match your search." : "No test cases generated yet."}</p>}
+				</div>
+				<section className="test-review-detail" id="selected-test-case" aria-label="Selected test case" aria-live="polite">
+					{selected ? (
+						<>
+							<span className="case-id">{selected.id}</span>
+							<p className="test-detail-meta">
+								{selected.type || "Functional"} · {selected.priority || "Medium"} priority ·{" "}
+								{getTestCaseLinkedRequirementIds(selected).join(", ")}
+							</p>
+							<h2>{selected.title}</h2>
+							{selected.description && <p>{selected.description}</p>}
+							{findings.length > 0 && (
+								<details className="test-inline-findings">
+									<summary>Quality findings for {selected.id}</summary>
+									<ul>
+										{findings.map((issue) => (
+											<li key={issue}>{issue}</li>
+										))}
+									</ul>
+								</details>
+							)}
+							<h3>Preconditions</h3>
+							<p>{selected.preconditions || "None specified."}</p>
+							<div className="test-steps-heading">
+								<h3>Steps and expected results</h3>
+								<span>{steps.length} steps</span>
+							</div>
+							<ol className="test-detail-steps">
+								{steps.slice(0, expanded ? undefined : 2).map((step, index) => (
+									<li key={`${selected.id}-${index}`}>
+										<p>{step.action}</p>
+										<p>
+											<strong>Expected</strong> {step.expected || "Not specified"}
+										</p>
+										{step.test_data && (
+											<p>
+												<strong>Test data</strong> {step.test_data}
+											</p>
+										)}
+									</li>
 								))}
-							</tbody>
-						</table>
-					</div>
-				) : (
-					<div className="test-cases-grid">
-						{testCases.map((tc) => {
-							const linkedRequirementIds = getTestCaseLinkedRequirementIds(tc);
-							return (
-								<div key={tc.id} className="case-card">
-									<div className="case-header">
-										<span className="case-id">{tc.id}</span>
-										<span className="case-title">{tc.title}</span>
-										<span className={`priority-badge ${getPriorityClass(tc.priority)}`}>{tc.priority}</span>
-									</div>
-									{tc.description && <div className="case-description">{tc.description}</div>}
-									<div className="case-meta">
-										<span className="meta-item">
-											<strong>Type:</strong> {tc.type}
-										</span>
-										<span className={`status-badge ${getStatusClass(tc.status)}`}>{tc.status}</span>
-										<span className="meta-item">
-											<strong>Est:</strong> {tc.estimated_time}
-										</span>
-									</div>
-									{linkedRequirementIds.length > 0 && (
-										<div className="case-tags traceability-links">
-											{linkedRequirementIds.map((requirementId) => (
-												<span key={`${tc.id}-linked-${requirementId}`} className="tag traceability-case-tag">
-													{requirementId}
-												</span>
-											))}
+							</ol>
+							{steps.length > 2 && (
+								<button
+									className="secondary small"
+									type="button"
+									aria-expanded={expanded}
+									onClick={() => onToggleRowExpansion(selected.id)}
+								>
+									{expanded ? "Show fewer steps" : `Show all ${steps.length} steps`}
+								</button>
+							)}
+							<h3>Expected result</h3>
+							<p>{selected.expected_result || "Not specified."}</p>
+							<details className="test-case-metadata">
+								<summary>Test data and metadata</summary>
+								<dl>
+									{Object.entries({
+										"Test data": selected.test_data,
+										"Estimated time": selected.estimated_time,
+										"Case status": selected.status || "Draft",
+										Automation: selected.automation_status || "Manual",
+										Component: selected.component,
+										"Linked requirements": getTestCaseLinkedRequirementIds(selected).join(", "),
+										Tags: selected.tags?.join(", "),
+									}).map(([label, value]) => (
+										<div key={label}>
+											<dt>{label}</dt>
+											<dd>{value || "Not specified"}</dd>
 										</div>
-									)}
-									{tc.preconditions && <div className="case-preconditions">{tc.preconditions}</div>}
-									<div className="case-steps">
-										<strong>Steps</strong>
-										<ol>
-											{tc.steps?.map((step, index) => (
-												<li key={`${tc.id}-card-step-${step.step || index + 1}`}>
-													<span className="step-action">
-														{step.step || index + 1}. {step.action}
-													</span>
-													<span className="step-expected">→ {step.expected}</span>
-													{step.test_data && <span className="step-data">📋 {step.test_data}</span>}
-												</li>
-											))}
-										</ol>
-									</div>
-									{tc.expected_result && (
-										<div className="case-expected">
-											<strong>Expected Result:</strong> {tc.expected_result}
-										</div>
-									)}
-									{tc.tags && tc.tags.length > 0 && (
-										<div className="case-tags">
-											{tc.tags.map((tag) => (
-												<span key={tag} className="tag">
-													{tag}
-												</span>
-											))}
-										</div>
-									)}
-								</div>
-							);
-						})}
-					</div>
-				)}
-			</div>
-
+									))}
+								</dl>
+								<p>Case status and automation intent do not indicate quality approval or execution readiness.</p>
+							</details>
+						</>
+					) : (
+						<p>Select a test case to review its details.</p>
+					)}
+				</section>
+			</section>
 			{testCases.length > 0 && allowRefinement && (
-				<div className="feedback-section">
+				<section className="feedback-section">
 					<h3>Human Feedback</h3>
-					<p className="feedback-description">Provide feedback on the generated test cases. The AI will refine them based on your input.</p>
+					<label htmlFor={feedbackId}>Changes to the test suite</label>
 					<textarea
+						id={feedbackId}
 						className="feedback-textarea"
-						placeholder="Enter your feedback here... e.g., 'Add more negative test cases for upload feature', 'TC-003 needs more detailed steps', 'Include security test cases', etc."
+						placeholder="Describe the changes needed…"
 						value={feedback}
 						onChange={(event) => onFeedbackChange(event.target.value)}
 						rows={4}
 					/>
-					<div className="feedback-actions">
-						<button
-							onClick={onRefineTestCases}
-							disabled={!feedback.trim() || isGenerating || testCaseActionDisabled}
-							className="feedback-button"
-						>
-							{isGenerating ? "⏳ Updating Test Cases..." : "🔄 Implement Changes"}
-						</button>
-					</div>
-				</div>
+					<button onClick={onRefineTestCases} disabled={!feedback.trim() || isGenerating || testCaseActionDisabled}>
+						{isGenerating ? "Updating test cases…" : "Implement Changes"}
+					</button>
+				</section>
 			)}
 		</>
 	);

--- a/frontend/src/components/generation/GeneratedTestCasesView.jsx
+++ b/frontend/src/components/generation/GeneratedTestCasesView.jsx
@@ -1,3 +1,6 @@
+import { ListDetail, ResultCount, List, SelectableItem, ListItem, CollectionState } from "../ui/collections";
+import { Input, Button, Textarea } from "../ui/controls";
+import { Disclosure } from "../ui/surfaces";
 import { useId, useState } from "react";
 import { ChevronRight } from "lucide-react";
 import { getTestCaseLinkedRequirementIds } from "../../utils/requirements";
@@ -29,25 +32,25 @@ export default function GeneratedTestCasesView({
 		: [];
 	return (
 		<>
-			<section className="test-review-workspace" aria-label="Generated test cases">
+			<ListDetail className="test-review-workspace" aria-label="Generated test cases">
 				<div className="test-review-list">
 					<h2>Generated Test Cases</h2>
 					<label htmlFor={searchId} className="sr-only">
 						Search test cases
 					</label>
-					<input
+					<Input
 						id={searchId}
 						type="search"
 						placeholder="Search test cases"
 						value={query}
 						onChange={(event) => setQuery(event.target.value)}
 					/>
-					<p className="test-list-count" role="status">
+					<ResultCount as="p" className="test-list-count" role="status">
 						{cases.length} of {testCases.length} test cases
-					</p>
-					<div className="test-review-items">
+					</ResultCount>
+					<List as="div" variant="grouped" className="test-review-items">
 						{cases.map((tc) => (
-							<button
+							<SelectableItem
 								key={tc.id}
 								type="button"
 								className={`test-review-item ${selected?.id === tc.id ? "selected" : ""}`}
@@ -63,10 +66,19 @@ export default function GeneratedTestCasesView({
 									</span>
 								</span>
 								<ChevronRight size={18} aria-hidden="true" />
-							</button>
+							</SelectableItem>
 						))}
-					</div>
-					{!cases.length && <p>{testCases.length ? "No test cases match your search." : "No test cases generated yet."}</p>}
+					</List>
+					{!cases.length && (
+						<CollectionState kind={testCases.length ? "filtered" : "empty"}>
+							<p>{testCases.length ? "No test cases match your search." : "No test cases generated yet."}</p>
+							{testCases.length > 0 && (
+								<Button variant="secondary" size="compact" onClick={() => setQuery("")}>
+									Clear search
+								</Button>
+							)}
+						</CollectionState>
+					)}
 				</div>
 				<section className="test-review-detail" id="selected-test-case" aria-label="Selected test case" aria-live="polite">
 					{selected ? (
@@ -79,14 +91,14 @@ export default function GeneratedTestCasesView({
 							<h2>{selected.title}</h2>
 							{selected.description && <p>{selected.description}</p>}
 							{findings.length > 0 && (
-								<details className="test-inline-findings">
+								<Disclosure className="test-inline-findings">
 									<summary>Quality findings for {selected.id}</summary>
-									<ul>
+									<List>
 										{findings.map((issue) => (
-											<li key={issue}>{issue}</li>
+											<ListItem key={issue}>{issue}</ListItem>
 										))}
-									</ul>
-								</details>
+									</List>
+								</Disclosure>
 							)}
 							<h3>Preconditions</h3>
 							<p>{selected.preconditions || "None specified."}</p>
@@ -94,9 +106,9 @@ export default function GeneratedTestCasesView({
 								<h3>Steps and expected results</h3>
 								<span>{steps.length} steps</span>
 							</div>
-							<ol className="test-detail-steps">
+							<List as="ol" className="test-detail-steps">
 								{steps.slice(0, expanded ? undefined : 2).map((step, index) => (
-									<li key={`${selected.id}-${index}`}>
+									<ListItem key={`${selected.id}-${index}`}>
 										<p>{step.action}</p>
 										<p>
 											<strong>Expected</strong> {step.expected || "Not specified"}
@@ -106,22 +118,22 @@ export default function GeneratedTestCasesView({
 												<strong>Test data</strong> {step.test_data}
 											</p>
 										)}
-									</li>
+									</ListItem>
 								))}
-							</ol>
+							</List>
 							{steps.length > 2 && (
-								<button
+								<Button
 									className="secondary small"
 									type="button"
 									aria-expanded={expanded}
 									onClick={() => onToggleRowExpansion(selected.id)}
 								>
 									{expanded ? "Show fewer steps" : `Show all ${steps.length} steps`}
-								</button>
+								</Button>
 							)}
 							<h3>Expected result</h3>
 							<p>{selected.expected_result || "Not specified."}</p>
-							<details className="test-case-metadata">
+							<Disclosure className="test-case-metadata">
 								<summary>Test data and metadata</summary>
 								<dl>
 									{Object.entries({
@@ -140,18 +152,18 @@ export default function GeneratedTestCasesView({
 									))}
 								</dl>
 								<p>Case status and automation intent do not indicate quality approval or execution readiness.</p>
-							</details>
+							</Disclosure>
 						</>
 					) : (
 						<p>Select a test case to review its details.</p>
 					)}
 				</section>
-			</section>
+			</ListDetail>
 			{testCases.length > 0 && allowRefinement && (
 				<section className="feedback-section">
 					<h3>Human Feedback</h3>
 					<label htmlFor={feedbackId}>Changes to the test suite</label>
-					<textarea
+					<Textarea
 						id={feedbackId}
 						className="feedback-textarea"
 						placeholder="Describe the changes needed…"
@@ -159,9 +171,9 @@ export default function GeneratedTestCasesView({
 						onChange={(event) => onFeedbackChange(event.target.value)}
 						rows={4}
 					/>
-					<button onClick={onRefineTestCases} disabled={!feedback.trim() || isGenerating || testCaseActionDisabled}>
+					<Button onClick={onRefineTestCases} disabled={!feedback.trim() || isGenerating || testCaseActionDisabled}>
 						{isGenerating ? "Updating test cases…" : "Implement Changes"}
-					</button>
+					</Button>
 				</section>
 			)}
 		</>

--- a/frontend/src/components/generation/RequirementAnalysisPanel.jsx
+++ b/frontend/src/components/generation/RequirementAnalysisPanel.jsx
@@ -1,3 +1,5 @@
+import { CollectionState, List, ListItem } from "../ui/collections";
+import { Surface, Disclosure } from "../ui/surfaces";
 export default function RequirementAnalysisPanel({
 	requirementAnalysis,
 	coverageMetrics,
@@ -7,16 +9,16 @@ export default function RequirementAnalysisPanel({
 }) {
 	if (requirementAnalysis.length === 0) {
 		return (
-			<div className="generate-result-empty">
+			<CollectionState as="div" kind="empty" className="generate-result-empty">
 				<h3>Requirement Analysis</h3>
 				<p>No requirement analysis is available for this run.</p>
-			</div>
+			</CollectionState>
 		);
 	}
 
 	return (
-		<div className="result-section">
-			<details className="collapsible-panel" open>
+		<Surface as="div" className="result-section">
+			<Disclosure className="collapsible-panel" open>
 				<summary className="collapsible-panel-summary">
 					<span className="collapsible-panel-copy">
 						<span className="collapsible-panel-title">Requirement Analysis</span>
@@ -64,7 +66,7 @@ export default function RequirementAnalysisPanel({
 							</span>
 						</div>
 					)}
-					<div className="analysis-card-list">
+					<List as="div" variant="grouped" className="analysis-card-list">
 						{requirementAnalysis.map((analysis) => {
 							const summary = getRequirementAnalysisSummary(analysis.requirement_id);
 							const gaps = getRequirementAnalysisGaps(analysis.requirement_id);
@@ -102,81 +104,81 @@ export default function RequirementAnalysisPanel({
 									<div className="analysis-detail-grid">
 										<div className="analysis-detail-block">
 											<h4>Business rules</h4>
-											<ul className="analysis-detail-list">
+											<List className="analysis-detail-list">
 												{(analysis.business_rules || []).slice(0, 2).map((rule) => (
-													<li key={rule.id}>{rule.title}</li>
+													<ListItem key={rule.id}>{rule.title}</ListItem>
 												))}
-											</ul>
+											</List>
 										</div>
 										<div className="analysis-detail-block">
 											<h4>Constraints</h4>
-											<ul className="analysis-detail-list">
+											<List className="analysis-detail-list">
 												{(analysis.field_constraints || []).slice(0, 2).map((constraint) => (
-													<li key={constraint.id}>
+													<ListItem key={constraint.id}>
 														{constraint.field_name}: {constraint.description}
-													</li>
+													</ListItem>
 												))}
-											</ul>
+											</List>
 										</div>
 										<div className="analysis-detail-block">
 											<h4>Permissions</h4>
-											<ul className="analysis-detail-list">
+											<List className="analysis-detail-list">
 												{(analysis.role_permissions || []).slice(0, 2).map((permission) => (
-													<li key={permission.id}>
+													<ListItem key={permission.id}>
 														{permission.role}: {permission.action}
-													</li>
+													</ListItem>
 												))}
-											</ul>
+											</List>
 										</div>
 										<div className="analysis-detail-block">
 											<h4>Transitions</h4>
-											<ul className="analysis-detail-list">
+											<List className="analysis-detail-list">
 												{(analysis.state_transitions || []).slice(0, 2).map((transition) => (
-													<li key={transition.id}>
+													<ListItem key={transition.id}>
 														{transition.from_state} → {transition.to_state}
-													</li>
+													</ListItem>
 												))}
-											</ul>
+											</List>
 										</div>
 										<div className="analysis-detail-block">
 											<h4>Risks</h4>
-											<ul className="analysis-detail-list">
+											<List className="analysis-detail-list">
 												{(analysis.risk_signals || []).slice(0, 2).map((risk) => (
-													<li key={risk.id}>
+													<ListItem key={risk.id}>
 														{risk.severity}: {risk.title}
-													</li>
+													</ListItem>
 												))}
-											</ul>
+											</List>
 										</div>
 									</div>
 									{hasGaps && (
 										<div className="analysis-gap-block">
 											<strong>Coverage gaps</strong>
-											<ul className="analysis-gap-list">
+											<List className="analysis-gap-list">
 												{gaps.highRisks.slice(0, 2).map((item) => (
-													<li key={item}>{item}</li>
+													<ListItem key={item}>{item}</ListItem>
 												))}
 												{gaps.rules.slice(0, 2).map((item) => (
-													<li key={item}>{item}</li>
+													<ListItem key={item}>{item}</ListItem>
 												))}
 												{gaps.constraints.slice(0, 2).map((item) => (
-													<li key={item}>{item}</li>
+													<ListItem key={item}>{item}</ListItem>
 												))}
 												{gaps.permissions.slice(0, 2).map((item) => (
-													<li key={item}>{item}</li>
+													<ListItem key={item}>{item}</ListItem>
 												))}
 												{gaps.transitions.slice(0, 2).map((item) => (
-													<li key={item}>{item}</li>
+													<ListItem key={item}>{item}</ListItem>
 												))}
-											</ul>
+											</List>
 										</div>
 									)}
 								</div>
 							);
 						})}
-					</div>
+					</List>
 				</div>
-			</details>
-		</div>
+			</Disclosure>
+		</Surface>
 	);
 }

--- a/frontend/src/components/generation/ScenarioCoveragePanel.jsx
+++ b/frontend/src/components/generation/ScenarioCoveragePanel.jsx
@@ -1,3 +1,5 @@
+import { CollectionState, List } from "../ui/collections";
+import { Surface, Disclosure } from "../ui/surfaces";
 export default function ScenarioCoveragePanel({
 	coveragePlan,
 	coveredScenarioTotal,
@@ -9,16 +11,16 @@ export default function ScenarioCoveragePanel({
 }) {
 	if (coveragePlan.length === 0) {
 		return (
-			<div className="generate-result-empty">
+			<CollectionState as="div" kind="empty" className="generate-result-empty">
 				<h3>Scenario Coverage Plan</h3>
 				<p>No scenario coverage plan is available for this run.</p>
-			</div>
+			</CollectionState>
 		);
 	}
 
 	return (
-		<div className="result-section">
-			<details className="collapsible-panel" open>
+		<Surface as="div" className="result-section">
+			<Disclosure className="collapsible-panel" open>
 				<summary className="collapsible-panel-summary">
 					<span className="collapsible-panel-copy">
 						<span className="collapsible-panel-title">Scenario Coverage Plan</span>
@@ -43,7 +45,7 @@ export default function ScenarioCoveragePanel({
 					</span>
 				</summary>
 				<div className="collapsible-panel-body">
-					<div className="coverage-plan-list">
+					<List as="div" variant="grouped" className="coverage-plan-list">
 						{coveragePlan.map((plan) => {
 							const summary = getRequirementScenarioSummary(plan.requirement_id);
 							const missingScenarioTypes = new Set(summary?.missing_scenario_types || []);
@@ -77,9 +79,9 @@ export default function ScenarioCoveragePanel({
 								</div>
 							);
 						})}
-					</div>
+					</List>
 				</div>
-			</details>
-		</div>
+			</Disclosure>
+		</Surface>
 	);
 }

--- a/frontend/src/components/generation/TestCaseQualitySummary.jsx
+++ b/frontend/src/components/generation/TestCaseQualitySummary.jsx
@@ -1,0 +1,31 @@
+import { CircleAlert, CircleCheck } from "lucide-react";
+
+export default function TestCaseQualitySummary({ review, meta, exportLocked }) {
+	if (!review) return null;
+	const Icon = review.approved ? CircleCheck : CircleAlert;
+	const findings = [...new Set([...(review.blocking_issues || []), ...(review.unmet_criteria || [])])];
+	return (
+		<section className={`test-quality-summary ${review.approved ? "approved" : "attention"}`} aria-label="Test case quality">
+			<Icon size={28} aria-hidden="true" />
+			<div>
+				<strong>{review.approved ? "Machine quality check passed" : "Needs refinement"}</strong>
+				<p>
+					{meta.scoreLabel}
+					{meta.thresholdLabel ? ` · ${meta.thresholdLabel}` : ""}
+					{exportLocked ? " · Export is blocked." : ""}
+				</p>
+				<details className="test-quality-findings">
+					<summary>View findings</summary>
+					<p>{review.summary || "No review summary available."}</p>
+					{findings.length > 0 && (
+						<ul>
+							{findings.map((issue) => (
+								<li key={issue}>{issue}</li>
+							))}
+						</ul>
+					)}
+				</details>
+			</div>
+		</section>
+	);
+}

--- a/frontend/src/components/generation/TestCaseQualitySummary.jsx
+++ b/frontend/src/components/generation/TestCaseQualitySummary.jsx
@@ -1,3 +1,4 @@
+import { Disclosure } from "../ui/surfaces";
 import { CircleAlert, CircleCheck } from "lucide-react";
 
 export default function TestCaseQualitySummary({ review, meta, exportLocked }) {
@@ -14,7 +15,7 @@ export default function TestCaseQualitySummary({ review, meta, exportLocked }) {
 					{meta.thresholdLabel ? ` · ${meta.thresholdLabel}` : ""}
 					{exportLocked ? " · Export is blocked." : ""}
 				</p>
-				<details className="test-quality-findings">
+				<Disclosure className="test-quality-findings">
 					<summary>View findings</summary>
 					<p>{review.summary || "No review summary available."}</p>
 					{findings.length > 0 && (
@@ -24,7 +25,7 @@ export default function TestCaseQualitySummary({ review, meta, exportLocked }) {
 							))}
 						</ul>
 					)}
-				</details>
+				</Disclosure>
 			</div>
 		</section>
 	);

--- a/frontend/src/components/generation/TestCaseQualitySummary.jsx
+++ b/frontend/src/components/generation/TestCaseQualitySummary.jsx
@@ -1,3 +1,4 @@
+import { List, ListItem } from "../ui/collections";
 import { Disclosure } from "../ui/surfaces";
 import { CircleAlert, CircleCheck } from "lucide-react";
 
@@ -19,11 +20,11 @@ export default function TestCaseQualitySummary({ review, meta, exportLocked }) {
 					<summary>View findings</summary>
 					<p>{review.summary || "No review summary available."}</p>
 					{findings.length > 0 && (
-						<ul>
+						<List>
 							{findings.map((issue) => (
-								<li key={issue}>{issue}</li>
+								<ListItem key={issue}>{issue}</ListItem>
 							))}
-						</ul>
+						</List>
 					)}
 				</Disclosure>
 			</div>

--- a/frontend/src/components/generation/TraceabilityMatrixPanel.jsx
+++ b/frontend/src/components/generation/TraceabilityMatrixPanel.jsx
@@ -1,3 +1,5 @@
+import { CollectionState, TableScroll, Table } from "../ui/collections";
+import { Surface } from "../ui/surfaces";
 import { getRequirementContextPath } from "../../utils/requirements";
 
 export default function TraceabilityMatrixPanel({
@@ -9,15 +11,15 @@ export default function TraceabilityMatrixPanel({
 }) {
 	if (approvedRequirements.length === 0) {
 		return (
-			<div className="generate-result-empty">
+			<CollectionState as="div" kind="empty" className="generate-result-empty">
 				<h3>Traceability Matrix</h3>
 				<p>No approved requirements are available to trace for this run.</p>
-			</div>
+			</CollectionState>
 		);
 	}
 
 	return (
-		<div className="result-section">
+		<Surface as="div" className="result-section">
 			<h3>Traceability Matrix</h3>
 			<div className="workflow-diagnostics-pills">
 				<span className="workflow-diagnostics-pill">
@@ -30,15 +32,15 @@ export default function TraceabilityMatrixPanel({
 					Scenario coverage {coverageMetrics?.covered_planned_scenarios ?? 0}/{coverageMetrics?.planned_scenarios_total ?? 0}
 				</span>
 			</div>
-			<div className="traceability-table-wrapper" role="region" aria-label="Requirement traceability table" tabIndex={0}>
-				<table className="traceability-table">
+			<TableScroll className="traceability-table-wrapper" role="region" aria-label="Requirement traceability table" tabIndex={0}>
+				<Table className="traceability-table">
 					<thead>
 						<tr>
-							<th>Requirement</th>
-							<th>Story / source path</th>
-							<th>Linked test cases</th>
-							<th>Scenario coverage</th>
-							<th>Status</th>
+							<th scope="col">Requirement</th>
+							<th scope="col">Story / source path</th>
+							<th scope="col">Linked test cases</th>
+							<th scope="col">Scenario coverage</th>
+							<th scope="col">Status</th>
 						</tr>
 					</thead>
 					<tbody>
@@ -79,8 +81,8 @@ export default function TraceabilityMatrixPanel({
 							);
 						})}
 					</tbody>
-				</table>
-			</div>
-		</div>
+				</Table>
+			</TableScroll>
+		</Surface>
 	);
 }

--- a/frontend/src/components/integrations/AzureDevOpsConnectionSettings.jsx
+++ b/frontend/src/components/integrations/AzureDevOpsConnectionSettings.jsx
@@ -1,3 +1,4 @@
+import { Field, Input, Button } from "../ui/controls";
 export default function AzureDevOpsConnectionSettings({
 	azureDevOpsConnected,
 	azureDevOpsConnection,
@@ -37,26 +38,26 @@ export default function AzureDevOpsConnectionSettings({
 			) : null}
 			{!azureDevOpsConnected ? (
 				<div className="panel-form two-cols jira-connection-form">
-					<div className="form-group">
+					<Field className="form-group">
 						<label>Azure DevOps organization or project URL</label>
-						<input
+						<Input
 							placeholder="https://dev.azure.com/{organization}/{project}"
 							value={azureDevOpsConnectionForm.organizationUrl}
 							onChange={(event) => setAzureDevOpsConnectionForm((prev) => ({ ...prev, organizationUrl: event.target.value }))}
 						/>
-					</div>
-					<div className="form-group">
+					</Field>
+					<Field className="form-group">
 						<label>Account email (optional)</label>
-						<input
+						<Input
 							type="email"
 							placeholder="you@company.com or personal@example.com"
 							value={azureDevOpsConnectionForm.accountEmail}
 							onChange={(event) => setAzureDevOpsConnectionForm((prev) => ({ ...prev, accountEmail: event.target.value }))}
 						/>
-					</div>
+					</Field>
 					<div className="form-group jira-connection-token-group">
 						<label>Azure DevOps PAT</label>
-						<input
+						<Input
 							type="password"
 							placeholder="Paste your Azure DevOps Personal Access Token"
 							value={azureDevOpsConnectionForm.personalAccessToken}
@@ -68,31 +69,31 @@ export default function AzureDevOpsConnectionSettings({
 						</span>
 					</div>
 					<div className="panel-form button-row jira-connection-actions">
-						<button
+						<Button
 							onClick={saveAzureDevOpsConnection}
 							disabled={authActionDisabled || isSavingAzureDevOpsConnection || isAzureDevOpsConnectionLoading}
 						>
 							{isSavingAzureDevOpsConnection ? "⏳ Connecting..." : "Connect Azure DevOps"}
-						</button>
+						</Button>
 						{isAzureDevOpsConnectionLoading && <span className="helper-text">Refreshing Azure DevOps connection…</span>}
 					</div>
 				</div>
 			) : (
 				<div className="jira-connected-actions">
-					<button
+					<Button
 						className="secondary"
 						onClick={() => refreshAzureDevOpsConnectionStatus(currentUser)}
 						disabled={authActionDisabled || isAzureDevOpsConnectionLoading}
 					>
 						{isAzureDevOpsConnectionLoading ? "⏳ Refreshing status..." : "Refresh Status"}
-					</button>
-					<button
+					</Button>
+					<Button
 						className="secondary"
 						onClick={deleteStoredAzureDevOpsConnection}
 						disabled={authActionDisabled || isDeletingAzureDevOpsConnection}
 					>
 						{isDeletingAzureDevOpsConnection ? "⏳ Disconnecting..." : "Disconnect"}
-					</button>
+					</Button>
 				</div>
 			)}
 		</div>

--- a/frontend/src/components/integrations/JiraConnectionSettings.jsx
+++ b/frontend/src/components/integrations/JiraConnectionSettings.jsx
@@ -1,3 +1,4 @@
+import { Field, Input, Button } from "../ui/controls";
 export default function JiraConnectionSettings({
 	jiraConnected,
 	jiraConnection,
@@ -34,26 +35,26 @@ export default function JiraConnectionSettings({
 			) : null}
 			{!jiraConnected ? (
 				<div className="panel-form two-cols jira-connection-form">
-					<div className="form-group">
+					<Field className="form-group">
 						<label>JIRA base URL</label>
-						<input
+						<Input
 							placeholder="https://your-team.atlassian.net"
 							value={jiraConnectionForm.baseUrl}
 							onChange={(event) => setJiraConnectionForm((prev) => ({ ...prev, baseUrl: event.target.value }))}
 						/>
-					</div>
-					<div className="form-group">
+					</Field>
+					<Field className="form-group">
 						<label>JIRA email</label>
-						<input
+						<Input
 							type="email"
 							placeholder="qa@company.com"
 							value={jiraConnectionForm.email}
 							onChange={(event) => setJiraConnectionForm((prev) => ({ ...prev, email: event.target.value }))}
 						/>
-					</div>
+					</Field>
 					<div className="form-group jira-connection-token-group">
 						<label>JIRA API token</label>
-						<input
+						<Input
 							type="password"
 							placeholder="Paste your Atlassian API token"
 							value={jiraConnectionForm.apiToken}
@@ -61,24 +62,24 @@ export default function JiraConnectionSettings({
 						/>
 					</div>
 					<div className="panel-form button-row jira-connection-actions">
-						<button onClick={saveJiraConnection} disabled={authActionDisabled || isSavingJiraConnection || isJiraConnectionLoading}>
+						<Button onClick={saveJiraConnection} disabled={authActionDisabled || isSavingJiraConnection || isJiraConnectionLoading}>
 							{isSavingJiraConnection ? "⏳ Connecting..." : "Connect JIRA"}
-						</button>
+						</Button>
 						{isJiraConnectionLoading && <span className="helper-text">Refreshing JIRA connection…</span>}
 					</div>
 				</div>
 			) : (
 				<div className="jira-connected-actions">
-					<button
+					<Button
 						className="secondary"
 						onClick={() => refreshJiraConnectionStatus(currentUser)}
 						disabled={authActionDisabled || isJiraConnectionLoading}
 					>
 						{isJiraConnectionLoading ? "⏳ Refreshing status..." : "Refresh Status"}
-					</button>
-					<button className="secondary" onClick={deleteStoredJiraConnection} disabled={authActionDisabled || isDeletingJiraConnection}>
+					</Button>
+					<Button className="secondary" onClick={deleteStoredJiraConnection} disabled={authActionDisabled || isDeletingJiraConnection}>
 						{isDeletingJiraConnection ? "⏳ Disconnecting..." : "Disconnect"}
-					</button>
+					</Button>
 				</div>
 			)}
 		</div>

--- a/frontend/src/components/layout/AppHeader.jsx
+++ b/frontend/src/components/layout/AppHeader.jsx
@@ -1,3 +1,7 @@
+import { CollectionState } from "../ui/collections";
+import { Button, Input } from "../ui/controls";
+import { Menu } from "../ui/surfaces";
+import { Dialog } from "../ui/dialog";
 import { useCallback, useEffect, useId, useRef, useState } from "react";
 import { Check, ChevronDown, FolderOpen, LogOut, Plus, RefreshCw, Settings, UserRound } from "lucide-react";
 
@@ -22,7 +26,11 @@ function StatusUsagePills({ billingStatusItems, statusUsageItems, isUsageLoading
 						</span>
 					))
 				: null}
-			{isUsageLoading || isBillingLoading ? <span className="status-usage-loading">Loading usage…</span> : null}
+			{isUsageLoading || isBillingLoading ? (
+				<CollectionState as="span" kind="loading" className="status-usage-loading">
+					Loading usage…
+				</CollectionState>
+			) : null}
 		</div>
 	);
 }
@@ -58,7 +66,8 @@ function HealthMenu({ isAuthenticated, billingStatusItems, statusUsageItems, isU
 				closeAndRestoreFocus();
 			}}
 		>
-			<button
+			<Button
+				variant="plain"
 				ref={healthTriggerRef}
 				type="button"
 				className="command-health-trigger"
@@ -69,7 +78,7 @@ function HealthMenu({ isAuthenticated, billingStatusItems, statusUsageItems, isU
 			>
 				<span className="command-health-dot" aria-hidden="true" />
 				<span className="status-message">{healthLabel}</span>
-			</button>
+			</Button>
 			{isOpen ? (
 				<div id={healthDetailsId} className="command-health-details">
 					<p>
@@ -162,7 +171,8 @@ function AuthPanel({
 				<span className="auth-message">Checking session...</span>
 			) : isAuthenticated ? (
 				<div className="auth-account" ref={accountRef}>
-					<button
+					<Button
+						variant="plain"
 						ref={accountTriggerRef}
 						type="button"
 						className="auth-account-trigger"
@@ -181,9 +191,9 @@ function AuthPanel({
 						)}
 						<span className="auth-account-trigger-name">{userName}</span>
 						<ChevronDown className="auth-account-trigger-chevron" aria-hidden="true" size={15} strokeWidth={2.1} />
-					</button>
+					</Button>
 					{isAccountMenuOpen ? (
-						<div
+						<Menu
 							ref={accountMenuRef}
 							id={accountMenuId}
 							className="auth-account-menu"
@@ -205,7 +215,7 @@ function AuthPanel({
 								</div>
 							</div>
 							<div className="auth-account-actions">
-								<button
+								<Button
 									type="button"
 									role="menuitem"
 									onClick={() => {
@@ -215,8 +225,8 @@ function AuthPanel({
 								>
 									<Settings aria-hidden="true" size={17} strokeWidth={2.1} />
 									Settings
-								</button>
-								<button
+								</Button>
+								<Button
 									type="button"
 									role="menuitem"
 									onClick={() => {
@@ -227,20 +237,20 @@ function AuthPanel({
 								>
 									<LogOut aria-hidden="true" size={17} strokeWidth={2.1} />
 									{isAuthenticating ? "Signing out..." : "Sign Out"}
-								</button>
+								</Button>
 							</div>
-						</div>
+						</Menu>
 					) : null}
 				</div>
 			) : hasFirebaseAuthConfig && hasVisibleAuthProviders ? (
 				<div className="auth-login">
-					<button type="button" onClick={openSignInDialog} disabled={isAuthenticating}>
+					<Button type="button" onClick={openSignInDialog} disabled={isAuthenticating}>
 						{isAuthenticating && currentAuthProviderLabel
 							? `Signing in with ${currentAuthProviderLabel}...`
 							: isAuthenticating
 								? "Signing in..."
 								: "Sign In"}
-					</button>
+					</Button>
 				</div>
 			) : hasFirebaseAuthConfig ? (
 				<span className="auth-message auth-config-missing">No Firebase sign-in providers are currently available.</span>
@@ -323,7 +333,8 @@ function ProjectMenu({
 
 	return (
 		<div className="command-project-control" ref={menuRef}>
-			<button
+			<Button
+				variant="plain"
 				ref={triggerRef}
 				type="button"
 				className="command-project-trigger"
@@ -338,10 +349,10 @@ function ProjectMenu({
 					<span>{isLoadingProjects ? "Loading projects" : triggerMeta}</span>
 				</span>
 				<ChevronDown aria-hidden="true" size={18} strokeWidth={2.1} />
-			</button>
+			</Button>
 
 			{isOpen && (
-				<div
+				<Dialog
 					ref={dialogRef}
 					className="command-project-menu"
 					role="dialog"
@@ -358,7 +369,8 @@ function ProjectMenu({
 							<strong>Projects</strong>
 							<span>{projects.length ? `${projects.length} available` : "No projects yet"}</span>
 						</div>
-						<button
+						<Button
+							variant="plain"
 							type="button"
 							className="command-project-menu-action"
 							onClick={onRefreshProjects}
@@ -366,7 +378,7 @@ function ProjectMenu({
 						>
 							<RefreshCw aria-hidden="true" size={16} strokeWidth={2.1} />
 							{isLoadingProjects ? "Refreshing" : "Refresh projects"}
-						</button>
+						</Button>
 					</div>
 
 					<div className="command-project-list" aria-label="Available QA projects">
@@ -374,7 +386,8 @@ function ProjectMenu({
 							projects.map((project) => {
 								const isSelected = selectedProjectId === project.project_id;
 								return (
-									<button
+									<Button
+										variant="plain"
 										type="button"
 										key={project.project_id}
 										className={`command-project-option ${isSelected ? "selected" : ""}`}
@@ -389,29 +402,32 @@ function ProjectMenu({
 											<span>revision {project.current_revision}</span>
 										</span>
 										{isSelected && <Check aria-hidden="true" size={17} strokeWidth={2.4} />}
-									</button>
+									</Button>
 								);
 							})
 						) : (
-							<p className="command-project-empty">Create a QA project to persist workflow progress.</p>
+							<CollectionState as="p" kind="empty" className="command-project-empty">
+								Create a QA project to persist workflow progress.
+							</CollectionState>
 						)}
 					</div>
 
 					{currentProject && (
-						<button
+						<Button
+							variant="plain"
 							type="button"
 							className="command-project-clear"
 							onClick={() => handleOpenProject("")}
 							disabled={authActionDisabled || isOpeningProject}
 						>
 							Clear selection
-						</button>
+						</Button>
 					)}
 
 					<form className="command-project-create" onSubmit={handleCreateProject}>
 						<label htmlFor="command-project-create-name">New project</label>
 						<div className="command-project-create-row">
-							<input
+							<Input
 								id="command-project-create-name"
 								type="text"
 								value={newProjectName}
@@ -419,13 +435,13 @@ function ProjectMenu({
 								placeholder="New QA project name"
 								disabled={authActionDisabled || isCreatingProject}
 							/>
-							<button type="submit" disabled={authActionDisabled || isCreatingProject || !newProjectName.trim()}>
+							<Button type="submit" disabled={authActionDisabled || isCreatingProject || !newProjectName.trim()}>
 								<Plus aria-hidden="true" size={16} strokeWidth={2.2} />
 								{isCreatingProject ? "Creating" : "New Project"}
-							</button>
+							</Button>
 						</div>
 					</form>
-				</div>
+				</Dialog>
 			)}
 		</div>
 	);
@@ -438,7 +454,9 @@ export function SignInDialog({ isOpen, onOverlayClick, onClose, isAuthenticating
 
 	return (
 		<div className="auth-dialog-overlay" onClick={onOverlayClick}>
-			<div
+			<Dialog
+				manageFocus
+				onClose={onClose}
 				className="auth-dialog"
 				role="dialog"
 				aria-modal="true"
@@ -450,7 +468,8 @@ export function SignInDialog({ isOpen, onOverlayClick, onClose, isAuthenticating
 						<h2 id="auth-dialog-title">Choose a sign-in method</h2>
 						<p>Select one provider to continue into the workspace.</p>
 					</div>
-					<button
+					<Button
+						variant="plain"
 						type="button"
 						className="auth-dialog-close"
 						onClick={onClose}
@@ -458,11 +477,12 @@ export function SignInDialog({ isOpen, onOverlayClick, onClose, isAuthenticating
 						aria-label="Close sign-in dialog"
 					>
 						×
-					</button>
+					</Button>
 				</div>
 				<div className="auth-provider-list">
 					{providers.map((provider) => (
-						<button
+						<Button
+							variant="plain"
 							key={provider.id}
 							type="button"
 							className={`auth-provider-option auth-provider-option--${provider.buttonVariant || provider.id}`}
@@ -473,10 +493,10 @@ export function SignInDialog({ isOpen, onOverlayClick, onClose, isAuthenticating
 								<AuthProviderIcon providerId={provider.id} />
 							</span>
 							<span className="auth-provider-option-label">{provider.buttonText || `Sign in with ${provider.label}`}</span>
-						</button>
+						</Button>
 					))}
 				</div>
-			</div>
+			</Dialog>
 		</div>
 	);
 }
@@ -532,7 +552,7 @@ export default function AppNavigationControls({
 				isUsageLoading={isUsageLoading}
 				isBillingLoading={isBillingLoading}
 			/>
-			<button
+			<Button
 				type="button"
 				className="settings-open-btn"
 				data-testid="settings-open-button"
@@ -541,7 +561,7 @@ export default function AppNavigationControls({
 			>
 				<Settings aria-hidden="true" size={18} strokeWidth={2.1} />
 				<span className="settings-open-label">Settings</span>
-			</button>
+			</Button>
 			<AuthPanel
 				isVerifyingSession={isVerifyingSession}
 				isAuthenticated={isAuthenticated}

--- a/frontend/src/components/layout/BillingBanner.jsx
+++ b/frontend/src/components/layout/BillingBanner.jsx
@@ -1,3 +1,4 @@
+import { Link } from "../ui/controls";
 export default function BillingBanner({ isAuthenticated, pilotAlert, billingContactEmail }) {
 	if (!isAuthenticated || !pilotAlert) {
 		return null;
@@ -9,9 +10,9 @@ export default function BillingBanner({ isAuthenticated, pilotAlert, billingCont
 				<strong>{pilotAlert.title}</strong>
 				<span>{pilotAlert.message}</span>
 			</div>
-			<a href={`mailto:${billingContactEmail}`} className="billing-banner-link">
+			<Link href={`mailto:${billingContactEmail}`} className="billing-banner-link">
 				Contact {billingContactEmail}
-			</a>
+			</Link>
 		</div>
 	);
 }

--- a/frontend/src/components/layout/ProjectPageHeader.jsx
+++ b/frontend/src/components/layout/ProjectPageHeader.jsx
@@ -1,0 +1,23 @@
+import RouteLink from "../../app/RouteLink";
+
+export default function ProjectPageHeader({ title, project, navigate, titleId, actions, children }) {
+	return (
+		<header className="project-page-header">
+			<nav className="project-breadcrumb" aria-label="Breadcrumb">
+				<RouteLink to="/projects" navigate={navigate}>
+					Projects
+				</RouteLink>
+				<span aria-hidden="true">/</span>
+				<span aria-current="page">{title}</span>
+			</nav>
+			<div className="project-page-title-row">
+				<h1 id={titleId}>{title}</h1>
+				{actions}
+			</div>
+			<p>
+				{project?.name || "Project"} · Revision {project?.current_revision ?? 0}
+			</p>
+			{children}
+		</header>
+	);
+}

--- a/frontend/src/components/layout/WorkflowNavigationDrawer.jsx
+++ b/frontend/src/components/layout/WorkflowNavigationDrawer.jsx
@@ -2,8 +2,8 @@ import {
 	BookOpen,
 	Bot,
 	ClipboardCheck,
-	CloudUpload,
-	Download,
+	FileText,
+	ChartNoAxesColumnIncreasing,
 	LayoutGrid,
 	PanelLeftClose,
 	PanelLeftOpen,
@@ -11,7 +11,7 @@ import {
 } from "lucide-react";
 import { useRef } from "react";
 
-import StatusBadge from "../workflow/StatusBadge";
+import { Circle, LockKeyhole } from "lucide-react";
 
 const STATE_LABELS = {
 	active: "Current",
@@ -22,12 +22,12 @@ const STATE_LABELS = {
 };
 
 const WORKFLOW_ICONS = {
-	0: CloudUpload,
+	0: FileText,
 	1: BookOpen,
 	2: LayoutGrid,
 	3: WandSparkles,
 	4: Bot,
-	5: Download,
+	5: ChartNoAxesColumnIncreasing,
 	6: ClipboardCheck,
 };
 
@@ -77,8 +77,7 @@ export default function WorkflowNavigationDrawer({
 		>
 			<div className="workflow-navigation-header">
 				<div>
-					<span>Workflow</span>
-					<strong>{tabs.find((tab) => tab.id === activeTab)?.label || "Workspace"}</strong>
+					<span>Project</span>
 				</div>
 				<button
 					ref={toggleRef}
@@ -97,7 +96,15 @@ export default function WorkflowNavigationDrawer({
 				{tabs.map((tab) => {
 					const isActive = activeTab === tab.id;
 					const state = statusByTabId[tab.id] || "pending";
-					const stateLabel = isActive ? STATE_LABELS.active : STATE_LABELS[state] || STATE_LABELS.pending;
+					const stateLabel =
+						tab.id === 7
+							? ""
+							: state === "attention" && tab.id === 6
+								? "Awaiting review"
+								: state === "attention" && tab.id === 3
+									? "Needs refinement"
+									: STATE_LABELS[state] || STATE_LABELS.pending;
+					const StatusIcon = state === "blocked" ? LockKeyhole : Circle;
 					const WorkflowIcon = WORKFLOW_ICONS[tab.id] || LayoutGrid;
 					const itemContent = (
 						<>
@@ -106,11 +113,13 @@ export default function WorkflowNavigationDrawer({
 							</span>
 							<span className="workflow-navigation-copy">
 								<strong>{tab.label}</strong>
-								<span>{tab.title}</span>
+								{stateLabel && !isCollapsed && (
+									<span className={`nav-workflow-status ${state}`}>
+										<StatusIcon size={10} aria-hidden="true" fill={state === "blocked" ? "none" : "currentColor"} />
+										{stateLabel}
+									</span>
+								)}
 							</span>
-							{!isCollapsed && (
-								<StatusBadge className="workflow-navigation-state" status={isActive ? "active" : state} label={stateLabel} />
-							)}
 						</>
 					);
 					const itemClassName = `workflow-navigation-item ${state} ${isActive ? "active" : ""}`;
@@ -129,8 +138,8 @@ export default function WorkflowNavigationDrawer({
 									handleSelection(tab.id);
 								}}
 								aria-current={isActive ? "page" : undefined}
-								aria-label={`${tab.label}, ${stateLabel}`}
-								title={isCollapsed ? [tab.label, stateLabel].join(" — ") : undefined}
+								aria-label={[tab.label, stateLabel].filter(Boolean).join(", ")}
+								title={isCollapsed ? [tab.label, stateLabel].filter(Boolean).join(" — ") : undefined}
 							>
 								{itemContent}
 							</a>
@@ -144,8 +153,8 @@ export default function WorkflowNavigationDrawer({
 							className={itemClassName}
 							onClick={() => handleSelection(tab.id)}
 							aria-current={isActive ? "page" : undefined}
-							aria-label={`${tab.label}, ${stateLabel}`}
-							title={isCollapsed ? [tab.label, stateLabel].join(" — ") : undefined}
+							aria-label={[tab.label, stateLabel].filter(Boolean).join(", ")}
+							title={isCollapsed ? [tab.label, stateLabel].filter(Boolean).join(" — ") : undefined}
 						>
 							{itemContent}
 						</button>

--- a/frontend/src/components/layout/WorkflowNavigationDrawer.jsx
+++ b/frontend/src/components/layout/WorkflowNavigationDrawer.jsx
@@ -1,3 +1,4 @@
+import { Button, Link } from "../ui/controls";
 import {
 	BookOpen,
 	Bot,
@@ -79,7 +80,8 @@ export default function WorkflowNavigationDrawer({
 				<div>
 					<span>Project</span>
 				</div>
-				<button
+				<Button
+					variant="plain"
 					ref={toggleRef}
 					type="button"
 					className="workflow-navigation-toggle"
@@ -90,7 +92,7 @@ export default function WorkflowNavigationDrawer({
 					aria-controls={isCompact ? navigationItemsId : undefined}
 				>
 					<ToggleIcon aria-hidden="true" size={18} strokeWidth={2.1} />
-				</button>
+				</Button>
 			</div>
 			<div id={navigationItemsId} className="workflow-navigation-list" hidden={itemsHidden}>
 				{tabs.map((tab) => {
@@ -126,7 +128,7 @@ export default function WorkflowNavigationDrawer({
 
 					if (tab.href) {
 						return (
-							<a
+							<Link
 								key={tab.id}
 								href={tab.href}
 								className={itemClassName}
@@ -142,12 +144,12 @@ export default function WorkflowNavigationDrawer({
 								title={isCollapsed ? [tab.label, stateLabel].filter(Boolean).join(" — ") : undefined}
 							>
 								{itemContent}
-							</a>
+							</Link>
 						);
 					}
 
 					return (
-						<button
+						<Button
 							type="button"
 							key={tab.id}
 							className={itemClassName}
@@ -157,7 +159,7 @@ export default function WorkflowNavigationDrawer({
 							title={isCollapsed ? [tab.label, stateLabel].filter(Boolean).join(" — ") : undefined}
 						>
 							{itemContent}
-						</button>
+						</Button>
 					);
 				})}
 			</div>

--- a/frontend/src/components/layout/WorkflowStepper.jsx
+++ b/frontend/src/components/layout/WorkflowStepper.jsx
@@ -1,3 +1,4 @@
+import { Button } from "../ui/controls";
 export default function WorkflowStepper({ tabs, activeTab, onTabChange }) {
 	return (
 		<nav className="tabs workflow-stepper" aria-label="Workflow steps">
@@ -5,7 +6,8 @@ export default function WorkflowStepper({ tabs, activeTab, onTabChange }) {
 				const isActive = activeTab === tab.id;
 				const isComplete = activeTab > tab.id;
 				return (
-					<button
+					<Button
+						variant="plain"
 						key={tab.id}
 						className={`tab workflow-step ${isActive ? "active" : ""} ${isComplete ? "complete" : ""}`}
 						onClick={() => onTabChange(tab.id)}
@@ -13,7 +15,7 @@ export default function WorkflowStepper({ tabs, activeTab, onTabChange }) {
 					>
 						<span className="tab-number">{isComplete ? "✓" : tab.id + 1}</span>
 						<span className="tab-label">{tab.label}</span>
-					</button>
+					</Button>
 				);
 			})}
 		</nav>

--- a/frontend/src/components/layout/WorkflowTabs.jsx
+++ b/frontend/src/components/layout/WorkflowTabs.jsx
@@ -1,11 +1,12 @@
+import { Button } from "../ui/controls";
 export default function WorkflowTabs({ tabs, activeTab, onTabChange }) {
 	return (
 		<div className="tabs">
 			{tabs.map((tab) => (
-				<button key={tab.id} className={`tab ${activeTab === tab.id ? "active" : ""}`} onClick={() => onTabChange(tab.id)}>
+				<Button variant="plain" key={tab.id} className={`tab ${activeTab === tab.id ? "active" : ""}`} onClick={() => onTabChange(tab.id)}>
 					<span className="tab-number">{tab.id + 1}</span>
 					<span className="tab-label">{tab.label}</span>
-				</button>
+				</Button>
 			))}
 		</div>
 	);

--- a/frontend/src/components/projects/ContextualTaskCard.jsx
+++ b/frontend/src/components/projects/ContextualTaskCard.jsx
@@ -1,3 +1,7 @@
+import { Dialog } from "../ui/dialog";
+import { Alert, Disclosure } from "../ui/surfaces";
+import { Button } from "../ui/controls";
+import { List, ListItem } from "../ui/collections";
 import { useEffect, useRef, useState } from "react";
 
 import { formatTaskLabel, formatTaskProvenance, getTaskProvenance } from "./contextualTask";
@@ -49,35 +53,13 @@ function RegenerationConfirmation({ isSubmitting, error, onCancel, onConfirm }) 
 			onClick={() => {
 				if (!isSubmitting) onCancel();
 			}}
-			onKeyDown={(event) => {
-				if (event.key === "Escape" && !isSubmitting) {
-					event.preventDefault();
-					onCancel();
-					return;
-				}
-				if (event.key !== "Tab") return;
-				const focusable = Array.from(
-					dialogRef.current?.querySelectorAll(
-						"button:not(:disabled), [href], input:not(:disabled), select:not(:disabled), textarea:not(:disabled)"
-					) || []
-				);
-				if (!focusable.length) {
-					event.preventDefault();
-					dialogRef.current?.focus();
-					return;
-				}
-				const first = focusable[0];
-				const last = focusable.at(-1);
-				if (event.shiftKey && document.activeElement === first) {
-					event.preventDefault();
-					last.focus();
-				} else if (!event.shiftKey && document.activeElement === last) {
-					event.preventDefault();
-					first.focus();
-				}
-			}}
 		>
-			<div
+			<Dialog
+				manageFocus
+				initialFocusRef={confirmButtonRef}
+				onClose={() => {
+					if (!isSubmitting) onCancel();
+				}}
 				ref={dialogRef}
 				className="contextual-task-dialog"
 				role="dialog"
@@ -95,19 +77,19 @@ function RegenerationConfirmation({ isSubmitting, error, onCancel, onConfirm }) 
 					and existing cases or coverage may be replaced. If it fails, the current suite remains available.
 				</p>
 				{error ? (
-					<div className="contextual-task-dialog-error" role="alert">
+					<Alert as="div" tone="danger" className="contextual-task-dialog-error" role="alert">
 						{error}
-					</div>
+					</Alert>
 				) : null}
 				<div className="contextual-task-dialog-actions">
-					<button type="button" className="secondary" onClick={onCancel} disabled={isSubmitting}>
+					<Button type="button" className="secondary" onClick={onCancel} disabled={isSubmitting}>
 						Cancel
-					</button>
-					<button ref={confirmButtonRef} type="button" onClick={onConfirm} disabled={isSubmitting}>
+					</Button>
+					<Button ref={confirmButtonRef} type="button" onClick={onConfirm} disabled={isSubmitting}>
 						{isSubmitting ? "Regenerating…" : "Confirm regeneration"}
-					</button>
+					</Button>
 				</div>
-			</div>
+			</Dialog>
 		</div>
 	);
 }
@@ -216,12 +198,12 @@ export default function ContextualTaskCard({
 			</div>
 			<div className="contextual-task-controls">
 				{hasPrimaryAction ? (
-					<button type="button" onClick={handlePrimaryAction} disabled={primaryDisabled}>
+					<Button type="button" onClick={handlePrimaryAction} disabled={primaryDisabled}>
 						{isPrimaryBusy ? "Working…" : actionCtaLabel(action, navigationOnly)}
-					</button>
+					</Button>
 				) : null}
 				{hasDetails ? (
-					<details className="contextual-task-details">
+					<Disclosure className="contextual-task-details">
 						<summary>Details</summary>
 						<div className="contextual-task-details-body">
 							{stage ? (
@@ -235,15 +217,15 @@ export default function ContextualTaskCard({
 										<strong>Sources</strong> {provenanceLabel}
 									</p>
 									{provenance.some((source) => source.snapshotId) ? (
-										<ul className="contextual-task-snapshot-list" aria-label="Source snapshots">
+										<List className="contextual-task-snapshot-list" aria-label="Source snapshots">
 											{provenance
 												.filter((source) => source.snapshotId)
 												.map((source) => (
-													<li key={source.stage}>
+													<ListItem key={source.stage}>
 														{source.label}: {source.snapshotId}
-													</li>
+													</ListItem>
 												))}
-										</ul>
+										</List>
 									) : null}
 								</div>
 							) : null}
@@ -261,7 +243,7 @@ export default function ContextualTaskCard({
 										const secondaryBusy = Boolean(busyMap[secondaryAction.action] || locallyBusyAction === secondaryAction.action);
 										return (
 											<div className="contextual-task-secondary-action" key={`${secondaryAction.action}-${secondaryAction.stage}`}>
-												<button
+												<Button
 													ref={secondaryAction.action === "full_regenerate" ? regenerationTriggerRef : null}
 													type="button"
 													className="secondary small"
@@ -269,7 +251,7 @@ export default function ContextualTaskCard({
 													disabled={disabled || disabledMap[secondaryAction.action] || secondaryBusy || !secondaryAction.enabled}
 												>
 													{secondaryBusy ? "Working…" : actionLabel(secondaryAction)}
-												</button>
+												</Button>
 												<p>{secondaryAction.reason || firstBlocker(secondaryAction) || "Optional workflow action."}</p>
 												{firstBlocker(secondaryAction) && firstBlocker(secondaryAction) !== secondaryAction.reason ? (
 													<span className="contextual-task-blocker">{firstBlocker(secondaryAction)}</span>
@@ -280,7 +262,7 @@ export default function ContextualTaskCard({
 								</div>
 							) : null}
 						</div>
-					</details>
+					</Disclosure>
 				) : null}
 			</div>
 			{confirmationAction ? (

--- a/frontend/src/components/projects/OrchestratorCockpitPanel.jsx
+++ b/frontend/src/components/projects/OrchestratorCockpitPanel.jsx
@@ -28,7 +28,7 @@ export default function OrchestratorCockpitPanel({
 		return null;
 	}
 
-	return (
+	const content = (
 		<section className="contextual-task-region" aria-label="Contextual task">
 			{error ? (
 				<div className="orchestrator-error" role="alert">
@@ -49,5 +49,13 @@ export default function OrchestratorCockpitPanel({
 				/>
 			) : null}
 		</section>
+	);
+	return !primaryAction && !error ? (
+		<details className="optional-workflow-actions">
+			<summary>More actions</summary>
+			{content}
+		</details>
+	) : (
+		content
 	);
 }

--- a/frontend/src/components/projects/OrchestratorCockpitPanel.jsx
+++ b/frontend/src/components/projects/OrchestratorCockpitPanel.jsx
@@ -1,3 +1,4 @@
+import { Alert, Disclosure } from "../ui/surfaces";
 import ContextualTaskCard from "./ContextualTaskCard";
 import { selectContextualTask } from "./contextualTask";
 
@@ -31,9 +32,9 @@ export default function OrchestratorCockpitPanel({
 	const content = (
 		<section className="contextual-task-region" aria-label="Contextual task">
 			{error ? (
-				<div className="orchestrator-error" role="alert">
+				<Alert as="div" tone="danger" className="orchestrator-error" role="alert">
 					{error}
-				</div>
+				</Alert>
 			) : null}
 			{primaryAction || secondaryActions.length ? (
 				<ContextualTaskCard
@@ -51,10 +52,10 @@ export default function OrchestratorCockpitPanel({
 		</section>
 	);
 	return !primaryAction && !error ? (
-		<details className="optional-workflow-actions">
+		<Disclosure className="optional-workflow-actions">
 			<summary>More actions</summary>
 			{content}
-		</details>
+		</Disclosure>
 	) : (
 		content
 	);

--- a/frontend/src/components/projects/RunDetailsDrawer.jsx
+++ b/frontend/src/components/projects/RunDetailsDrawer.jsx
@@ -1,6 +1,7 @@
+import { Disclosure } from "../ui/surfaces";
 export default function RunDetailsDrawer({ title = "Run details", summary, children, defaultOpen = true }) {
 	return (
-		<details className="run-details-drawer" open={defaultOpen}>
+		<Disclosure className="run-details-drawer" open={defaultOpen}>
 			<summary>
 				<span className="run-details-summary-copy">
 					<strong>{title}</strong>
@@ -9,6 +10,6 @@ export default function RunDetailsDrawer({ title = "Run details", summary, child
 				<span className="run-details-toggle">Show details</span>
 			</summary>
 			<div className="run-details-body">{children}</div>
-		</details>
+		</Disclosure>
 	);
 }

--- a/frontend/src/components/requirements/RequirementReviewWorkbench.jsx
+++ b/frontend/src/components/requirements/RequirementReviewWorkbench.jsx
@@ -1,3 +1,6 @@
+import { Surface, Disclosure } from "../ui/surfaces";
+import { Button, Link, Select, Checkbox } from "../ui/controls";
+import { TableScroll, Table } from "../ui/collections";
 import { REQUIREMENT_QUALITY_FLAG_OPTIONS, REQUIREMENT_REVIEW_STATUSES } from "../../constants/workflow";
 import {
 	formatSourceIssueKey,
@@ -18,7 +21,7 @@ export default function RequirementReviewWorkbench({
 	onQualityFlagToggle,
 }) {
 	return (
-		<div className="result-section">
+		<Surface as="div" className="result-section">
 			<h3>Requirement Review Workbench</h3>
 			{requirements.length === 0 ? (
 				<span className="helper-text">No requirements extracted yet.</span>
@@ -34,12 +37,12 @@ export default function RequirementReviewWorkbench({
 							</p>
 						</div>
 						<div className="requirement-review-bulk-actions">
-							<button type="button" className="secondary small" onClick={onApproveNonRejected}>
+							<Button type="button" className="secondary small" onClick={onApproveNonRejected}>
 								Approve non-rejected
-							</button>
-							<button type="button" className="secondary small" onClick={onMarkAllNeedsReview}>
+							</Button>
+							<Button type="button" className="secondary small" onClick={onMarkAllNeedsReview}>
 								Mark all needs review
-							</button>
+							</Button>
 						</div>
 					</div>
 					{groupRequirementsByContext(requirements).map((group) => (
@@ -53,16 +56,21 @@ export default function RequirementReviewWorkbench({
 									{group.requirements.length} requirement{group.requirements.length === 1 ? "" : "s"}
 								</span>
 							</div>
-							<div className="requirement-table-wrapper" role="region" aria-label={`${group.label} requirements table`} tabIndex={0}>
-								<table className="requirement-review-table">
+							<TableScroll
+								className="requirement-table-wrapper"
+								role="region"
+								aria-label={`${group.label} requirements table`}
+								tabIndex={0}
+							>
+								<Table className="requirement-review-table">
 									<thead>
 										<tr>
-											<th>Epic</th>
-											<th>ID</th>
-											<th>Requirement</th>
-											<th>Review source</th>
-											<th>Review status</th>
-											<th>Quality flags</th>
+											<th scope="col">Epic</th>
+											<th scope="col">ID</th>
+											<th scope="col">Requirement</th>
+											<th scope="col">Review source</th>
+											<th scope="col">Review status</th>
+											<th scope="col">Quality flags</th>
 										</tr>
 									</thead>
 									<tbody>
@@ -89,19 +97,19 @@ export default function RequirementReviewWorkbench({
 													</td>
 													<td className="requirement-review-source-cell">
 														{req.source_excerpt ? (
-															<details className="requirement-evidence compact">
+															<Disclosure className="requirement-evidence compact">
 																<summary>Source evidence</summary>
 																<p>{req.source_excerpt}</p>
 																{req.source_issue_url ? (
-																	<a href={req.source_issue_url} target="_blank" rel="noreferrer">
+																	<Link href={req.source_issue_url} target="_blank" rel="noreferrer">
 																		Open source ↗
-																	</a>
+																	</Link>
 																) : null}
-															</details>
+															</Disclosure>
 														) : req.source_issue_url ? (
-															<a className="requirement-source-link" href={req.source_issue_url} target="_blank" rel="noreferrer">
+															<Link className="requirement-source-link" href={req.source_issue_url} target="_blank" rel="noreferrer">
 																Open source ↗
-															</a>
+															</Link>
 														) : req.source_path || req.source_section ? (
 															<span className="cell-secondary">{req.source_path || req.source_section}</span>
 														) : (
@@ -116,7 +124,7 @@ export default function RequirementReviewWorkbench({
 														) : null}
 													</td>
 													<td className="requirement-status-cell">
-														<select
+														<Select
 															value={reviewStatus}
 															onChange={(event) => onReviewStatusChange(req.id, event.target.value)}
 															aria-label={`Review status for ${requirementId}`}
@@ -126,17 +134,17 @@ export default function RequirementReviewWorkbench({
 																	{statusOption}
 																</option>
 															))}
-														</select>
+														</Select>
 													</td>
 													<td className="requirement-flags-cell">
-														<details className="requirement-quality-details">
+														<Disclosure className="requirement-quality-details">
 															<summary>
 																{qualityFlags.length ? `${qualityFlags.length} flag${qualityFlags.length === 1 ? "" : "s"}` : "Add flags"}
 															</summary>
 															<div className="quality-flag-checklist">
 																{REQUIREMENT_QUALITY_FLAG_OPTIONS.map((flag) => (
 																	<label key={`${requirementId}-${flag}`}>
-																		<input
+																		<Checkbox
 																			type="checkbox"
 																			checked={qualityFlags.includes(flag)}
 																			onChange={() => onQualityFlagToggle(req.id, flag)}
@@ -145,18 +153,18 @@ export default function RequirementReviewWorkbench({
 																	</label>
 																))}
 															</div>
-														</details>
+														</Disclosure>
 													</td>
 												</tr>
 											);
 										})}
 									</tbody>
-								</table>
-							</div>
+								</Table>
+							</TableScroll>
 						</div>
 					))}
 				</div>
 			)}
-		</div>
+		</Surface>
 	);
 }

--- a/frontend/src/components/reviews/ReviewInbox.jsx
+++ b/frontend/src/components/reviews/ReviewInbox.jsx
@@ -2,6 +2,7 @@ import { CircleAlert, CircleCheck, ClipboardCheck, Info, ListChecks, Sparkles, W
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import {
+	formatWorkItemCount,
 	formatWorkspaceDate,
 	formatWorkspaceLabel,
 	formatWorkspaceStatus,
@@ -52,6 +53,7 @@ export const isActionableReviewItem = (item) =>
 	item?.enabled === true && item?.kind !== "information" && !COMPLETED_STATUSES.has(item?.status);
 
 const formatCount = (item) => {
+	if (item?.stage === "use_cases") return formatWorkItemCount(item);
 	if (!Number.isInteger(item?.count)) return "";
 	const unit = COUNT_UNIT_BY_STAGE[item.stage] || "item";
 	return `${item.count} ${unit}${item.count === 1 ? "" : "s"}`;

--- a/frontend/src/components/reviews/ReviewInbox.jsx
+++ b/frontend/src/components/reviews/ReviewInbox.jsx
@@ -1,3 +1,6 @@
+import { Badge } from "../ui/surfaces";
+import { ListItem, CollectionState, CollectionToolbar, List } from "../ui/collections";
+import { Button, Select } from "../ui/controls";
 import { CircleAlert, CircleCheck, ClipboardCheck, Info, ListChecks, Sparkles, Wrench } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 
@@ -74,11 +77,14 @@ const statusIcon = (status) => {
 function ReviewInboxStatus({ status }) {
 	const Icon = statusIcon(status);
 	return (
-		<span className={`review-inbox-status review-inbox-status-${getWorkspaceStatusTone(status)}`}>
-			<Icon aria-hidden="true" size={14} />
+		<Badge
+			tone={getWorkspaceStatusTone(status)}
+			icon={Icon}
+			className={`review-inbox-status review-inbox-status-${getWorkspaceStatusTone(status)}`}
+		>
 			<span className="sr-only">Status: </span>
 			{formatWorkspaceStatus(status)}
-		</span>
+		</Badge>
 	);
 }
 
@@ -88,7 +94,7 @@ function ReviewInboxRow({ item, onOpenProject }) {
 	const destination = getWorkItemDestination(item);
 	const count = formatCount(item);
 	return (
-		<li className="review-inbox-row">
+		<ListItem className="review-inbox-row">
 			<div className="review-inbox-kind">
 				<span className="review-inbox-kind-icon">
 					<KindIcon aria-hidden="true" size={18} />
@@ -127,13 +133,13 @@ function ReviewInboxRow({ item, onOpenProject }) {
 			>
 				Open workbench
 			</ProjectOpenLink>
-		</li>
+		</ListItem>
 	);
 }
 
 function ReviewInboxEmpty({ title, message, action = null }) {
 	return (
-		<section className="review-inbox-empty" aria-labelledby="review-inbox-empty-title">
+		<CollectionState as="section" kind="empty" className="review-inbox-empty" aria-labelledby="review-inbox-empty-title">
 			<span>
 				<ListChecks aria-hidden="true" size={22} />
 			</span>
@@ -142,7 +148,7 @@ function ReviewInboxEmpty({ title, message, action = null }) {
 				<p>{message}</p>
 			</div>
 			{action}
-		</section>
+		</CollectionState>
 	);
 }
 
@@ -160,56 +166,56 @@ function ReviewInboxFilters({
 }) {
 	const hasFilters = stage !== "all" || status !== "all";
 	return (
-		<fieldset className="review-inbox-controls">
+		<CollectionToolbar as="fieldset" className="review-inbox-controls">
 			<legend className="sr-only">Review filters</legend>
 			<div className="review-inbox-view-switch" role="group" aria-label="Inbox view">
-				<button
+				<Button
 					type="button"
 					className={view === "actionable" ? "active" : ""}
 					aria-pressed={view === "actionable"}
 					onClick={() => onViewChange("actionable")}
 				>
 					Actionable
-				</button>
-				<button
+				</Button>
+				<Button
 					type="button"
 					className={view === "informational" ? "active" : ""}
 					aria-pressed={view === "informational"}
 					onClick={() => onViewChange("informational")}
 				>
 					Informational &amp; completed
-				</button>
+				</Button>
 			</div>
 			<div className="review-inbox-selects">
 				<label>
 					<span>Stage</span>
-					<select ref={stageSelectRef} value={stage} onChange={(event) => onStageChange(event.target.value)}>
+					<Select ref={stageSelectRef} value={stage} onChange={(event) => onStageChange(event.target.value)}>
 						<option value="all">All stages</option>
 						{stageOptions.map((option) => (
 							<option value={option} key={option}>
 								{formatWorkspaceLabel(option)}
 							</option>
 						))}
-					</select>
+					</Select>
 				</label>
 				<label>
 					<span>Status</span>
-					<select value={status} onChange={(event) => onStatusChange(event.target.value)}>
+					<Select value={status} onChange={(event) => onStatusChange(event.target.value)}>
 						<option value="all">All statuses</option>
 						{statusOptions.map((option) => (
 							<option value={option} key={option}>
 								{formatWorkspaceStatus(option)}
 							</option>
 						))}
-					</select>
+					</Select>
 				</label>
 				{hasFilters ? (
-					<button type="button" className="review-inbox-clear-filters" onClick={onClearFilters}>
+					<Button type="button" className="review-inbox-clear-filters" onClick={onClearFilters}>
 						Clear filters
-					</button>
+					</Button>
 				) : null}
 			</div>
-		</fieldset>
+		</CollectionToolbar>
 	);
 }
 
@@ -290,11 +296,11 @@ export default function ReviewInbox({ items, onOpenProject }) {
 			</div>
 
 			{filteredItems.length ? (
-				<ul className="review-inbox-list">
+				<List variant="collection" className="review-inbox-list">
 					{filteredItems.map((item) => (
 						<ReviewInboxRow key={itemIdentity(item)} item={item} onOpenProject={onOpenProject} />
 					))}
-				</ul>
+				</List>
 			) : deduplicatedItems.length === 0 ? (
 				<ReviewInboxEmpty
 					title="Review queue is clear"
@@ -305,9 +311,9 @@ export default function ReviewInbox({ items, onOpenProject }) {
 					title="No items match these filters"
 					message="Choose another stage or status, or clear the filters to restore this queue view."
 					action={
-						<button type="button" className="secondary" onClick={clearFilters}>
+						<Button type="button" className="secondary" onClick={clearFilters}>
 							Clear filters
-						</button>
+						</Button>
 					}
 				/>
 			) : view === "actionable" ? (
@@ -315,9 +321,9 @@ export default function ReviewInbox({ items, onOpenProject }) {
 					title="No actionable reviews"
 					message="You are caught up. Informational and completed project states remain available in the secondary view."
 					action={
-						<button type="button" className="secondary" onClick={showInformationalItems}>
+						<Button type="button" className="secondary" onClick={showInformationalItems}>
 							View informational items
-						</button>
+						</Button>
 					}
 				/>
 			) : (

--- a/frontend/src/components/reviews/UseCaseReviewWorkbench.jsx
+++ b/frontend/src/components/reviews/UseCaseReviewWorkbench.jsx
@@ -1,3 +1,6 @@
+import { ListItem, CollectionState, List, CollectionToolbar } from "../ui/collections";
+import { Disclosure, Alert } from "../ui/surfaces";
+import { Button, Radio, Textarea, Input } from "../ui/controls";
 import { useEffect, useId, useMemo, useRef, useState } from "react";
 
 import { formatWorkspaceDate, formatWorkspaceLabel } from "../workspace/workspacePresentation";
@@ -168,8 +171,8 @@ function ArtifactSummary({ project, snapshot, stageState, scenarioTotal, groupTo
 
 function ScenarioCard({ scenario }) {
 	return (
-		<li className="use-case-scenario-card">
-			<details className="scenario-details">
+		<ListItem className="use-case-scenario-card">
+			<Disclosure className="scenario-details">
 				<summary>
 					<span className="scenario-summary-copy">
 						<span className="use-case-scenario-type">{scenario.id || formatWorkspaceLabel(scenario.scenario_type, "Scenario")}</span>
@@ -183,14 +186,18 @@ function ScenarioCard({ scenario }) {
 						{scenario.must_have ? "Must have" : "Recommended"}
 					</span>
 				</div>
-			</details>
-		</li>
+			</Disclosure>
+		</ListItem>
 	);
 }
 
 function CoverageContext({ analysis }) {
 	if (!analysis) {
-		return <p className="use-case-context-empty">No additional constraint or risk analysis is attached to this requirement.</p>;
+		return (
+			<CollectionState as="p" kind="empty" className="use-case-context-empty">
+				No additional constraint or risk analysis is attached to this requirement.
+			</CollectionState>
+		);
 	}
 	const constraints = normalizeList(analysis.field_constraints);
 	const risks = normalizeList(analysis.risk_signals);
@@ -202,13 +209,13 @@ function CoverageContext({ analysis }) {
 			<div>
 				<h4>Constraints</h4>
 				{constraints.length ? (
-					<ul>
+					<List>
 						{constraints.map((constraint, index) => (
-							<li key={constraint.id || `${constraint.field_name}-${index}`}>
+							<ListItem key={constraint.id || `${constraint.field_name}-${index}`}>
 								<strong>{constraint.field_name || "Constraint"}</strong>: {constraint.description}
-							</li>
+							</ListItem>
 						))}
-					</ul>
+					</List>
 				) : (
 					<p>No field constraints identified.</p>
 				)}
@@ -216,26 +223,26 @@ function CoverageContext({ analysis }) {
 			<div>
 				<h4>Risks and gaps</h4>
 				{risks.length || dependencies.length || permissions.length || transitions.length ? (
-					<ul>
+					<List>
 						{risks.map((risk, index) => (
-							<li key={risk.id || `${risk.title}-${index}`}>
+							<ListItem key={risk.id || `${risk.title}-${index}`}>
 								<strong>{formatWorkspaceLabel(risk.severity, "Risk")}</strong>: {risk.title || risk.rationale}
-							</li>
+							</ListItem>
 						))}
 						{dependencies.map((dependency) => (
-							<li key={dependency}>Dependency: {dependency}</li>
+							<ListItem key={dependency}>Dependency: {dependency}</ListItem>
 						))}
 						{permissions.map((permission, index) => (
-							<li key={permission.id || `${permission.role}-${permission.action}-${index}`}>
+							<ListItem key={permission.id || `${permission.role}-${permission.action}-${index}`}>
 								Permission: {permission.role} can {`${permission.action || "act"}`.toLowerCase()}
-							</li>
+							</ListItem>
 						))}
 						{transitions.map((transition, index) => (
-							<li key={transition.id || `${transition.from_state}-${transition.to_state}-${index}`}>
+							<ListItem key={transition.id || `${transition.from_state}-${transition.to_state}-${index}`}>
 								Transition: {transition.from_state} → {transition.to_state}
-							</li>
+							</ListItem>
 						))}
-					</ul>
+					</List>
 				) : (
 					<p>No risks or dependencies identified.</p>
 				)}
@@ -309,13 +316,13 @@ function ReviewDecisionPanel({ stageState, snapshot, review }) {
 			) : null}
 
 			{!snapshotMatches ? (
-				<div className="use-case-review-alert conflict" role="alert">
+				<Alert as="div" tone="warning" className="use-case-review-alert conflict" role="alert">
 					<strong>The loaded artifact is no longer the project’s current Use Cases version.</strong>
 					<p>Reload the latest project state before making a decision.</p>
-					<button type="button" className="secondary" onClick={() => void handleReload()} disabled={isBusy}>
+					<Button type="button" className="secondary" onClick={() => void handleReload()} disabled={isBusy}>
 						Reload latest
-					</button>
-				</div>
+					</Button>
+				</Alert>
 			) : null}
 
 			{stageState?.stale ? (
@@ -331,7 +338,7 @@ function ReviewDecisionPanel({ stageState, snapshot, review }) {
 			<fieldset className="use-case-decision-options" disabled={formDisabled}>
 				<legend>Choose a decision</legend>
 				<label className={review.decision === "approve" ? "selected" : ""}>
-					<input
+					<Radio
 						type="radio"
 						name="use-case-review-decision"
 						value="approve"
@@ -345,7 +352,7 @@ function ReviewDecisionPanel({ stageState, snapshot, review }) {
 					</span>
 				</label>
 				<label className={review.decision === "request_changes" ? "selected" : ""}>
-					<input
+					<Radio
 						type="radio"
 						name="use-case-review-decision"
 						value="request_changes"
@@ -361,7 +368,7 @@ function ReviewDecisionPanel({ stageState, snapshot, review }) {
 
 			<div className="use-case-comment-field">
 				<label htmlFor="use-case-review-comment">Review comment {commentRequired ? <span>Required</span> : <span>Optional</span>}</label>
-				<textarea
+				<Textarea
 					id="use-case-review-comment"
 					ref={commentRef}
 					value={review.comment}
@@ -386,31 +393,31 @@ function ReviewDecisionPanel({ stageState, snapshot, review }) {
 			</div>
 
 			{review.status === "conflict" ? (
-				<div className="use-case-review-alert conflict" role="alert">
+				<Alert as="div" tone="warning" className="use-case-review-alert conflict" role="alert">
 					<strong>Reload required</strong>
 					<p>{review.error}</p>
-					<button type="button" className="secondary" onClick={() => void handleReload()} disabled={isBusy}>
+					<Button type="button" className="secondary" onClick={() => void handleReload()} disabled={isBusy}>
 						{review.isReloading ? "Reloading…" : "Reload latest"}
-					</button>
-				</div>
+					</Button>
+				</Alert>
 			) : review.status === "refresh_error" ? (
-				<div className="use-case-review-alert warning" role="alert">
+				<Alert as="div" tone="warning" className="use-case-review-alert warning" role="alert">
 					<strong>Decision saved; refresh required</strong>
 					<p>{review.error}</p>
-					<button type="button" className="secondary" onClick={() => void handleReload()} disabled={isBusy}>
+					<Button type="button" className="secondary" onClick={() => void handleReload()} disabled={isBusy}>
 						{review.isReloading ? "Reloading…" : "Reload latest"}
-					</button>
-				</div>
+					</Button>
+				</Alert>
 			) : review.status === "error" ? (
-				<div id="use-case-review-error" className="use-case-review-alert error" role="alert">
+				<Alert as="div" tone="danger" id="use-case-review-error" className="use-case-review-alert error" role="alert">
 					<strong>{commentInvalid ? "Comment required" : "Decision not saved"}</strong>
 					<p>{review.error}</p>
 					{commentInvalid ? null : (
-						<button type="button" className="secondary" onClick={() => void handleRetry()} disabled={isBusy || formDisabled}>
+						<Button type="button" className="secondary" onClick={() => void handleRetry()} disabled={isBusy || formDisabled}>
 							Retry
-						</button>
+						</Button>
 					)}
-				</div>
+				</Alert>
 			) : null}
 
 			<div className="use-case-review-announcement" role="status" aria-live="polite" aria-atomic="true">
@@ -423,7 +430,7 @@ function ReviewDecisionPanel({ stageState, snapshot, review }) {
 						? "Your feedback will be recorded with the decision."
 						: "Approval advances the durable project review state."}
 				</p>
-				<button type="submit" disabled={!review.decision || formDisabled || (review.decision === "approve" && approvalBlocked)}>
+				<Button type="submit" disabled={!review.decision || formDisabled || (review.decision === "approve" && approvalBlocked)}>
 					{review.isSubmitting
 						? "Saving decision…"
 						: !review.decision
@@ -431,7 +438,7 @@ function ReviewDecisionPanel({ stageState, snapshot, review }) {
 							: review.decision === "request_changes"
 								? "Request changes"
 								: "Approve Use Cases"}
-				</button>
+				</Button>
 			</div>
 		</form>
 	);
@@ -514,7 +521,7 @@ export default function UseCaseReviewWorkbench({ project, snapshot, stageState, 
 					<span>Use Cases v{snapshot.version ?? stageState?.version ?? "—"}</span>
 					<span>{effectiveStageState?.stale ? "Stale artifact" : "Current artifact"}</span>
 				</div>
-				<details className="use-case-supporting-details">
+				<Disclosure className="use-case-supporting-details">
 					<summary>Quality, coverage and review history</summary>
 					<ArtifactSummary
 						project={project}
@@ -538,18 +545,18 @@ export default function UseCaseReviewWorkbench({ project, snapshot, stageState, 
 					{machineIssues.length ? (
 						<section className="use-case-machine-issues" aria-labelledby="use-case-machine-issues-title">
 							<h2 id="use-case-machine-issues-title">Machine review findings</h2>
-							<ul>
+							<List>
 								{machineIssues.map((issue) => (
-									<li key={issue}>{issue}</li>
+									<ListItem key={issue}>{issue}</ListItem>
 								))}
-							</ul>
+							</List>
 						</section>
 					) : null}
-				</details>
+				</Disclosure>
 			</div>
 			<div className="artifact-review-columns">
 				<section className="use-case-collection" aria-labelledby="use-case-collection-title">
-					<div className="use-case-collection-heading">
+					<CollectionToolbar as="div" className="use-case-collection-heading">
 						<div>
 							<span className="use-case-section-kicker">Review artifact</span>
 							<h2 id="use-case-collection-title">Use case scenarios</h2>
@@ -560,7 +567,7 @@ export default function UseCaseReviewWorkbench({ project, snapshot, stageState, 
 						</div>
 						<div className="use-case-search-field">
 							<label htmlFor={searchId}>Search use cases</label>
-							<input
+							<Input
 								id={searchId}
 								type="search"
 								value={query}
@@ -569,18 +576,23 @@ export default function UseCaseReviewWorkbench({ project, snapshot, stageState, 
 								placeholder="Requirement, scenario, risk, or constraint"
 							/>
 						</div>
-					</div>
+					</CollectionToolbar>
 
 					{filteredGroups.length > 1 ? (
 						<div className="use-case-group-toolbar">
-							<button type="button" className="use-case-group-toggle-all" onClick={() => setAllGroupsExpanded(!groupsExpandedByDefault)}>
+							<Button
+								variant="plain"
+								type="button"
+								className="use-case-group-toggle-all"
+								onClick={() => setAllGroupsExpanded(!groupsExpandedByDefault)}
+							>
 								{groupsExpandedByDefault ? "Collapse all groups" : "Expand all groups"}
-							</button>
+							</Button>
 						</div>
 					) : null}
 
 					{filteredGroups.length ? (
-						<div className="use-case-group-list" aria-label="Use Case groups">
+						<List as="div" variant="grouped" className="use-case-group-list" aria-label="Use Case groups">
 							{filteredGroups.map((group, groupIndex) => {
 								const groupKey = group.requirement_id || normalizeText(group.requirement_text) || `group-${groupIndex}`;
 								const titleId = `use-case-group-${groupIndex}-${`${group.requirement_id || "requirement"}`.replace(/[^a-zA-Z0-9_-]/g, "-")}`;
@@ -591,7 +603,7 @@ export default function UseCaseReviewWorkbench({ project, snapshot, stageState, 
 										aria-label={`${group.requirement_id || "Unidentified"} · ${group.requirement_text || "Requirement coverage"}`}
 										key={groupKey}
 									>
-										<details
+										<Disclosure
 											className="use-case-group-details"
 											open={isOpen}
 											onToggle={(event) => {
@@ -611,32 +623,34 @@ export default function UseCaseReviewWorkbench({ project, snapshot, stageState, 
 												</strong>
 											</summary>
 											{group.scenarios.length ? (
-												<ul
+												<List
 													className="use-case-scenario-list"
 													aria-label={`Scenarios for ${group.requirement_id || "unidentified requirement"}`}
 												>
 													{group.scenarios.map((scenario, scenarioIndex) => (
 														<ScenarioCard key={scenario.id || `${group.requirement_id}-${scenarioIndex}`} scenario={scenario} />
 													))}
-												</ul>
+												</List>
 											) : (
-												<p className="use-case-context-empty">No scenarios were generated for this requirement.</p>
+												<CollectionState as="p" kind="empty" className="use-case-context-empty">
+													No scenarios were generated for this requirement.
+												</CollectionState>
 											)}
-											<details className="use-case-coverage-context">
+											<Disclosure className="use-case-coverage-context">
 												<summary aria-label={`Coverage context for ${group.requirement_id || "unidentified requirement"}`}>
 													Coverage context
 												</summary>
 												<CoverageContext analysis={group.analysis} />
-											</details>
-										</details>
+											</Disclosure>
+										</Disclosure>
 									</section>
 								);
 							})}
-						</div>
+						</List>
 					) : (
-						<div className="use-case-search-empty" role="status">
+						<CollectionState as="div" kind="filtered" className="use-case-search-empty" role="status">
 							<strong>No use cases match “{query}”.</strong>
-							<button
+							<Button
 								type="button"
 								className="secondary"
 								onClick={() => {
@@ -645,15 +659,15 @@ export default function UseCaseReviewWorkbench({ project, snapshot, stageState, 
 								}}
 							>
 								Clear search
-							</button>
-						</div>
+							</Button>
+						</CollectionState>
 					)}
 				</section>
 
 				<ReviewDecisionPanel stageState={effectiveStageState} snapshot={snapshot} review={review} />
 			</div>
 
-			<details className="use-case-provenance">
+			<Disclosure className="use-case-provenance">
 				<summary>Details</summary>
 				<dl>
 					<div>
@@ -685,7 +699,7 @@ export default function UseCaseReviewWorkbench({ project, snapshot, stageState, 
 						</div>
 					) : null}
 				</dl>
-			</details>
+			</Disclosure>
 		</div>
 	);
 }

--- a/frontend/src/components/reviews/UseCaseReviewWorkbench.jsx
+++ b/frontend/src/components/reviews/UseCaseReviewWorkbench.jsx
@@ -169,17 +169,21 @@ function ArtifactSummary({ project, snapshot, stageState, scenarioTotal, groupTo
 function ScenarioCard({ scenario }) {
 	return (
 		<li className="use-case-scenario-card">
-			<div className="use-case-scenario-heading">
-				<div>
-					<span className="use-case-scenario-type">{formatWorkspaceLabel(scenario.scenario_type, "Scenario")}</span>
-					<h4>{scenario.title || scenario.objective || "Untitled scenario"}</h4>
+			<details className="scenario-details">
+				<summary>
+					<span className="scenario-summary-copy">
+						<span className="use-case-scenario-type">{scenario.id || formatWorkspaceLabel(scenario.scenario_type, "Scenario")}</span>
+						<strong>{scenario.title || scenario.objective || "Untitled scenario"}</strong>
+					</span>
+				</summary>
+				<div className="scenario-expanded-content">
+					<p>{scenario.objective || "No additional objective provided."}</p>
+					<span>
+						{formatWorkspaceLabel(scenario.scenario_type, "Scenario")} · {formatWorkspaceLabel(scenario.priority, "Unprioritized")} ·{" "}
+						{scenario.must_have ? "Must have" : "Recommended"}
+					</span>
 				</div>
-				<div className="use-case-scenario-badges" aria-label="Scenario priority">
-					<span>{formatWorkspaceLabel(scenario.priority, "Unprioritized")}</span>
-					<span className={scenario.must_have ? "required" : "recommended"}>{scenario.must_have ? "Must have" : "Recommended"}</span>
-				</div>
-			</div>
-			{scenario.objective && scenario.objective !== scenario.title ? <p>{scenario.objective}</p> : null}
+			</details>
 		</li>
 	);
 }
@@ -287,7 +291,7 @@ function ReviewDecisionPanel({ stageState, snapshot, review }) {
 			<div className="use-case-decision-heading">
 				<div>
 					<span className="use-case-section-kicker">Human decision</span>
-					<h2>Complete this review</h2>
+					<h2>Review decision</h2>
 					<p>{humanMeta.label}. Your decision applies only to the current immutable artifact.</p>
 				</div>
 			</div>
@@ -419,8 +423,14 @@ function ReviewDecisionPanel({ stageState, snapshot, review }) {
 						? "Your feedback will be recorded with the decision."
 						: "Approval advances the durable project review state."}
 				</p>
-				<button type="submit" disabled={formDisabled || (review.decision === "approve" && approvalBlocked)}>
-					{review.isSubmitting ? "Saving decision…" : review.decision === "request_changes" ? "Request changes" : "Approve Use Cases"}
+				<button type="submit" disabled={!review.decision || formDisabled || (review.decision === "approve" && approvalBlocked)}>
+					{review.isSubmitting
+						? "Saving decision…"
+						: !review.decision
+							? "Choose a decision"
+							: review.decision === "request_changes"
+								? "Request changes"
+								: "Approve Use Cases"}
 				</button>
 			</div>
 		</form>
@@ -497,139 +507,151 @@ export default function UseCaseReviewWorkbench({ project, snapshot, stageState, 
 
 	return (
 		<div className="use-case-review-workbench">
-			<ArtifactSummary
-				project={project}
-				snapshot={snapshot}
-				stageState={effectiveStageState}
-				scenarioTotal={scenarioTotal}
-				groupTotal={coveragePlan.length}
-				machineReview={machineReview}
-				humanReview={humanReview}
-			/>
-
-			<section className="use-case-coverage-metrics" aria-label="Coverage metrics">
-				{coverageMetrics.map((metric) => (
-					<div key={metric.label}>
-						<span>{metric.label}</span>
-						<strong>{metric.value}</strong>
-					</div>
-				))}
-			</section>
-
-			{machineIssues.length ? (
-				<section className="use-case-machine-issues" aria-labelledby="use-case-machine-issues-title">
-					<h2 id="use-case-machine-issues-title">Machine review findings</h2>
-					<ul>
-						{machineIssues.map((issue) => (
-							<li key={issue}>{issue}</li>
-						))}
-					</ul>
-				</section>
-			) : null}
-
-			<section className="use-case-collection" aria-labelledby="use-case-collection-title">
-				<div className="use-case-collection-heading">
-					<div>
-						<span className="use-case-section-kicker">Review artifact</span>
-						<h2 id="use-case-collection-title">Use case scenarios</h2>
-						<p role="status" aria-live="polite">
-							Showing {visibleScenarioTotal} of {scenarioTotal} scenarios across {filteredGroups.length} of {coveragePlan.length}{" "}
-							requirement groups.
-						</p>
-					</div>
-					<div className="use-case-search-field">
-						<label htmlFor={searchId}>Search use cases</label>
-						<input
-							id={searchId}
-							type="search"
-							value={query}
-							ref={searchRef}
-							onChange={(event) => updateQuery(event.target.value)}
-							placeholder="Requirement, scenario, risk, or constraint"
-						/>
-					</div>
+			<div className="use-case-meta-row">
+				<div className="use-case-compact-summary">
+					<strong>{scenarioTotal} scenarios</strong>
+					<span>{coveragePlan.length} requirement groups</span>
+					<span>Use Cases v{snapshot.version ?? stageState?.version ?? "—"}</span>
+					<span>{effectiveStageState?.stale ? "Stale artifact" : "Current artifact"}</span>
 				</div>
+				<details className="use-case-supporting-details">
+					<summary>Quality, coverage and review history</summary>
+					<ArtifactSummary
+						project={project}
+						snapshot={snapshot}
+						stageState={effectiveStageState}
+						scenarioTotal={scenarioTotal}
+						groupTotal={coveragePlan.length}
+						machineReview={machineReview}
+						humanReview={humanReview}
+					/>
 
-				{filteredGroups.length > 1 ? (
-					<div className="use-case-group-toolbar">
-						<button type="button" className="use-case-group-toggle-all" onClick={() => setAllGroupsExpanded(!groupsExpandedByDefault)}>
-							{groupsExpandedByDefault ? "Collapse all groups" : "Expand all groups"}
-						</button>
+					<section className="use-case-coverage-metrics" aria-label="Coverage metrics">
+						{coverageMetrics.map((metric) => (
+							<div key={metric.label}>
+								<span>{metric.label}</span>
+								<strong>{metric.value}</strong>
+							</div>
+						))}
+					</section>
+
+					{machineIssues.length ? (
+						<section className="use-case-machine-issues" aria-labelledby="use-case-machine-issues-title">
+							<h2 id="use-case-machine-issues-title">Machine review findings</h2>
+							<ul>
+								{machineIssues.map((issue) => (
+									<li key={issue}>{issue}</li>
+								))}
+							</ul>
+						</section>
+					) : null}
+				</details>
+			</div>
+			<div className="artifact-review-columns">
+				<section className="use-case-collection" aria-labelledby="use-case-collection-title">
+					<div className="use-case-collection-heading">
+						<div>
+							<span className="use-case-section-kicker">Review artifact</span>
+							<h2 id="use-case-collection-title">Use case scenarios</h2>
+							<p role="status" aria-live="polite">
+								Showing {visibleScenarioTotal} of {scenarioTotal} scenarios across {filteredGroups.length} of {coveragePlan.length}{" "}
+								requirement groups.
+							</p>
+						</div>
+						<div className="use-case-search-field">
+							<label htmlFor={searchId}>Search use cases</label>
+							<input
+								id={searchId}
+								type="search"
+								value={query}
+								ref={searchRef}
+								onChange={(event) => updateQuery(event.target.value)}
+								placeholder="Requirement, scenario, risk, or constraint"
+							/>
+						</div>
 					</div>
-				) : null}
 
-				{filteredGroups.length ? (
-					<div className="use-case-group-list" aria-label="Use Case groups">
-						{filteredGroups.map((group, groupIndex) => {
-							const groupKey = group.requirement_id || normalizeText(group.requirement_text) || `group-${groupIndex}`;
-							const titleId = `use-case-group-${groupIndex}-${`${group.requirement_id || "requirement"}`.replace(/[^a-zA-Z0-9_-]/g, "-")}`;
-							const isOpen = groupToggles[groupKey] ?? groupsExpandedByDefault;
-							return (
-								<section
-									className="use-case-group"
-									aria-label={`${group.requirement_id || "Unidentified"} · ${group.requirement_text || "Requirement coverage"}`}
-									key={groupKey}
-								>
-									<details
-										className="use-case-group-details"
-										open={isOpen}
-										onToggle={(event) => {
-											const nextOpen = event.currentTarget.open;
-											if (nextOpen !== isOpen) {
-												setGroupToggles((previous) => ({ ...previous, [groupKey]: nextOpen }));
-											}
-										}}
+					{filteredGroups.length > 1 ? (
+						<div className="use-case-group-toolbar">
+							<button type="button" className="use-case-group-toggle-all" onClick={() => setAllGroupsExpanded(!groupsExpandedByDefault)}>
+								{groupsExpandedByDefault ? "Collapse all groups" : "Expand all groups"}
+							</button>
+						</div>
+					) : null}
+
+					{filteredGroups.length ? (
+						<div className="use-case-group-list" aria-label="Use Case groups">
+							{filteredGroups.map((group, groupIndex) => {
+								const groupKey = group.requirement_id || normalizeText(group.requirement_text) || `group-${groupIndex}`;
+								const titleId = `use-case-group-${groupIndex}-${`${group.requirement_id || "requirement"}`.replace(/[^a-zA-Z0-9_-]/g, "-")}`;
+								const isOpen = groupToggles[groupKey] ?? groupsExpandedByDefault;
+								return (
+									<section
+										className="use-case-group"
+										aria-label={`${group.requirement_id || "Unidentified"} · ${group.requirement_text || "Requirement coverage"}`}
+										key={groupKey}
 									>
-										<summary className="use-case-group-heading">
-											<div>
-												<span>Source requirement {group.requirement_id || "Unidentified"}</span>
-												<h3 id={titleId}>{group.requirement_text || "Requirement coverage"}</h3>
-											</div>
-											<strong>
-												{group.scenarios.length} scenario{group.scenarios.length === 1 ? "" : "s"}
-											</strong>
-										</summary>
-										{group.scenarios.length ? (
-											<ul
-												className="use-case-scenario-list"
-												aria-label={`Scenarios for ${group.requirement_id || "unidentified requirement"}`}
-											>
-												{group.scenarios.map((scenario, scenarioIndex) => (
-													<ScenarioCard key={scenario.id || `${group.requirement_id}-${scenarioIndex}`} scenario={scenario} />
-												))}
-											</ul>
-										) : (
-											<p className="use-case-context-empty">No scenarios were generated for this requirement.</p>
-										)}
-										<details className="use-case-coverage-context">
-											<summary aria-label={`Coverage context for ${group.requirement_id || "unidentified requirement"}`}>
-												Coverage context
+										<details
+											className="use-case-group-details"
+											open={isOpen}
+											onToggle={(event) => {
+												const nextOpen = event.currentTarget.open;
+												if (nextOpen !== isOpen) {
+													setGroupToggles((previous) => ({ ...previous, [groupKey]: nextOpen }));
+												}
+											}}
+										>
+											<summary className="use-case-group-heading">
+												<div>
+													<span>Source requirement {group.requirement_id || "Unidentified"}</span>
+													<h3 id={titleId}>{group.requirement_text || "Requirement coverage"}</h3>
+												</div>
+												<strong>
+													{group.scenarios.length} scenario{group.scenarios.length === 1 ? "" : "s"}
+												</strong>
 											</summary>
-											<CoverageContext analysis={group.analysis} />
+											{group.scenarios.length ? (
+												<ul
+													className="use-case-scenario-list"
+													aria-label={`Scenarios for ${group.requirement_id || "unidentified requirement"}`}
+												>
+													{group.scenarios.map((scenario, scenarioIndex) => (
+														<ScenarioCard key={scenario.id || `${group.requirement_id}-${scenarioIndex}`} scenario={scenario} />
+													))}
+												</ul>
+											) : (
+												<p className="use-case-context-empty">No scenarios were generated for this requirement.</p>
+											)}
+											<details className="use-case-coverage-context">
+												<summary aria-label={`Coverage context for ${group.requirement_id || "unidentified requirement"}`}>
+													Coverage context
+												</summary>
+												<CoverageContext analysis={group.analysis} />
+											</details>
 										</details>
-									</details>
-								</section>
-							);
-						})}
-					</div>
-				) : (
-					<div className="use-case-search-empty" role="status">
-						<strong>No use cases match “{query}”.</strong>
-						<button
-							type="button"
-							className="secondary"
-							onClick={() => {
-								updateQuery("");
-								window.requestAnimationFrame(() => searchRef.current?.focus());
-							}}
-						>
-							Clear search
-						</button>
-					</div>
-				)}
-			</section>
+									</section>
+								);
+							})}
+						</div>
+					) : (
+						<div className="use-case-search-empty" role="status">
+							<strong>No use cases match “{query}”.</strong>
+							<button
+								type="button"
+								className="secondary"
+								onClick={() => {
+									updateQuery("");
+									window.requestAnimationFrame(() => searchRef.current?.focus());
+								}}
+							>
+								Clear search
+							</button>
+						</div>
+					)}
+				</section>
 
-			<ReviewDecisionPanel stageState={effectiveStageState} snapshot={snapshot} review={review} />
+				<ReviewDecisionPanel stageState={effectiveStageState} snapshot={snapshot} review={review} />
+			</div>
 
 			<details className="use-case-provenance">
 				<summary>Details</summary>

--- a/frontend/src/components/settings/SettingsDialog.jsx
+++ b/frontend/src/components/settings/SettingsDialog.jsx
@@ -1,3 +1,6 @@
+import { Dialog } from "../ui/dialog";
+import { Button } from "../ui/controls";
+import { TabList, Tab, TabPanel } from "../ui/tabs";
 import AzureDevOpsConnectionSettings from "../integrations/AzureDevOpsConnectionSettings";
 import JiraConnectionSettings from "../integrations/JiraConnectionSettings";
 import WorkflowSettingsPanel from "../workflow/WorkflowSettingsPanel";
@@ -22,7 +25,9 @@ export default function SettingsDialog({
 
 	return (
 		<div className="auth-dialog-overlay settings-dialog-overlay" onClick={onOverlayClick}>
-			<div
+			<Dialog
+				manageFocus
+				onClose={onClose}
 				className="settings-dialog"
 				role="dialog"
 				aria-modal="true"
@@ -34,27 +39,33 @@ export default function SettingsDialog({
 						<h2 id="settings-dialog-title">Settings</h2>
 						<p>Manage one-time connections and advanced workflow tuning without crowding the main pipeline.</p>
 					</div>
-					<button type="button" className="auth-dialog-close" onClick={onClose} aria-label="Close settings dialog">
+					<Button variant="plain" type="button" className="auth-dialog-close" onClick={onClose} aria-label="Close settings dialog">
 						×
-					</button>
+					</Button>
 				</div>
-				<div className="settings-dialog-nav" role="tablist" aria-label="Settings sections">
-					<button
+				<TabList className="settings-dialog-nav" role="tablist" aria-label="Settings sections">
+					<Tab
 						type="button"
+						id="settings-workflow-tab"
+						selected={settingsSection === "workflow"}
+						aria-controls="settings-section-panel"
 						className={`settings-nav-btn ${settingsSection === "workflow" ? "active" : ""}`}
 						onClick={() => setSettingsSection("workflow")}
 					>
 						Workflow tuning
-					</button>
-					<button
+					</Tab>
+					<Tab
 						type="button"
+						id="settings-integrations-tab"
+						selected={settingsSection === "integrations"}
+						aria-controls="settings-section-panel"
 						className={`settings-nav-btn ${settingsSection === "integrations" ? "active" : ""}`}
 						onClick={() => setSettingsSection("integrations")}
 					>
 						Integrations
-					</button>
-				</div>
-				<div className="settings-dialog-body">
+					</Tab>
+				</TabList>
+				<TabPanel id="settings-section-panel" aria-labelledby={`settings-${settingsSection}-tab`} className="settings-dialog-body">
 					{settingsSection === "workflow" ? (
 						<>
 							<div className="settings-section-intro">
@@ -89,8 +100,8 @@ export default function SettingsDialog({
 							</div>
 						</>
 					)}
-				</div>
-			</div>
+				</TabPanel>
+			</Dialog>
 		</div>
 	);
 }

--- a/frontend/src/components/template/TemplateSetupPanel.jsx
+++ b/frontend/src/components/template/TemplateSetupPanel.jsx
@@ -1,3 +1,4 @@
+import { Field, Input, Select, Button } from "../ui/controls";
 import { TEMPLATE_FORMAT_OPTIONS } from "../../constants/workflow";
 
 export default function TemplateSetupPanel({ templateName, setTemplateName, templateFormat, setTemplateFormat, goPrev, goNext }) {
@@ -6,34 +7,35 @@ export default function TemplateSetupPanel({ templateName, setTemplateName, temp
 			<h2 className="panel-title">Template Setup</h2>
 			<p className="panel-description">Configure the template name and output format for generated test cases.</p>
 			<div className="panel-form">
-				<div className="form-group">
-					<label>Template name</label>
-					<input placeholder="default" value={templateName} onChange={(e) => setTemplateName(e.target.value)} />
-				</div>
-				<div className="form-group">
-					<label>Template format</label>
-					<select value={templateFormat} onChange={(e) => setTemplateFormat(e.target.value)}>
+				<Field className="form-group" label="Template name">
+					<Input placeholder="default" value={templateName} onChange={(e) => setTemplateName(e.target.value)} />
+				</Field>
+				<Field
+					className="form-group"
+					label="Template format"
+					hint={
+						TEMPLATE_FORMAT_OPTIONS.find((option) => option.value === templateFormat)?.description ||
+						"Choose the exported test-case format."
+					}
+				>
+					<Select value={templateFormat} onChange={(e) => setTemplateFormat(e.target.value)}>
 						{TEMPLATE_FORMAT_OPTIONS.map((option) => (
 							<option key={option.value} value={option.value}>
 								{option.label}
 							</option>
 						))}
-					</select>
-					<span className="field-hint">
-						{TEMPLATE_FORMAT_OPTIONS.find((option) => option.value === templateFormat)?.description ||
-							"Choose how generated cases should be displayed."}
-					</span>
-				</div>
+					</Select>
+				</Field>
 			</div>
 			<span className="helper-text">
 				Fields used: id, title, description, priority, type, status, preconditions, steps, expected result, test data, estimated time,
 				automation status, component, linked requirement IDs, scenario refs, source refs, and tags.
 			</span>
 			<div className="panel-nav">
-				<button onClick={goPrev} className="secondary">
+				<Button onClick={goPrev} className="secondary">
 					Back
-				</button>
-				<button onClick={goNext}>Next</button>
+				</Button>
+				<Button onClick={goNext}>Next</Button>
 			</div>
 		</section>
 	);

--- a/frontend/src/components/template/TemplateSetupPanel.jsx
+++ b/frontend/src/components/template/TemplateSetupPanel.jsx
@@ -1,9 +1,10 @@
+import { Surface } from "../ui/surfaces";
 import { Field, Input, Select, Button } from "../ui/controls";
 import { TEMPLATE_FORMAT_OPTIONS } from "../../constants/workflow";
 
 export default function TemplateSetupPanel({ templateName, setTemplateName, templateFormat, setTemplateFormat, goPrev, goNext }) {
 	return (
-		<section className="panel">
+		<Surface as="section" className="panel">
 			<h2 className="panel-title">Template Setup</h2>
 			<p className="panel-description">Configure the template name and output format for generated test cases.</p>
 			<div className="panel-form">
@@ -37,6 +38,6 @@ export default function TemplateSetupPanel({ templateName, setTemplateName, temp
 				</Button>
 				<Button onClick={goNext}>Next</Button>
 			</div>
-		</section>
+		</Surface>
 	);
 }

--- a/frontend/src/components/ui/collections.jsx
+++ b/frontend/src/components/ui/collections.jsx
@@ -1,0 +1,60 @@
+const classes = (...values) => values.filter(Boolean).join(" ");
+
+export function Table({ density = "comfortable", className, ...props }) {
+	return <table {...props} data-ui="table" data-density={density} className={classes("ui-table", className)} />;
+}
+export function TableScroll({ as: Element = "div", className, ...props }) {
+	return <Element role="region" tabIndex={0} {...props} data-ui="table-scroll" className={classes("ui-table-scroll", className)} />;
+}
+export function List({ as: Element = "ul", variant = "plain", className, ...props }) {
+	return <Element {...props} data-ui="list" data-variant={variant} className={classes("ui-list", className)} />;
+}
+export function ListItem({ as: Element = "li", className, ...props }) {
+	return <Element {...props} data-ui="list-item" className={classes("ui-list-item", className)} />;
+}
+export function SelectableItem({ selected, className, ...props }) {
+	return (
+		<button
+			type="button"
+			{...props}
+			aria-pressed={selected ?? props["aria-pressed"]}
+			data-ui="selectable-item"
+			className={classes("ui-selectable-item", className)}
+		/>
+	);
+}
+export function ListDetail({ as: Element = "section", className, ...props }) {
+	return <Element {...props} data-ui="list-detail" className={classes("ui-list-detail", className)} />;
+}
+export function CollectionToolbar({ as: Element = "div", className, ...props }) {
+	return <Element {...props} data-ui="collection-toolbar" className={classes("ui-collection-toolbar", className)} />;
+}
+export function ResultCount({ as: Element = "p", className, ...props }) {
+	return (
+		<Element
+			role="status"
+			aria-live="polite"
+			aria-atomic="true"
+			{...props}
+			data-ui="result-count"
+			className={classes("ui-result-count", className)}
+		/>
+	);
+}
+export function CollectionState({ as: Element = "div", kind = "empty", title, description, action, children, className, ...props }) {
+	return (
+		<Element
+			role={kind === "error" ? "alert" : kind === "loading" ? "status" : undefined}
+			aria-busy={kind === "loading" || undefined}
+			{...props}
+			data-ui="collection-state"
+			data-kind={kind}
+			className={classes("ui-collection-state", className)}
+		>
+			{title && <h3>{title}</h3>}
+			{description && <p>{description}</p>}
+			{children}
+			{action}
+		</Element>
+	);
+}

--- a/frontend/src/components/ui/controls.jsx
+++ b/frontend/src/components/ui/controls.jsx
@@ -1,0 +1,73 @@
+import { cloneElement, isValidElement, useId } from "react";
+
+const classes = (...values) => values.filter(Boolean).join(" ");
+
+export function Button({ variant, size = "normal", busy = false, disabled, type = "button", className, children, ...props }) {
+	const appearance = variant || (className?.split(" ").includes("secondary") ? "secondary" : "primary");
+	return (
+		<button
+			{...props}
+			type={type}
+			disabled={disabled || busy}
+			aria-busy={busy || props["aria-busy"] || undefined}
+			data-ui={props["data-ui"] || "button"}
+			data-variant={appearance}
+			data-size={size}
+			className={classes("ui-button", className)}
+		>
+			{children}
+		</button>
+	);
+}
+
+export function Link({ className, ...props }) {
+	return <a {...props} data-ui="link" className={classes("ui-link", className)} />;
+}
+
+export function Input({ type = "text", className, ...props }) {
+	return <input {...props} type={type} data-ui="input" className={classes("ui-input", className)} />;
+}
+export function Checkbox(props) {
+	return <Input {...props} type="checkbox" />;
+}
+export function Radio(props) {
+	return <Input {...props} type="radio" />;
+}
+export function Select({ className, ...props }) {
+	return <select {...props} data-ui="select" className={classes("ui-input", className)} />;
+}
+export function Textarea({ className, ...props }) {
+	return <textarea {...props} data-ui="textarea" className={classes("ui-input", className)} />;
+}
+
+// Existing composed fields can pass children only; labeled fields associate their
+// control, help and error text without owning its value or validation policy.
+export function Field({ id, label, hint, error, children, className, ...props }) {
+	const generatedId = useId();
+	const controlId = id || generatedId;
+	const describedBy = [hint && `${controlId}-hint`, error && `${controlId}-error`].filter(Boolean).join(" ");
+	const control =
+		label && isValidElement(children)
+			? cloneElement(children, {
+					id: controlId,
+					"aria-describedby": [children.props["aria-describedby"], describedBy].filter(Boolean).join(" ") || undefined,
+					"aria-invalid": error ? true : children.props["aria-invalid"],
+				})
+			: children;
+	return (
+		<div {...props} data-ui="field" className={classes("ui-field", className)}>
+			{label && <label htmlFor={controlId}>{label}</label>}
+			{control}
+			{hint && (
+				<p id={`${controlId}-hint`} className="ui-field-hint">
+					{hint}
+				</p>
+			)}
+			{error && (
+				<p id={`${controlId}-error`} className="ui-field-error" role="alert">
+					{error}
+				</p>
+			)}
+		</div>
+	);
+}

--- a/frontend/src/components/ui/controls.jsx
+++ b/frontend/src/components/ui/controls.jsx
@@ -1,5 +1,5 @@
 import { Search } from "lucide-react";
-import { cloneElement, isValidElement, useId } from "react";
+import { Children, cloneElement, isValidElement, useId } from "react";
 
 const classes = (...values) => values.filter(Boolean).join(" ");
 
@@ -45,16 +45,34 @@ export function Textarea({ className, ...props }) {
 // control, help and error text without owning its value or validation policy.
 export function Field({ id, label, hint, error, children, className, ...props }) {
 	const generatedId = useId();
-	const controlId = id || generatedId;
-	const describedBy = [hint && `${controlId}-hint`, error && `${controlId}-error`].filter(Boolean).join(" ");
+	const parts = Children.toArray(children);
+	const controls = parts.filter((child) => isValidElement(child) && [Input, Select, Textarea, Checkbox, Radio].includes(child.type));
+	const singleControl = controls.length === 1 ? controls[0] : null;
+	const controlId = id || singleControl?.props.id || generatedId;
+	const hints = parts.filter((child) => isValidElement(child) && /(?:hint|helper-text)/.test(child.props.className || ""));
+	const describedBy = [
+		hint && `${controlId}-hint`,
+		error && `${controlId}-error`,
+		...hints.map((child, index) => child.props.id || `${controlId}-hint-${index}`),
+	]
+		.filter(Boolean)
+		.join(" ");
+	const associate = (child) =>
+		cloneElement(child, {
+			id: controlId,
+			"aria-describedby": [child.props["aria-describedby"], describedBy].filter(Boolean).join(" ") || undefined,
+			"aria-invalid": error ? true : child.props["aria-invalid"],
+		});
 	const control =
 		label && isValidElement(children)
-			? cloneElement(children, {
-					id: controlId,
-					"aria-describedby": [children.props["aria-describedby"], describedBy].filter(Boolean).join(" ") || undefined,
-					"aria-invalid": error ? true : children.props["aria-invalid"],
-				})
-			: children;
+			? associate(children)
+			: parts.map((child) => {
+					if (!isValidElement(child) || !singleControl) return child;
+					if (child === singleControl) return associate(child);
+					if (child.type === "label") return cloneElement(child, { htmlFor: child.props.htmlFor || controlId });
+					const hintIndex = hints.indexOf(child);
+					return hintIndex >= 0 ? cloneElement(child, { id: child.props.id || `${controlId}-hint-${hintIndex}` }) : child;
+				});
 	return (
 		<div {...props} data-ui="field" className={classes("ui-field", className)}>
 			{label && <label htmlFor={controlId}>{label}</label>}

--- a/frontend/src/components/ui/controls.jsx
+++ b/frontend/src/components/ui/controls.jsx
@@ -1,3 +1,4 @@
+import { Search } from "lucide-react";
 import { cloneElement, isValidElement, useId } from "react";
 
 const classes = (...values) => values.filter(Boolean).join(" ");
@@ -69,5 +70,16 @@ export function Field({ id, label, hint, error, children, className, ...props })
 				</p>
 			)}
 		</div>
+	);
+}
+
+export function SearchField({ label, className, shortcut, ...props }) {
+	return (
+		<label className={classes("ui-search", className)}>
+			<span className="sr-only">{label}</span>
+			<Search size={18} aria-hidden="true" />
+			<Input {...props} type="search" />
+			{shortcut && <kbd aria-hidden="true">{shortcut}</kbd>}
+		</label>
 	);
 }

--- a/frontend/src/components/ui/dialog.jsx
+++ b/frontend/src/components/ui/dialog.jsx
@@ -1,0 +1,60 @@
+import { useEffect, useRef } from "react";
+
+export function Dialog({ as: Element = "div", className = "", onClose, manageFocus = false, ref: externalRef, ...props }) {
+	const internalRef = useRef(null);
+	const closeRef = useRef(onClose);
+	useEffect(() => {
+		closeRef.current = onClose;
+	});
+	useEffect(() => {
+		if (!manageFocus) return;
+		const previous = document.activeElement;
+		const node = internalRef.current;
+		const targets = () =>
+			[...node.querySelectorAll("button, a[href], input, select, textarea, [tabindex]")].filter(
+				(element) => !element.disabled && element.tabIndex >= 0 && element.getClientRects().length
+			);
+		(targets()[0] || node).focus();
+		const keydown = (event) => {
+			if (event.key === "Escape" && closeRef.current) {
+				event.preventDefault();
+				event.stopPropagation();
+				closeRef.current();
+			}
+			if (event.key !== "Tab") return;
+			const items = targets();
+			const first = items[0];
+			const last = items.at(-1);
+			if (!items.length) {
+				event.preventDefault();
+				node.focus();
+			} else if (event.shiftKey && (document.activeElement === first || document.activeElement === node)) {
+				event.preventDefault();
+				last.focus();
+			} else if (!event.shiftKey && document.activeElement === last) {
+				event.preventDefault();
+				first.focus();
+			}
+		};
+		node.addEventListener("keydown", keydown);
+		return () => {
+			node.removeEventListener("keydown", keydown);
+			if (previous?.isConnected) previous.focus();
+		};
+	}, [manageFocus]);
+	return (
+		<Element
+			role="dialog"
+			aria-modal="true"
+			tabIndex={-1}
+			{...props}
+			ref={(node) => {
+				internalRef.current = node;
+				if (typeof externalRef === "function") externalRef(node);
+				else if (externalRef) externalRef.current = node;
+			}}
+			data-ui="dialog"
+			className={`ui-dialog ${className}`}
+		/>
+	);
+}

--- a/frontend/src/components/ui/dialog.jsx
+++ b/frontend/src/components/ui/dialog.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from "react";
 
-export function Dialog({ as: Element = "div", className = "", onClose, manageFocus = false, ref: externalRef, ...props }) {
+export function Dialog({ as: Element = "div", className = "", onClose, manageFocus = false, initialFocusRef, ref: externalRef, ...props }) {
 	const internalRef = useRef(null);
 	const closeRef = useRef(onClose);
 	useEffect(() => {
@@ -14,7 +14,7 @@ export function Dialog({ as: Element = "div", className = "", onClose, manageFoc
 			[...node.querySelectorAll("button, a[href], input, select, textarea, [tabindex]")].filter(
 				(element) => !element.disabled && element.tabIndex >= 0 && element.getClientRects().length
 			);
-		(targets()[0] || node).focus();
+		(initialFocusRef?.current || targets()[0] || node).focus();
 		const keydown = (event) => {
 			if (event.key === "Escape" && closeRef.current) {
 				event.preventDefault();
@@ -41,11 +41,11 @@ export function Dialog({ as: Element = "div", className = "", onClose, manageFoc
 			node.removeEventListener("keydown", keydown);
 			if (previous?.isConnected) previous.focus();
 		};
-	}, [manageFocus]);
+	}, [manageFocus, initialFocusRef]);
 	return (
 		<Element
 			role="dialog"
-			aria-modal="true"
+			aria-modal={manageFocus || undefined}
 			tabIndex={-1}
 			{...props}
 			ref={(node) => {

--- a/frontend/src/components/ui/surfaces.jsx
+++ b/frontend/src/components/ui/surfaces.jsx
@@ -1,0 +1,36 @@
+import { CircleAlert, CircleCheck, Circle, Clock3, LockKeyhole, XCircle } from "lucide-react";
+const classes = (...values) => values.filter(Boolean).join(" ");
+const icons = {
+	success: CircleCheck,
+	warning: CircleAlert,
+	danger: XCircle,
+	pending: Circle,
+	blocked: LockKeyhole,
+	running: Clock3,
+	neutral: Circle,
+	info: Circle,
+};
+
+export function Badge({ tone = "neutral", icon: Icon = icons[tone], children, className, ...props }) {
+	return (
+		<span {...props} data-ui="badge" data-tone={tone} className={classes("ui-badge", className)}>
+			{Icon && <Icon size={14} aria-hidden="true" />}
+			{children}
+		</span>
+	);
+}
+export function Surface({ as: Element = "section", tone = "neutral", className, ...props }) {
+	return <Element {...props} data-ui="surface" data-tone={tone} className={classes("ui-surface", className)} />;
+}
+export function Alert({ as: Element = "div", tone = "info", className, role, ...props }) {
+	return <Element {...props} role={role} data-ui="alert" data-tone={tone} className={classes("ui-alert", className)} />;
+}
+export function Disclosure({ className, ...props }) {
+	return <details {...props} data-ui="disclosure" className={classes("ui-disclosure", className)} />;
+}
+export function Progress({ className, ...props }) {
+	return <progress {...props} data-ui="progress" className={classes("ui-progress", className)} />;
+}
+export function Menu({ as: Element = "div", className, ...props }) {
+	return <Element role="menu" {...props} data-ui="menu" className={classes("ui-menu", className)} />;
+}

--- a/frontend/src/components/ui/tabs.jsx
+++ b/frontend/src/components/ui/tabs.jsx
@@ -1,0 +1,51 @@
+import { Button } from "./controls";
+
+export function TabList({ as: Element = "div", className = "", onKeyDown, ...props }) {
+	return (
+		<Element
+			{...props}
+			role="tablist"
+			data-ui="tablist"
+			className={`ui-tablist ${className}`}
+			onKeyDown={(event) => {
+				onKeyDown?.(event);
+				if (event.defaultPrevented || event.altKey || event.ctrlKey || event.metaKey) return;
+				const vertical = props["aria-orientation"] === "vertical";
+				const previous = vertical ? "ArrowUp" : "ArrowLeft";
+				const next = vertical ? "ArrowDown" : "ArrowRight";
+				if (![previous, next, "Home", "End"].includes(event.key)) return;
+				const tabs = [...event.currentTarget.querySelectorAll('[role="tab"]')].filter(
+					(tab) => !tab.disabled && tab.getAttribute("aria-disabled") !== "true"
+				);
+				const index = tabs.indexOf(event.target);
+				if (index < 0 || !tabs.length) return;
+				const target =
+					event.key === "Home"
+						? tabs[0]
+						: event.key === "End"
+							? tabs.at(-1)
+							: tabs[(index + (event.key === next ? 1 : tabs.length - 1)) % tabs.length];
+				event.preventDefault();
+				target.focus();
+				target.click();
+			}}
+		/>
+	);
+}
+export function Tab({ selected, className = "", ...props }) {
+	const active = selected ?? props["aria-selected"];
+	return (
+		<Button
+			variant="tab"
+			{...props}
+			role="tab"
+			aria-selected={active}
+			tabIndex={active ? 0 : -1}
+			data-ui="tab"
+			className={`ui-tab ${className}`}
+		/>
+	);
+}
+export function TabPanel({ as: Element = "div", className = "", ...props }) {
+	return <Element role="tabpanel" tabIndex={0} {...props} data-ui="tabpanel" className={`ui-tabpanel ${className}`} />;
+}

--- a/frontend/src/components/workflow/StatusBadge.jsx
+++ b/frontend/src/components/workflow/StatusBadge.jsx
@@ -1,3 +1,4 @@
+import { Badge } from "../ui/surfaces";
 import { CheckCircle2, Circle, CircleAlert, Clock3, LockKeyhole, MapPin, XCircle } from "lucide-react";
 
 const STATUS_ICONS = Object.freeze({
@@ -28,10 +29,25 @@ export default function StatusBadge({ status, label, compact = false, accessible
 	const Icon = STATUS_ICONS[tone] || Circle;
 	const classes = ["status-badge-token", `status-badge-token--${tone}`, compact ? "compact" : "", className].filter(Boolean).join(" ");
 
+	const tones = {
+		complete: "success",
+		attention: "warning",
+		blocked: "blocked",
+		failed: "danger",
+		running: "running",
+		active: "info",
+		pending: "pending",
+	};
 	return (
-		<span className={classes} data-status-tone={tone} aria-label={accessibleLabel || undefined} title={compact ? label : undefined}>
-			<Icon aria-hidden="true" size={14} strokeWidth={2.25} />
+		<Badge
+			tone={tones[tone]}
+			icon={Icon}
+			className={classes}
+			data-status-tone={tone}
+			aria-label={accessibleLabel || undefined}
+			title={compact ? label : undefined}
+		>
 			<span className="status-badge-token-label">{label}</span>
-		</span>
+		</Badge>
 	);
 }

--- a/frontend/src/components/workflow/WorkflowDiagnostics.jsx
+++ b/frontend/src/components/workflow/WorkflowDiagnostics.jsx
@@ -1,3 +1,4 @@
+import { List, ListItem } from "../ui/collections";
 const SOURCE_LABELS = {
 	model: "Model-authored",
 	model_recovered: "Recovered model",
@@ -124,31 +125,31 @@ export default function WorkflowDiagnostics({ title, diagnostics, appliedSetting
 			{actionableWarnings.length > 0 && (
 				<div className="workflow-diagnostics-block warning">
 					<strong>Warnings</strong>
-					<ul>
+					<List>
 						{actionableWarnings.map((warning) => (
-							<li key={warning}>{warning}</li>
+							<ListItem key={warning}>{warning}</ListItem>
 						))}
-					</ul>
+					</List>
 				</div>
 			)}
 			{parserRecoveries.length > 0 && (
 				<div className="workflow-diagnostics-block info">
 					<strong>Parser recoveries</strong>
-					<ul>
+					<List>
 						{parserRecoveries.map((recovery) => (
-							<li key={recovery}>{recovery}</li>
+							<ListItem key={recovery}>{recovery}</ListItem>
 						))}
-					</ul>
+					</List>
 				</div>
 			)}
 			{parserFailures.length > 0 && (
 				<div className="workflow-diagnostics-block alert">
 					<strong>Parser issues</strong>
-					<ul>
+					<List>
 						{parserFailures.map((failure) => (
-							<li key={failure}>{failure}</li>
+							<ListItem key={failure}>{failure}</ListItem>
 						))}
-					</ul>
+					</List>
 				</div>
 			)}
 		</div>

--- a/frontend/src/components/workflow/WorkflowSettingsPanel.jsx
+++ b/frontend/src/components/workflow/WorkflowSettingsPanel.jsx
@@ -1,3 +1,4 @@
+import { Field, Input } from "../ui/controls";
 import { WORKFLOW_SETTING_FIELDS } from "../../constants/workflow";
 
 export default function WorkflowSettingsPanel({ title, description, settings, setSettings }) {
@@ -16,9 +17,9 @@ export default function WorkflowSettingsPanel({ title, description, settings, se
 			</div>
 			<div className="workflow-settings-grid">
 				{WORKFLOW_SETTING_FIELDS.map((field) => (
-					<div className="form-group" key={field.key}>
+					<Field className="form-group" key={field.key}>
 						<label>{field.label}</label>
-						<input
+						<Input
 							type="number"
 							min={field.min}
 							max={field.max}
@@ -26,7 +27,7 @@ export default function WorkflowSettingsPanel({ title, description, settings, se
 							value={settings[field.key]}
 							onChange={updateWorkflowSetting(field.key)}
 						/>
-					</div>
+					</Field>
 				))}
 			</div>
 			<p className="workflow-settings-help">Leave any field blank to use the backend default for that workflow.</p>

--- a/frontend/src/components/workspace/ActivityIndex.jsx
+++ b/frontend/src/components/workspace/ActivityIndex.jsx
@@ -1,3 +1,6 @@
+import { Badge } from "../ui/surfaces";
+import { CollectionToolbar, CollectionState } from "../ui/collections";
+import { Select, Button } from "../ui/controls";
 import { CheckCircle2, Circle, CircleAlert, Clock3, FileText, SearchX, XCircle } from "lucide-react";
 
 import { formatWorkspaceStatus, getWorkspaceStatusTone } from "./workspacePresentation";
@@ -31,15 +34,16 @@ export function ActivityStatus({ status, kind }) {
 	const Icon = kind === "report" ? getReportStatusIcon(status) : getRunStatusIcon(status);
 	const label = formatActivityStatus(status, kind);
 	return (
-		<span
+		<Badge
+			tone={getWorkspaceStatusTone(status)}
+			icon={Icon}
 			className={`activity-index-status activity-index-status-${getWorkspaceStatusTone(status)}`}
 			data-status-kind={kind}
 			data-status-value={status || "unknown"}
 		>
-			<Icon aria-hidden="true" size={15} />
 			<span className="sr-only">Status: </span>
 			{label}
-		</span>
+		</Badge>
 	);
 }
 
@@ -60,7 +64,7 @@ export function ActivityIndexFilters({
 	};
 
 	return (
-		<fieldset className="activity-index-controls" aria-label={`Filter ${name.toLocaleLowerCase()}`}>
+		<CollectionToolbar as="fieldset" className="activity-index-controls" aria-label={`Filter ${name.toLocaleLowerCase()}`}>
 			<legend className="sr-only">Filter {name.toLocaleLowerCase()}</legend>
 			<WorkspaceSearch
 				value={query}
@@ -73,23 +77,23 @@ export function ActivityIndexFilters({
 				{filters.map((filter) => (
 					<label key={filter.id}>
 						<span>{filter.label}</span>
-						<select ref={filter.selectRef} value={filter.value} onChange={(event) => filter.onChange(event.target.value)}>
+						<Select ref={filter.selectRef} value={filter.value} onChange={(event) => filter.onChange(event.target.value)}>
 							<option value="all">{filter.allLabel}</option>
 							{filter.options.map((option) => (
 								<option value={option.value} key={option.value}>
 									{option.label}
 								</option>
 							))}
-						</select>
+						</Select>
 					</label>
 				))}
 				{hasActiveFilters ? (
-					<button type="button" className="activity-index-clear-filters" onClick={clearFilters}>
+					<Button type="button" className="activity-index-clear-filters" onClick={clearFilters}>
 						Clear filters
-					</button>
+					</Button>
 				) : null}
 			</div>
-		</fieldset>
+		</CollectionToolbar>
 	);
 }
 
@@ -111,14 +115,14 @@ export function ActivityIndexResultsHeading({ id, eyebrow, title, countLabel, he
 
 export function ActivityIndexEmpty({ title, message }) {
 	return (
-		<section className="activity-index-empty" aria-labelledby="activity-index-empty-title">
-			<span className="activity-index-empty-icon">
+		<CollectionState as="section" kind="empty" className="activity-index-empty" aria-labelledby="activity-index-empty-title">
+			<CollectionState as="span" kind="empty" className="activity-index-empty-icon">
 				<SearchX aria-hidden="true" size={22} />
-			</span>
+			</CollectionState>
 			<div>
 				<h2 id="activity-index-empty-title">{title}</h2>
 				<p>{message}</p>
 			</div>
-		</section>
+		</CollectionState>
 	);
 }

--- a/frontend/src/components/workspace/HomeWorkspaceSections.jsx
+++ b/frontend/src/components/workspace/HomeWorkspaceSections.jsx
@@ -1,3 +1,5 @@
+import { List, ListItem, CollectionState } from "../ui/collections";
+import { Button } from "../ui/controls";
 import { useState } from "react";
 import { Activity, ClipboardCheck, FileText, FolderKanban, PlayCircle } from "lucide-react";
 
@@ -106,9 +108,9 @@ export function MyWorkSection({
 										{group.items.length}
 									</span>
 								</h3>
-								<ul id={workItemListId}>
+								<List id={workItemListId}>
 									{visibleItems.map((item) => (
-										<li key={item.work_item_id}>
+										<ListItem key={item.work_item_id}>
 											<div className="workspace-work-item-copy">
 												<div className="workspace-card-meta">
 													<span>{item.project_name || "Project"}</span>
@@ -121,11 +123,11 @@ export function MyWorkSection({
 											<ProjectOpenLink projectId={item.project_id} destination={getWorkItemDestination(item)} onOpenProject={onOpenProject}>
 												Open
 											</ProjectOpenLink>
-										</li>
+										</ListItem>
 									))}
-								</ul>
+								</List>
 								{hiddenCount > 0 ? (
-									<button
+									<Button
 										type="button"
 										className="workspace-show-more"
 										aria-controls={workItemListId}
@@ -133,7 +135,7 @@ export function MyWorkSection({
 										onClick={() => toggleGroup(group.id)}
 									>
 										{isExpanded ? "Show fewer" : `Show ${hiddenCount} more`}
-									</button>
+									</Button>
 								) : null}
 							</section>
 						);
@@ -169,9 +171,9 @@ export function WorkspaceProjectsSection({
 				</div>
 			</div>
 			{projects.length ? (
-				<ul className="workspace-project-grid">
+				<List className="workspace-project-grid">
 					{projects.map((project) => (
-						<li className="workspace-project-card" key={project.project_id}>
+						<ListItem className="workspace-project-card" key={project.project_id}>
 							<div className="workspace-project-card-heading">
 								<FolderKanban aria-hidden="true" size={19} />
 								<div>
@@ -188,13 +190,13 @@ export function WorkspaceProjectsSection({
 									Open
 								</ProjectOpenLink>
 							</div>
-						</li>
+						</ListItem>
 					))}
-				</ul>
+				</List>
 			) : (
-				<p className="workspace-filter-empty" role="status">
+				<CollectionState as="p" kind="filtered" className="workspace-filter-empty" role="status">
 					{emptyMessage}
-				</p>
+				</CollectionState>
 			)}
 		</section>
 	);
@@ -202,7 +204,7 @@ export function WorkspaceProjectsSection({
 
 function RunActivity({ run, onOpenProject }) {
 	return (
-		<li>
+		<ListItem>
 			<PlayCircle aria-hidden="true" size={18} />
 			<div>
 				<div className="workspace-card-meta">
@@ -218,13 +220,13 @@ function RunActivity({ run, onOpenProject }) {
 			<ProjectOpenLink projectId={run.project_id} destination={PROJECT_DESTINATIONS.AUTOMATION} onOpenProject={onOpenProject}>
 				View
 			</ProjectOpenLink>
-		</li>
+		</ListItem>
 	);
 }
 
 function ReportActivity({ report, onOpenProject }) {
 	return (
-		<li>
+		<ListItem>
 			<FileText aria-hidden="true" size={18} />
 			<div>
 				<div className="workspace-card-meta">
@@ -238,7 +240,7 @@ function ReportActivity({ report, onOpenProject }) {
 			<ProjectOpenLink projectId={report.project_id} destination={PROJECT_DESTINATIONS.REPORTS} onOpenProject={onOpenProject}>
 				View
 			</ProjectOpenLink>
-		</li>
+		</ListItem>
 	);
 }
 
@@ -267,21 +269,21 @@ export function RecentActivitySection({
 					{visibleRuns.length ? (
 						<section aria-labelledby="recent-runs-title">
 							<h3 id="recent-runs-title">Runs</h3>
-							<ul>
+							<List>
 								{visibleRuns.map((run) => (
 									<RunActivity key={run.run_record_id} run={run} onOpenProject={onOpenProject} />
 								))}
-							</ul>
+							</List>
 						</section>
 					) : null}
 					{visibleReports.length ? (
 						<section aria-labelledby="recent-reports-title">
 							<h3 id="recent-reports-title">Reports</h3>
-							<ul>
+							<List>
 								{visibleReports.map((report) => (
 									<ReportActivity key={report.report_id} report={report} onOpenProject={onOpenProject} />
 								))}
-							</ul>
+							</List>
 						</section>
 					) : null}
 				</div>

--- a/frontend/src/components/workspace/HomeWorkspaceSections.jsx
+++ b/frontend/src/components/workspace/HomeWorkspaceSections.jsx
@@ -3,6 +3,7 @@ import { Activity, ClipboardCheck, FileText, FolderKanban, PlayCircle } from "lu
 
 import { PROJECT_DESTINATIONS } from "../../app/workflowRoutes";
 import {
+	formatWorkItemCount,
 	formatWorkspaceDate,
 	formatWorkspaceLabel,
 	getProjectDestination,
@@ -37,7 +38,7 @@ export function ContinueWorkingSection({
 						</div>
 						<h3>{getWorkItemTitle(item)}</h3>
 						<p>{item.reason}</p>
-						{Number.isInteger(item.count) ? <span className="workspace-count">{item.count} items</span> : null}
+						{formatWorkItemCount(item) ? <span className="workspace-count">{formatWorkItemCount(item)}</span> : null}
 						<ProjectProgress completed={project?.completed_stage_count} total={project?.total_stage_count} />
 					</div>
 					<ProjectOpenLink
@@ -115,7 +116,7 @@ export function MyWorkSection({
 												</div>
 												<strong>{getWorkItemTitle(item)}</strong>
 												<p>{item.reason}</p>
-												{Number.isInteger(item.count) ? <span className="workspace-count">{item.count} items</span> : null}
+												{formatWorkItemCount(item) ? <span className="workspace-count">{formatWorkItemCount(item)}</span> : null}
 											</div>
 											<ProjectOpenLink projectId={item.project_id} destination={getWorkItemDestination(item)} onOpenProject={onOpenProject}>
 												Open

--- a/frontend/src/components/workspace/WorkspacePrimitives.jsx
+++ b/frontend/src/components/workspace/WorkspacePrimitives.jsx
@@ -1,3 +1,6 @@
+import { SearchField, Link, Button } from "../ui/controls";
+import { Progress, Badge } from "../ui/surfaces";
+import { CollectionState } from "../ui/collections";
 import { AlertCircle, ArrowRight, RotateCcw, Search } from "lucide-react";
 import { useEffect, useRef } from "react";
 
@@ -30,24 +33,25 @@ export function WorkspaceSearch({
 	}, []);
 
 	return (
-		<label className="workspace-search">
-			<span className="sr-only">{label}</span>
-			<Search aria-hidden="true" size={18} />
-			<input
-				ref={inputRef}
-				type="search"
-				value={value}
-				onChange={(event) => onChange(event.target.value)}
-				placeholder={placeholder}
-				autoComplete="off"
-			/>
-			<kbd aria-hidden="true">Ctrl/⌘ K</kbd>
-		</label>
+		<SearchField
+			className="workspace-search"
+			label={label}
+			ref={inputRef}
+			value={value}
+			onChange={(event) => onChange(event.target.value)}
+			placeholder={placeholder}
+			autoComplete="off"
+			shortcut="Ctrl/⌘ K"
+		/>
 	);
 }
 
 export function WorkspaceStatus({ status }) {
-	return <span className={`workspace-status workspace-status-${getWorkspaceStatusTone(status)}`}>{formatWorkspaceStatus(status)}</span>;
+	return (
+		<Badge tone={getWorkspaceStatusTone(status)} className={`workspace-status workspace-status-${getWorkspaceStatusTone(status)}`}>
+			{formatWorkspaceStatus(status)}
+		</Badge>
+	);
 }
 
 export function ProjectProgress({ completed = 0, total = 0 }) {
@@ -65,13 +69,13 @@ export function ProjectProgress({ completed = 0, total = 0 }) {
 					{Math.min(safeCompleted, safeTotal)} of {safeTotal} stages
 				</strong>
 			</div>
-			<progress
+			<Progress
 				value={Math.min(safeCompleted, safeTotal)}
 				max={safeTotal}
 				aria-label={`Workflow progress: ${Math.min(safeCompleted, safeTotal)} of ${safeTotal} stages complete`}
 			>
 				{Math.round((Math.min(safeCompleted, safeTotal) / safeTotal) * 100)}%
-			</progress>
+			</Progress>
 		</div>
 	);
 }
@@ -86,7 +90,7 @@ export function ProjectOpenLink({ projectId, destination, onOpenProject, childre
 	}
 	const path = getProjectPath(projectId, destination);
 	return (
-		<a
+		<Link
 			href={path}
 			className={className}
 			aria-label={ariaLabel}
@@ -98,31 +102,39 @@ export function ProjectOpenLink({ projectId, destination, onOpenProject, childre
 		>
 			<span>{children}</span>
 			<ArrowRight aria-hidden="true" size={17} />
-		</a>
+		</Link>
 	);
 }
 
 export function WorkspaceErrorState({ message, onRetry }) {
 	return (
-		<section className="workspace-state workspace-error-state" role="alert" aria-labelledby="workspace-error-title">
+		<CollectionState
+			as="section"
+			kind="error"
+			className="workspace-state workspace-error-state"
+			role="alert"
+			aria-labelledby="workspace-error-title"
+		>
 			<AlertCircle aria-hidden="true" size={24} />
 			<div>
 				<h2 id="workspace-error-title">We couldn’t load your workspace</h2>
 				<p>{message || "Workspace summary is unavailable. Please try again."}</p>
 			</div>
 			{onRetry ? (
-				<button type="button" className="secondary workspace-retry-button" onClick={onRetry}>
+				<Button type="button" className="secondary workspace-retry-button" onClick={onRetry}>
 					<RotateCcw aria-hidden="true" size={16} />
 					Retry
-				</button>
+				</Button>
 			) : null}
-		</section>
+		</CollectionState>
 	);
 }
 
 export function WorkspaceLoadingState({ projectsOnly = false }) {
 	return (
-		<div
+		<CollectionState
+			as="div"
+			kind="loading"
 			className={`workspace-loading-grid ${projectsOnly ? "workspace-loading-projects" : ""}`}
 			role="status"
 			aria-live="polite"
@@ -137,6 +149,6 @@ export function WorkspaceLoadingState({ projectsOnly = false }) {
 					<span className="workspace-skeleton-line workspace-skeleton-medium" />
 				</div>
 			))}
-		</div>
+		</CollectionState>
 	);
 }

--- a/frontend/src/components/workspace/workspacePresentation.js
+++ b/frontend/src/components/workspace/workspacePresentation.js
@@ -111,3 +111,13 @@ export const matchesWorkspaceQuery = (query, ...values) => {
 export function getProjectPath(projectId, destination = PROJECT_DESTINATIONS.OVERVIEW) {
 	return buildProjectPath(projectId, destination);
 }
+
+export const formatWorkItemCount = (item) => {
+	if (item?.stage !== "use_cases") return Number.isInteger(item?.count) ? `${item.count} items` : "";
+	const parts = [];
+	if (Number.isInteger(item.count)) parts.push(`${item.count} scenario${item.count === 1 ? "" : "s"}`);
+	if (Number.isInteger(item.requirement_group_count)) {
+		parts.push(`${item.requirement_group_count} requirement group${item.requirement_group_count === 1 ? "" : "s"}`);
+	}
+	return parts.join(" · ");
+};

--- a/frontend/src/hooks/useUseCaseReview.js
+++ b/frontend/src/hooks/useUseCaseReview.js
@@ -38,7 +38,7 @@ export default function useUseCaseReview({
 	const projectScopeRef = useRef("");
 	const requestScopeRef = useRef("");
 	const scopeContextRef = useRef(null);
-	const [decision, setDecisionState] = useState("approve");
+	const [decision, setDecisionState] = useState("");
 	const [comment, setCommentState] = useState("");
 	const [outcome, setOutcome] = useState(initialOutcome);
 
@@ -70,7 +70,7 @@ export default function useUseCaseReview({
 		retryIdentityRef.current = null;
 
 		if (projectChanged) {
-			setDecisionState("approve");
+			setDecisionState("");
 			setCommentState("");
 			setOutcome(initialOutcome());
 			return;
@@ -120,7 +120,7 @@ export default function useUseCaseReview({
 	}, []);
 
 	const submit = useCallback(async () => {
-		if (submittingRef.current) {
+		if (submittingRef.current || !["approve", "request_changes"].includes(decision)) {
 			return null;
 		}
 		const normalizedComment = `${comment || ""}`.trim();

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -1,3 +1,4 @@
+import { Button } from "../components/ui/controls";
 import { FolderPlus, Sparkles } from "lucide-react";
 import { useMemo, useState } from "react";
 
@@ -64,10 +65,10 @@ export default function HomePage({
 				<div className="workspace-header-actions">
 					<WorkspaceSearch value={query} onChange={setQuery} />
 					{onCreateProject ? (
-						<button type="button" className="workspace-create-button" onClick={onCreateProject}>
+						<Button type="button" className="workspace-create-button" onClick={onCreateProject}>
 							<FolderPlus aria-hidden="true" size={17} />
 							Create project
-						</button>
+						</Button>
 					) : null}
 				</div>
 			</header>
@@ -85,10 +86,10 @@ export default function HomePage({
 						<p>Bring requirements into one place, ground them with product context, and build reviewable test coverage.</p>
 					</div>
 					{onCreateProject ? (
-						<button type="button" onClick={onCreateProject}>
+						<Button type="button" onClick={onCreateProject}>
 							<FolderPlus aria-hidden="true" size={17} />
 							Create project
-						</button>
+						</Button>
 					) : null}
 				</section>
 			) : summary ? (

--- a/frontend/src/pages/ProjectsPage.jsx
+++ b/frontend/src/pages/ProjectsPage.jsx
@@ -1,3 +1,4 @@
+import { Input, Button } from "../components/ui/controls";
 import { FolderPlus } from "lucide-react";
 import { useMemo, useState } from "react";
 
@@ -107,7 +108,7 @@ export default function ProjectsPage({
 				<form onSubmit={handleCreateProject} aria-label="Create project" noValidate>
 					<label htmlFor="new-workspace-project-name">Project name</label>
 					<div className="workspace-create-controls">
-						<input
+						<Input
 							id="new-workspace-project-name"
 							type="text"
 							value={projectName}
@@ -123,10 +124,10 @@ export default function ProjectsPage({
 							aria-invalid={Boolean(createError)}
 							aria-describedby={createError ? "create-project-error" : createNotice ? "create-project-notice" : undefined}
 						/>
-						<button type="submit" disabled={createBusy}>
+						<Button type="submit" disabled={createBusy}>
 							<FolderPlus aria-hidden="true" size={17} />
 							{createBusy ? "Creating…" : "Create project"}
-						</button>
+						</Button>
 					</div>
 					{createError ? (
 						<p className="workspace-form-message workspace-form-error" id="create-project-error" role="alert">

--- a/frontend/src/pages/ReportsPage.jsx
+++ b/frontend/src/pages/ReportsPage.jsx
@@ -1,3 +1,5 @@
+import { ListItem, List } from "../components/ui/collections";
+import { Button } from "../components/ui/controls";
 import { FileText, RefreshCw } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 
@@ -23,7 +25,7 @@ const formatReportFormat = (value) => (/^[a-z0-9]{1,8}$/i.test(`${value || ""}`)
 function ReportRow({ report, onOpenProject }) {
 	const evidenceIdentity = report.report_id || "Unavailable";
 	return (
-		<li className="activity-index-row activity-index-report-row">
+		<ListItem className="activity-index-row activity-index-report-row">
 			<span className="activity-index-kind-icon">
 				<FileText aria-hidden="true" size={20} />
 			</span>
@@ -63,7 +65,7 @@ function ReportRow({ report, onOpenProject }) {
 			>
 				Open evidence
 			</ProjectOpenLink>
-		</li>
+		</ListItem>
 	);
 }
 
@@ -158,7 +160,7 @@ export default function ReportsPage({ summary, isLoading = false, isRefreshing =
 				<div className="activity-index-header-actions">
 					{summary?.generated_at ? <time dateTime={summary.generated_at}>Updated {formatWorkspaceDate(summary.generated_at)}</time> : null}
 					{onRefresh ? (
-						<button
+						<Button
 							ref={refreshButtonRef}
 							type="button"
 							className="secondary activity-index-refresh-button"
@@ -167,7 +169,7 @@ export default function ReportsPage({ summary, isLoading = false, isRefreshing =
 						>
 							<RefreshCw aria-hidden="true" size={15} />
 							{isRefreshing ? "Refreshing…" : "Refresh reports"}
-						</button>
+						</Button>
 					) : null}
 				</div>
 			</header>
@@ -220,11 +222,11 @@ export default function ReportsPage({ summary, isLoading = false, isRefreshing =
 						countLabel={`${filteredReports.length} report${filteredReports.length === 1 ? "" : "s"}`}
 					/>
 					{filteredReports.length ? (
-						<ul className="activity-index-list" aria-label="Recent reports">
+						<List variant="collection" className="activity-index-list" aria-label="Recent reports">
 							{filteredReports.map((report) => (
 								<ReportRow key={report.report_id} report={report} onOpenProject={onOpenProject} />
 							))}
-						</ul>
+						</List>
 					) : reports.length === 0 ? (
 						<ActivityIndexEmpty
 							title="No recent reports"

--- a/frontend/src/pages/ReviewsPage.jsx
+++ b/frontend/src/pages/ReviewsPage.jsx
@@ -1,3 +1,4 @@
+import { Button } from "../components/ui/controls";
 import { RefreshCw } from "lucide-react";
 import { useRef } from "react";
 
@@ -38,7 +39,7 @@ export default function ReviewsPage({ summary, isLoading = false, isRefreshing =
 				<div className="review-inbox-header-actions">
 					{summary?.generated_at ? <time dateTime={summary.generated_at}>Updated {formatWorkspaceDate(summary.generated_at)}</time> : null}
 					{onRefresh ? (
-						<button
+						<Button
 							ref={refreshButtonRef}
 							type="button"
 							className="secondary review-inbox-refresh-button"
@@ -47,7 +48,7 @@ export default function ReviewsPage({ summary, isLoading = false, isRefreshing =
 						>
 							<RefreshCw aria-hidden="true" size={15} />
 							{isRefreshing ? "Refreshing…" : "Refresh reviews"}
-						</button>
+						</Button>
 					) : null}
 				</div>
 			</header>

--- a/frontend/src/pages/RunsPage.jsx
+++ b/frontend/src/pages/RunsPage.jsx
@@ -1,3 +1,5 @@
+import { ListItem, List } from "../components/ui/collections";
+import { Button } from "../components/ui/controls";
 import { PlayCircle, RefreshCw } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 
@@ -18,7 +20,7 @@ const exactCount = (value) => (Number.isInteger(value) && value >= 0 ? value : "
 function RunRow({ run, onOpenProject }) {
 	const runIdentity = run.run_id || run.run_record_id || "Unavailable";
 	return (
-		<li className="activity-index-row activity-index-run-row">
+		<ListItem className="activity-index-row activity-index-run-row">
 			<span className="activity-index-kind-icon">
 				<PlayCircle aria-hidden="true" size={20} />
 			</span>
@@ -68,7 +70,7 @@ function RunRow({ run, onOpenProject }) {
 			>
 				Open evidence
 			</ProjectOpenLink>
-		</li>
+		</ListItem>
 	);
 }
 
@@ -141,7 +143,7 @@ export default function RunsPage({ summary, isLoading = false, isRefreshing = fa
 				<div className="activity-index-header-actions">
 					{summary?.generated_at ? <time dateTime={summary.generated_at}>Updated {formatWorkspaceDate(summary.generated_at)}</time> : null}
 					{onRefresh ? (
-						<button
+						<Button
 							ref={refreshButtonRef}
 							type="button"
 							className="secondary activity-index-refresh-button"
@@ -150,7 +152,7 @@ export default function RunsPage({ summary, isLoading = false, isRefreshing = fa
 						>
 							<RefreshCw aria-hidden="true" size={15} />
 							{isRefreshing ? "Refreshing…" : "Refresh runs"}
-						</button>
+						</Button>
 					) : null}
 				</div>
 			</header>
@@ -195,11 +197,11 @@ export default function RunsPage({ summary, isLoading = false, isRefreshing = fa
 						countLabel={`${filteredRuns.length} run${filteredRuns.length === 1 ? "" : "s"}`}
 					/>
 					{filteredRuns.length ? (
-						<ul className="activity-index-list" aria-label="Recent runs">
+						<List variant="collection" className="activity-index-list" aria-label="Recent runs">
 							{filteredRuns.map((run) => (
 								<RunRow key={run.run_record_id || run.run_id} run={run} onOpenProject={onOpenProject} />
 							))}
-						</ul>
+						</List>
 					) : runs.length === 0 ? (
 						<ActivityIndexEmpty
 							title="No recent runs"

--- a/frontend/src/pages/UseCaseReviewPage.jsx
+++ b/frontend/src/pages/UseCaseReviewPage.jsx
@@ -1,3 +1,4 @@
+import { Link } from "../components/ui/controls";
 import ProjectPageHeader from "../components/layout/ProjectPageHeader";
 import RouteLink from "../app/RouteLink";
 import { PROJECT_DESTINATIONS, buildProjectPath } from "../app/workflowRoutes";
@@ -57,9 +58,9 @@ export default function UseCaseReviewPage({ project, identity, request, navigate
 							<span className={`use-case-page-freshness ${reviewStatus.tone}`} role="status" aria-label="Current human review status">
 								{reviewStatus.label}
 							</span>
-							<a className="use-case-skip-review-link" href="#use-case-review-decision">
+							<Link className="use-case-skip-review-link" href="#use-case-review-decision">
 								Skip to review decision
-							</a>
+							</Link>
 						</div>
 					) : null
 				}

--- a/frontend/src/pages/UseCaseReviewPage.jsx
+++ b/frontend/src/pages/UseCaseReviewPage.jsx
@@ -1,3 +1,4 @@
+import ProjectPageHeader from "../components/layout/ProjectPageHeader";
 import RouteLink from "../app/RouteLink";
 import { PROJECT_DESTINATIONS, buildProjectPath } from "../app/workflowRoutes";
 import UseCaseReviewWorkbench from "../components/reviews/UseCaseReviewWorkbench";
@@ -45,23 +46,24 @@ export default function UseCaseReviewPage({ project, identity, request, navigate
 			aria-busy={review.isSubmitting || review.isReloading || undefined}
 			tabIndex={-1}
 		>
-			<header className="use-case-review-page-header">
-				<div>
-					<span className="use-case-page-kicker">{project?.name || "Project"}</span>
-					<h1 id="use-case-review-title">Use Cases</h1>
-					<p>Review the current scenario artifact and record a durable human decision.</p>
-				</div>
-				{snapshot ? (
-					<div className="use-case-page-status-actions">
-						<span className={`use-case-page-freshness ${reviewStatus.tone}`} role="status" aria-label="Current human review status">
-							{reviewStatus.label}
-						</span>
-						<a className="use-case-skip-review-link" href="#use-case-review-decision">
-							Skip to review decision
-						</a>
-					</div>
-				) : null}
-			</header>
+			<ProjectPageHeader
+				title="Use Cases"
+				titleId="use-case-review-title"
+				project={project}
+				navigate={navigate}
+				actions={
+					snapshot ? (
+						<div className="use-case-page-status-actions">
+							<span className={`use-case-page-freshness ${reviewStatus.tone}`} role="status" aria-label="Current human review status">
+								{reviewStatus.label}
+							</span>
+							<a className="use-case-skip-review-link" href="#use-case-review-decision">
+								Skip to review decision
+							</a>
+						</div>
+					) : null
+				}
+			/>
 
 			{snapshot ? (
 				<UseCaseReviewWorkbench project={project} snapshot={snapshot} stageState={stageState} review={review} />

--- a/frontend/src/styles/forms.css
+++ b/frontend/src/styles/forms.css
@@ -68,7 +68,7 @@ input::placeholder {
 
 /* Buttons */
 button {
-	background: linear-gradient(180deg, #3b82f6 0%, var(--primary) 55%, var(--primary-hover) 100%);
+	background: var(--primary);
 	color: white;
 	border: none;
 	padding: 0.8rem 1.4rem;
@@ -91,7 +91,7 @@ button {
 }
 
 button:hover:not(:disabled) {
-	background: linear-gradient(180deg, #2f76f2 0%, var(--primary-hover) 55%, var(--primary-strong) 100%);
+	background: var(--primary-hover);
 	box-shadow:
 		inset 0 1px 0 rgb(255 255 255 / 0.18),
 		0 2px 4px rgb(15 28 51 / 0.14),

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -21,3 +21,5 @@
 @import "./activity-index.css";
 
 @import "./project-design.css";
+
+@import "./ui.css";

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -19,3 +19,5 @@
 @import "./use-case-review.css";
 @import "./review-inbox.css";
 @import "./activity-index.css";
+
+@import "./project-design.css";

--- a/frontend/src/styles/project-design.css
+++ b/frontend/src/styles/project-design.css
@@ -1,0 +1,982 @@
+/* Shared project design, issue #239. Route content keeps its own workflow. */
+:root {
+	--bg-color: #fff;
+	--radius-md: 10px;
+	--radius-lg: 12px;
+}
+body {
+	background: #fff;
+	font-size: 15px;
+}
+.page {
+	padding: 0;
+}
+.global-app-shell {
+	gap: 0;
+}
+.global-app-shell-header {
+	border: 0;
+	border-bottom: 1px solid var(--border-color);
+	border-radius: 0;
+	padding: 12px 28px;
+	min-height: 76px;
+	background: #fff;
+	box-shadow: none;
+}
+.global-navigation-link {
+	font-size: 15px;
+	font-weight: 650;
+	border: 0;
+}
+.global-navigation-link.active {
+	background: var(--primary-tonal);
+}
+.command-project-trigger {
+	box-shadow: none;
+}
+.workflow-shell {
+	--workflow-nav-column: 260px;
+	gap: 0;
+	align-items: stretch;
+}
+.workflow-shell.nav-collapsed {
+	--workflow-nav-column: 72px;
+}
+.workflow-navigation-drawer {
+	border: 0;
+	border-right: 1px solid var(--border-color);
+	border-radius: 0;
+	box-shadow: none;
+	background: #f8fafd;
+	backdrop-filter: none;
+	padding: 20px 16px;
+	gap: 16px;
+	min-height: calc(100vh - 76px);
+	align-content: start;
+	top: 0;
+}
+.workflow-navigation-header {
+	display: flex;
+	justify-content: space-between;
+	padding: 0 10px;
+}
+.workflow-navigation-header > div {
+	display: block;
+}
+.workflow-navigation-header span {
+	font-size: 12px;
+	color: var(--text-muted);
+}
+.workflow-navigation-toggle {
+	border: 0;
+	box-shadow: none;
+	background: transparent;
+}
+.workflow-navigation-list {
+	gap: 12px;
+}
+.workflow-navigation-item {
+	display: grid;
+	grid-template-columns: 24px minmax(0, 1fr);
+	gap: 16px;
+	min-height: 68px;
+	padding: 12px;
+	border: 0;
+	border-radius: 10px;
+	box-shadow: none;
+	background: transparent;
+	color: var(--text-main);
+}
+.workflow-navigation-item.active {
+	background: var(--primary-tonal);
+	color: var(--primary);
+	box-shadow: none;
+	border: 0;
+}
+.workflow-navigation-item .workflow-navigation-marker,
+.workflow-navigation-item.active .workflow-navigation-marker {
+	width: 24px;
+	height: 24px;
+	padding: 0;
+	background: none;
+	color: inherit;
+	border: 0;
+	border-radius: 0;
+	box-shadow: none;
+}
+.workflow-navigation-marker svg {
+	width: 22px;
+	height: 22px;
+}
+.workflow-navigation-item:not(.active).complete .workflow-navigation-marker,
+.workflow-navigation-item:not(.active).attention .workflow-navigation-marker,
+.workflow-navigation-item:not(.active).blocked .workflow-navigation-marker {
+	color: var(--text-main);
+	background: none;
+}
+.workflow-navigation-copy {
+	gap: 4px;
+}
+.workflow-navigation-copy strong {
+	font-size: 15px;
+	font-weight: 650;
+	white-space: normal;
+	overflow: visible;
+}
+.workflow-navigation-copy .nav-workflow-status {
+	display: flex;
+	align-items: center;
+	gap: 7px;
+	font-size: 13px;
+	line-height: 1.4;
+	white-space: normal;
+	overflow: visible;
+	color: var(--text-muted);
+}
+.nav-workflow-status svg {
+	flex: 0 0 auto;
+}
+.nav-workflow-status.complete svg {
+	color: var(--success);
+}
+.nav-workflow-status.attention svg {
+	color: var(--warning);
+}
+.workflow-main,
+.use-case-review-page,
+.project-overview-page {
+	padding: 28px 36px 48px;
+	background: #fff;
+	border: 0;
+	border-radius: 0;
+	box-shadow: none;
+	min-width: 0;
+}
+.route-page {
+	box-shadow: none;
+	border: 0;
+	border-radius: 0;
+	align-content: start;
+}
+.project-overview-page,
+.use-case-review-page {
+	gap: 24px;
+}
+.project-page-header {
+	display: grid;
+	gap: 12px;
+	margin-bottom: 28px;
+	min-width: 0;
+}
+.project-breadcrumb {
+	display: flex;
+	gap: 14px;
+	font-size: 14px;
+	color: var(--text-muted);
+	margin-bottom: 8px;
+}
+.project-breadcrumb a {
+	text-decoration: none;
+	color: var(--primary);
+}
+.project-page-title-row {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 16px;
+}
+.project-page-header h1 {
+	margin: 0;
+	font-size: 36px;
+	line-height: 1.2;
+	letter-spacing: -0.025em;
+	color: var(--text-main);
+	overflow-wrap: anywhere;
+}
+.project-page-header p {
+	margin: 0;
+	color: var(--text-muted);
+	font-size: 16px;
+}
+.panel {
+	border: 0;
+	border-radius: 0;
+	background: #fff;
+	box-shadow: none;
+	padding: 0;
+}
+button,
+.route-primary-link {
+	border-radius: 8px;
+	box-shadow: none;
+	font-size: 14px;
+}
+button:hover:not(:disabled) {
+	transform: none;
+	box-shadow: none;
+}
+input,
+textarea,
+select {
+	border-radius: 8px;
+	font: inherit;
+}
+.overview-counts {
+	display: grid;
+	grid-template-columns: repeat(3, 1fr);
+	padding: 24px 0;
+	border-bottom: 1px solid var(--border-color);
+}
+.overview-counts > div {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 12px;
+	border-right: 1px solid var(--border-color);
+}
+.overview-counts > div:last-child {
+	border: 0;
+}
+.overview-counts strong {
+	font-size: 28px;
+	color: var(--primary);
+}
+.overview-attention h2 {
+	font-size: 23px;
+	margin: 12px 0 20px;
+}
+.overview-attention-row {
+	display: grid;
+	grid-template-columns: 24px minmax(160px, 0.8fr) minmax(0, 1.2fr) auto;
+	gap: 20px;
+	align-items: center;
+	padding: 22px 0;
+	border-bottom: 1px solid var(--border-color);
+}
+.overview-attention-row svg {
+	color: var(--warning);
+}
+.overview-attention-row p {
+	margin: 0;
+	color: var(--text-muted);
+}
+.overview-attention-row a {
+	color: var(--primary);
+	text-decoration: none;
+}
+.overview-workbenches {
+	margin-top: 20px;
+	color: var(--text-muted);
+}
+.project-overview-page .contextual-task-card {
+	padding: 28px;
+	background: var(--primary-tonal);
+	border: 0;
+	border-radius: 10px;
+	box-shadow: none;
+}
+.project-overview-page .contextual-task-card h2 {
+	font-size: 25px;
+}
+.project-overview-page .contextual-task-card p {
+	font-size: 15px;
+}
+.use-case-page-status-actions {
+	justify-content: flex-start;
+}
+.use-case-compact-summary {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 20px;
+	color: var(--text-muted);
+	padding-bottom: 18px;
+	border-bottom: 1px solid var(--border-color);
+}
+.use-case-supporting-details {
+	color: var(--text-muted);
+}
+.use-case-supporting-details > summary {
+	cursor: pointer;
+	padding: 8px 0;
+}
+.use-case-supporting-details[open] {
+	padding-bottom: 16px;
+}
+.artifact-review-columns {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) 320px;
+	gap: 28px;
+	align-items: start;
+}
+.use-case-review-workbench {
+	gap: 16px;
+}
+.use-case-collection,
+.use-case-decision-panel {
+	min-width: 0;
+}
+.use-case-collection-heading {
+	display: grid;
+	gap: 16px;
+}
+.use-case-collection-heading h2 {
+	font-size: 22px;
+}
+.use-case-collection-heading .use-case-section-kicker,
+.use-case-decision-heading .use-case-section-kicker {
+	display: none;
+}
+.use-case-collection-heading p {
+	font-size: 13px;
+}
+.use-case-search-field {
+	width: 100%;
+	min-width: 0;
+}
+.use-case-group,
+.use-case-scenario-card {
+	box-shadow: none;
+	border-radius: 10px;
+	background: #fff;
+}
+.use-case-group-heading h3 {
+	font-size: 16px;
+	line-height: 1.5;
+}
+.use-case-scenario-card {
+	border: 0;
+	border-bottom: 1px solid var(--border-color);
+	padding: 16px 0;
+	border-radius: 0;
+}
+.use-case-scenario-heading h4 {
+	font-size: 15px;
+}
+.use-case-scenario-badges {
+	font-size: 12px;
+}
+.use-case-decision-panel {
+	background: #f8fafd;
+	border: 1px solid var(--border-color);
+	padding: 24px;
+	border-radius: 10px;
+	box-shadow: none;
+}
+.use-case-decision-heading h2 {
+	font-size: 22px;
+}
+.use-case-decision-options {
+	display: grid;
+	grid-template-columns: 1fr;
+	padding: 0;
+	gap: 14px;
+	border: 0;
+}
+.use-case-decision-options label,
+.use-case-decision-options label.selected {
+	border: 0;
+	background: transparent;
+	padding: 4px 0;
+	box-shadow: none;
+}
+.use-case-decision-options small {
+	display: none;
+}
+.use-case-decision-actions {
+	display: grid;
+}
+.use-case-decision-actions button {
+	width: 100%;
+}
+.use-case-decision-actions p {
+	font-size: 13px;
+}
+.test-cases-section-tabs {
+	background: none;
+	border: 0;
+	padding: 0;
+	margin: -10px 0 20px;
+	box-shadow: none;
+}
+.test-cases-page .contextual-task-region {
+	margin-bottom: 16px;
+}
+.test-generation-panel.has-test-cases > .panel-title,
+.test-generation-panel.has-test-cases > .panel-description {
+	display: none;
+}
+.test-generation-panel.has-test-cases > .generation-gate-card.ready {
+	background: none;
+	border: 0;
+	padding: 0;
+	margin: 0 0 16px;
+}
+.test-generation-panel.has-test-cases > .generation-gate-card.ready strong {
+	font-weight: 500;
+	color: var(--text-muted);
+}
+.test-generation-panel.has-test-cases > .generation-gate-card.ready p {
+	font-size: 13px;
+}
+.test-quality-summary {
+	display: flex;
+	align-items: flex-start;
+	gap: 18px;
+	padding: 18px 22px;
+	border: 1px solid #f5d6a8;
+	background: #fffbf4;
+	border-radius: 10px;
+	margin: 20px 0;
+}
+.test-quality-summary > svg {
+	color: #b86b00;
+	flex-shrink: 0;
+	margin-top: 3px;
+}
+.test-quality-summary.approved {
+	background: var(--success-tonal);
+	border-color: #b6dfd1;
+}
+.test-quality-summary.approved > svg {
+	color: var(--success);
+}
+.test-quality-summary strong {
+	font-size: 18px;
+}
+.test-quality-summary p {
+	margin: 4px 0;
+	color: var(--text-muted);
+}
+.test-quality-findings summary {
+	cursor: pointer;
+	color: var(--primary);
+	margin-top: 8px;
+}
+.test-quality-findings li,
+.test-inline-findings li {
+	overflow-wrap: anywhere;
+}
+.generate-results-workspace {
+	border: 0;
+	border-radius: 0;
+	background: #fff;
+	box-shadow: none;
+}
+.generate-results-header {
+	padding: 0 0 12px;
+	border: 0;
+	background: #fff;
+}
+.generate-results-header h3,
+.generate-results-header p {
+	display: none;
+}
+.generate-results-summary-pill {
+	background: transparent;
+	border: 0;
+	padding: 0;
+	color: var(--text-muted);
+	font-size: 14px;
+}
+.generate-results-tabs {
+	padding: 0;
+	gap: 4px;
+	border-bottom: 1px solid var(--border-color);
+	background: transparent;
+}
+.generate-result-tab {
+	background: transparent;
+	border: 0;
+	border-radius: 0;
+	box-shadow: none;
+	color: var(--text-muted);
+	padding: 14px 12px;
+	font-size: 14px;
+}
+.generate-result-tab.active {
+	color: var(--primary);
+	background: transparent;
+	border-bottom: 3px solid var(--primary);
+	box-shadow: none;
+}
+.generate-result-panel {
+	padding: 22px 0;
+}
+.test-review-workspace {
+	display: grid;
+	grid-template-columns: minmax(240px, 0.85fr) minmax(0, 1.35fr);
+	gap: 28px;
+}
+.test-review-list {
+	min-width: 0;
+	border-right: 1px solid var(--border-color);
+	padding-right: 20px;
+}
+.test-review-list h2 {
+	font-size: 18px;
+	margin: 0 0 12px;
+}
+.test-review-list input {
+	box-sizing: border-box;
+	width: 100%;
+}
+.test-list-count {
+	color: var(--text-muted);
+	font-size: 12px;
+	margin: 8px 0;
+}
+.test-review-items {
+	max-height: 70vh;
+	overflow-y: auto;
+}
+.test-review-item {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	width: 100%;
+	padding: 16px;
+	gap: 12px;
+	text-align: left;
+	border: 0;
+	border-bottom: 1px solid var(--border-color);
+	border-radius: 0;
+	color: var(--text-main);
+	background: transparent;
+}
+.test-review-item.selected {
+	border-radius: 8px;
+	background: var(--primary-tonal);
+}
+.test-review-item:hover:not(:disabled) {
+	background: var(--primary-tonal);
+}
+.test-review-item > span {
+	display: grid;
+	gap: 6px;
+	min-width: 0;
+}
+.test-review-item small,
+.test-review-item span span {
+	font-size: 13px;
+	font-weight: 400;
+	color: var(--text-muted);
+}
+.test-review-item strong {
+	font-size: 15px;
+	line-height: 1.45;
+	overflow-wrap: anywhere;
+}
+.test-review-item svg {
+	flex-shrink: 0;
+	color: var(--text-muted);
+}
+.test-review-detail {
+	min-width: 0;
+	overflow-wrap: anywhere;
+}
+.test-review-detail h2 {
+	margin: 8px 0;
+	font-size: 23px;
+	line-height: 1.3;
+}
+.test-review-detail h3 {
+	margin: 22px 0 8px;
+	font-size: 16px;
+}
+.test-review-detail p {
+	margin: 6px 0 14px;
+	color: var(--text-muted);
+}
+.test-review-detail .test-detail-meta {
+	font-size: 13px;
+	margin: 4px 0;
+}
+.test-inline-findings {
+	margin: 18px 0;
+	background: #fffbf4;
+	border: 1px solid #f5d6a8;
+	border-radius: 8px;
+	padding: 10px 14px;
+}
+.test-inline-findings summary {
+	cursor: pointer;
+}
+.test-steps-heading {
+	display: flex;
+	align-items: baseline;
+	justify-content: space-between;
+	border-top: 1px solid var(--border-color);
+}
+.test-steps-heading > span {
+	color: var(--text-muted);
+	font-size: 13px;
+}
+.test-detail-steps {
+	padding-left: 22px;
+}
+.test-detail-steps li {
+	border-bottom: 1px solid var(--border-color);
+	padding: 12px 0 12px 8px;
+}
+.test-detail-steps p:first-child {
+	color: var(--text-main);
+}
+.test-detail-steps strong {
+	font-size: 13px;
+	margin-right: 10px;
+	font-weight: 500;
+}
+.test-case-metadata {
+	border-top: 1px solid var(--border-color);
+	padding: 20px 0;
+	margin-top: 24px;
+}
+.test-case-metadata summary {
+	cursor: pointer;
+}
+.test-case-metadata dl > div {
+	display: grid;
+	grid-template-columns: 140px minmax(0, 1fr);
+	gap: 16px;
+	padding: 8px 0;
+}
+.test-case-metadata dd {
+	margin: 0;
+	color: var(--text-muted);
+}
+@media (max-width: 1200px) {
+	.artifact-review-columns {
+		grid-template-columns: minmax(0, 1fr);
+	}
+	.use-case-decision-panel {
+		max-width: none;
+	}
+	.overview-attention-row {
+		grid-template-columns: 24px minmax(0, 1fr);
+	}
+	.overview-attention-row p,
+	.overview-attention-row a {
+		grid-column: 2;
+	}
+	.global-app-shell-header {
+		padding: 12px 16px;
+	}
+}
+@media (max-width: 900px) {
+	.workflow-shell,
+	.workflow-shell.nav-collapsed {
+		grid-template-columns: minmax(0, 1fr);
+	}
+	.workflow-navigation-drawer,
+	.workflow-navigation-drawer.compact.collapsed {
+		min-height: 0;
+		border-right: 0;
+		border-bottom: 1px solid var(--border-color);
+		padding: 12px 16px;
+	}
+	.workflow-navigation-list {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+	.workflow-main,
+	.use-case-review-page,
+	.project-overview-page {
+		padding: 24px;
+	}
+	.test-review-workspace {
+		grid-template-columns: minmax(0, 1fr);
+	}
+	.test-review-list {
+		border-right: 0;
+		border-bottom: 1px solid var(--border-color);
+		padding: 0 0 20px;
+	}
+	.test-review-items {
+		max-height: 280px;
+	}
+	.global-app-shell-header {
+		flex-wrap: wrap;
+	}
+	.project-page-header h1 {
+		font-size: 30px;
+	}
+}
+@media (max-width: 480px) {
+	.workflow-main,
+	.use-case-review-page,
+	.project-overview-page {
+		padding: 20px 16px;
+	}
+	.overview-counts > div {
+		flex-direction: column;
+		gap: 4px;
+		font-size: 12px;
+	}
+	.workflow-navigation-list {
+		grid-template-columns: 1fr;
+	}
+	.test-quality-summary {
+		padding: 14px;
+	}
+	.global-navigation-list {
+		gap: 0;
+	}
+	.global-navigation-link {
+		padding: 8px;
+		font-size: 13px;
+	}
+	.test-case-metadata dl > div {
+		grid-template-columns: 1fr;
+		gap: 4px;
+	}
+}
+.workflow-navigation-item.active .workflow-navigation-copy .nav-workflow-status {
+	color: var(--text-muted);
+}
+.tab-content {
+	background: transparent;
+	border: 0;
+	border-radius: 0;
+	box-shadow: none;
+	padding: 0;
+}
+.optional-workflow-actions {
+	margin: 0 0 16px;
+	color: var(--text-muted);
+	font-size: 14px;
+}
+.optional-workflow-actions > summary {
+	cursor: pointer;
+}
+.optional-workflow-actions[open] > .contextual-task-region {
+	margin-top: 12px;
+}
+.test-cases-page .project-page-header {
+	margin-bottom: 20px;
+}
+.test-cases-page .optional-workflow-actions {
+	float: right;
+	margin: 0 0 8px 16px;
+}
+.test-suite-summary {
+	color: var(--text-muted);
+	margin: 0 0 16px;
+}
+.generate-results-header {
+	display: none;
+}
+.test-quality-summary {
+	clear: both;
+}
+.workflow-shell {
+	--workflow-nav-column: 276px;
+}
+@media (max-width: 600px) {
+	.project-page-title-row {
+		flex-wrap: wrap;
+	}
+	.test-cases-page .optional-workflow-actions {
+		float: none;
+		margin: 0 0 12px;
+	}
+}
+.test-quality-summary {
+	position: relative;
+	padding-right: 190px;
+	min-height: 76px;
+	box-sizing: border-box;
+}
+.test-quality-findings > summary {
+	position: absolute;
+	top: 20px;
+	right: 22px;
+	margin: 0;
+	padding: 10px 18px;
+	background: var(--primary);
+	border-radius: 8px;
+	color: white;
+	font-weight: 600;
+	list-style: none;
+}
+.test-quality-findings > summary::-webkit-details-marker {
+	display: none;
+}
+.test-quality-findings[open] {
+	margin-top: 20px;
+}
+@media (max-width: 600px) {
+	.test-quality-summary {
+		padding-right: 14px;
+	}
+	.test-quality-findings > summary {
+		position: static;
+		margin-top: 12px;
+	}
+}
+/* Cancel the former workbench's container-column rules: the inner review grid owns columns. */
+.use-case-review-page .use-case-review-workbench {
+	grid-template-columns: minmax(0, 1fr);
+}
+.artifact-review-columns {
+	grid-column: 1 / -1;
+}
+.artifact-review-columns .use-case-collection {
+	grid-column: 1;
+	border: 0;
+	padding: 0;
+	background: transparent;
+}
+.artifact-review-columns .use-case-decision-panel {
+	grid-column: 2;
+}
+.use-case-collection-heading {
+	grid-template-columns: minmax(0, 1fr);
+}
+.use-case-review-page .project-page-header {
+	margin-bottom: 0;
+}
+.project-overview-page > .contextual-task-region {
+	width: 100%;
+}
+.project-overview-page .contextual-task-card {
+	min-height: 160px;
+	box-sizing: border-box;
+}
+.workflow-navigation-item.active .workflow-navigation-copy strong {
+	color: var(--primary);
+}
+.workflow-navigation-item:not(.active) {
+	background: transparent;
+}
+@media (max-width: 1200px) {
+	.artifact-review-columns .use-case-decision-panel {
+		grid-column: 1;
+		position: static;
+	}
+}
+@media (min-width: 1201px) {
+	.command-project-control {
+		width: 300px;
+		flex-basis: 300px;
+	}
+}
+@media (min-width: 901px) and (max-width: 1100px) {
+	.global-app-shell-header {
+		gap: 8px;
+		padding: 12px;
+	}
+	.global-navigation-link {
+		font-size: 14px;
+		padding: 8px 10px;
+	}
+	.command-project-control {
+		width: 180px;
+		flex-basis: 180px;
+	}
+}
+.artifact-review-columns .use-case-decision-panel {
+	position: static;
+}
+.scenario-details > summary {
+	cursor: pointer;
+	font-size: 15px;
+	display: flex;
+	align-items: baseline;
+	gap: 12px;
+}
+.scenario-summary-copy {
+	display: grid;
+	grid-template-columns: minmax(80px, auto) minmax(0, 1fr);
+	gap: 16px;
+	align-items: baseline;
+}
+.scenario-summary-copy .use-case-scenario-type {
+	font-size: 12px;
+	text-transform: none;
+	letter-spacing: 0;
+	font-weight: 500;
+	color: var(--text-muted);
+}
+.scenario-summary-copy strong {
+	font-size: 15px;
+	line-height: 1.5;
+	font-weight: 550;
+}
+.scenario-expanded-content {
+	padding: 12px 0;
+	color: var(--text-muted);
+}
+.scenario-expanded-content > span {
+	font-size: 13px;
+}
+@media (max-width: 600px) {
+	.scenario-summary-copy {
+		grid-template-columns: 1fr;
+		gap: 4px;
+	}
+}
+.workflow-navigation-copy strong,
+.workflow-navigation-copy .nav-workflow-status {
+	overflow-wrap: anywhere;
+}
+.use-case-meta-row {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: baseline;
+	gap: 12px 24px;
+	padding-bottom: 12px;
+	border-bottom: 1px solid var(--border-color);
+}
+.use-case-compact-summary {
+	flex: 1 1 auto;
+	padding: 0;
+	border: 0;
+}
+.use-case-supporting-details {
+	flex: 0 1 auto;
+}
+.use-case-supporting-details[open] {
+	flex-basis: 100%;
+}
+.use-case-collection-heading {
+	grid-template-columns: minmax(0, 1fr) minmax(180px, 240px);
+	align-items: end;
+}
+.use-case-group-toggle-all {
+	border: 0;
+	background: transparent;
+	padding: 6px 0;
+	box-shadow: none;
+}
+.project-page-title-row .use-case-page-status-actions {
+	justify-content: flex-end;
+}
+.use-case-page-freshness.pending {
+	background: var(--warning-tonal);
+	color: #8b5500;
+}
+@media (max-width: 1200px) {
+	.project-page-title-row .use-case-page-status-actions {
+		flex-wrap: wrap;
+	}
+}
+@media (max-width: 600px) {
+	.use-case-collection-heading {
+		grid-template-columns: minmax(0, 1fr);
+	}
+	.project-page-title-row .use-case-page-status-actions {
+		justify-content: flex-start;
+	}
+}
+
+.use-case-meta-row > * {
+	min-width: 0;
+	max-width: 100%;
+	overflow-wrap: anywhere;
+}
+@media (max-width: 600px) {
+	.project-page-title-row .use-case-page-status-actions {
+		flex: 1 1 100%;
+		min-width: 0;
+		max-width: 100%;
+	}
+}

--- a/frontend/src/styles/project-design.css
+++ b/frontend/src/styles/project-design.css
@@ -1,12 +1,8 @@
 /* Shared project design, issue #239. Route content keeps its own workflow. */
-:root {
-	--bg-color: #fff;
-	--radius-md: 10px;
-	--radius-lg: 12px;
-}
+
 body {
 	background: #fff;
-	font-size: 15px;
+	font-size: var(--font-body);
 }
 .page {
 	padding: 0;
@@ -24,7 +20,7 @@ body {
 	box-shadow: none;
 }
 .global-navigation-link {
-	font-size: 15px;
+	font-size: var(--font-body);
 	font-weight: 650;
 	border: 0;
 }
@@ -118,7 +114,7 @@ body {
 	gap: 4px;
 }
 .workflow-navigation-copy strong {
-	font-size: 15px;
+	font-size: var(--font-body);
 	font-weight: 650;
 	white-space: normal;
 	overflow: visible;
@@ -127,7 +123,7 @@ body {
 	display: flex;
 	align-items: center;
 	gap: 7px;
-	font-size: 13px;
+	font-size: var(--font-secondary);
 	line-height: 1.4;
 	white-space: normal;
 	overflow: visible;
@@ -187,7 +183,7 @@ body {
 }
 .project-page-header h1 {
 	margin: 0;
-	font-size: 36px;
+	font-size: var(--font-page-title);
 	line-height: 1.2;
 	letter-spacing: -0.025em;
 	color: var(--text-main);
@@ -279,7 +275,7 @@ select {
 	font-size: 25px;
 }
 .project-overview-page .contextual-task-card p {
-	font-size: 15px;
+	font-size: var(--font-body);
 }
 .use-case-page-status-actions {
 	justify-content: flex-start;
@@ -327,7 +323,7 @@ select {
 	display: none;
 }
 .use-case-collection-heading p {
-	font-size: 13px;
+	font-size: var(--font-secondary);
 }
 .use-case-search-field {
 	width: 100%;
@@ -350,7 +346,7 @@ select {
 	border-radius: 0;
 }
 .use-case-scenario-heading h4 {
-	font-size: 15px;
+	font-size: var(--font-body);
 }
 .use-case-scenario-badges {
 	font-size: 12px;
@@ -389,7 +385,7 @@ select {
 	width: 100%;
 }
 .use-case-decision-actions p {
-	font-size: 13px;
+	font-size: var(--font-secondary);
 }
 .test-cases-section-tabs {
 	background: none;
@@ -416,7 +412,7 @@ select {
 	color: var(--text-muted);
 }
 .test-generation-panel.has-test-cases > .generation-gate-card.ready p {
-	font-size: 13px;
+	font-size: var(--font-secondary);
 }
 .test-quality-summary {
 	display: flex;
@@ -557,12 +553,12 @@ select {
 }
 .test-review-item small,
 .test-review-item span span {
-	font-size: 13px;
+	font-size: var(--font-secondary);
 	font-weight: 400;
 	color: var(--text-muted);
 }
 .test-review-item strong {
-	font-size: 15px;
+	font-size: var(--font-body);
 	line-height: 1.45;
 	overflow-wrap: anywhere;
 }
@@ -588,7 +584,7 @@ select {
 	color: var(--text-muted);
 }
 .test-review-detail .test-detail-meta {
-	font-size: 13px;
+	font-size: var(--font-secondary);
 	margin: 4px 0;
 }
 .test-inline-findings {
@@ -609,7 +605,7 @@ select {
 }
 .test-steps-heading > span {
 	color: var(--text-muted);
-	font-size: 13px;
+	font-size: var(--font-secondary);
 }
 .test-detail-steps {
 	padding-left: 22px;
@@ -622,7 +618,7 @@ select {
 	color: var(--text-main);
 }
 .test-detail-steps strong {
-	font-size: 13px;
+	font-size: var(--font-secondary);
 	margin-right: 10px;
 	font-weight: 500;
 }
@@ -697,7 +693,7 @@ select {
 		flex-wrap: wrap;
 	}
 	.project-page-header h1 {
-		font-size: 30px;
+		font-size: var(--font-page-title-mobile);
 	}
 }
 @media (max-width: 480px) {
@@ -722,7 +718,7 @@ select {
 	}
 	.global-navigation-link {
 		padding: 8px;
-		font-size: 13px;
+		font-size: var(--font-secondary);
 	}
 	.test-case-metadata dl > div {
 		grid-template-columns: 1fr;
@@ -878,7 +874,7 @@ select {
 }
 .scenario-details > summary {
 	cursor: pointer;
-	font-size: 15px;
+	font-size: var(--font-body);
 	display: flex;
 	align-items: baseline;
 	gap: 12px;
@@ -897,7 +893,7 @@ select {
 	color: var(--text-muted);
 }
 .scenario-summary-copy strong {
-	font-size: 15px;
+	font-size: var(--font-body);
 	line-height: 1.5;
 	font-weight: 550;
 }
@@ -906,7 +902,7 @@ select {
 	color: var(--text-muted);
 }
 .scenario-expanded-content > span {
-	font-size: 13px;
+	font-size: var(--font-secondary);
 }
 @media (max-width: 600px) {
 	.scenario-summary-copy {

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -18,7 +18,7 @@
 	--info-tonal: #f5f3ff;
 
 	/* Surfaces */
-	--bg-color: #f4f6fb;
+	--bg-color: #fff;
 	--card-bg: #ffffff;
 	--surface-container: #f8fafd;
 	--surface-container-high: #eef2f9;
@@ -38,9 +38,26 @@
 
 	/* Shape */
 	--radius-sm: 0.5rem;
-	--radius-md: 0.75rem;
-	--radius-lg: 1rem;
+	--radius-md: 10px;
+	--radius-lg: 12px;
 	--radius-xl: 1.25rem;
+
+	/* Shared density and rhythm */
+	--space-1: 4px;
+	--space-2: 8px;
+	--space-3: 12px;
+	--space-4: 16px;
+	--space-5: 24px;
+	--space-6: 32px;
+	--control-height: 44px;
+	--control-height-compact: 36px;
+	--table-cell-padding: 12px 16px;
+	--table-cell-padding-compact: 8px 12px;
+	--font-body: 15px;
+	--font-secondary: 13px;
+	--font-page-title: 36px;
+	--font-page-title-mobile: 30px;
+	--focus-outline: 2px solid var(--primary);
 
 	/* Typography */
 	--font-sans: "Inter", "InterVariable", system-ui, -apple-system, "Segoe UI", sans-serif;

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -7,7 +7,10 @@
 	--primary-container: #dbe7ff;
 	--primary-glow: rgb(37 99 235 / 0.28);
 
-	/* Semantic */
+	/* Semantic: text tones meet contrast on their tinted surfaces. */
+	--success-text: #047857;
+	--warning-text: #8b5500;
+	--danger-text: #b91c1c;
 	--success: #059669;
 	--success-tonal: #ecfdf5;
 	--warning: #d97706;

--- a/frontend/src/styles/ui.css
+++ b/frontend/src/styles/ui.css
@@ -96,7 +96,7 @@
 	box-shadow: none;
 }
 .ui-input[aria-invalid="true"] {
-	border-color: var(--danger);
+	border-color: var(--danger-text);
 }
 .ui-input:disabled {
 	background: var(--surface-container);
@@ -122,7 +122,7 @@
 	color: var(--text-muted);
 }
 .ui-field-error {
-	color: var(--danger);
+	color: var(--danger-text);
 }
 .ui-badge {
 	display: inline-flex;
@@ -137,14 +137,14 @@
 	flex-shrink: 0;
 }
 .ui-badge[data-tone="success"] {
-	color: var(--success);
+	color: var(--success-text);
 }
 .ui-badge[data-tone="warning"],
 .ui-badge[data-tone="blocked"] {
-	color: #8b5500;
+	color: var(--warning-text);
 }
 .ui-badge[data-tone="danger"] {
-	color: var(--danger);
+	color: var(--danger-text);
 }
 .ui-badge[data-tone="neutral"],
 .ui-badge[data-tone="pending"] {
@@ -354,4 +354,39 @@
 	.ui-selectable-item {
 		transition: none;
 	}
+}
+
+.ui-search {
+	display: flex;
+	align-items: center;
+	gap: var(--space-2);
+	min-width: 0;
+	padding: 0 var(--space-3);
+	border: 1px solid var(--border-strong);
+	border-radius: var(--radius-sm);
+	background: var(--card-bg);
+}
+.ui-search > svg {
+	flex: 0 0 auto;
+	color: var(--text-muted);
+}
+.ui-search .ui-input[type="search"]:not([type="file"]) {
+	border: 0;
+	box-shadow: none;
+	background: transparent;
+	padding-left: 0;
+	padding-right: 0;
+	flex: 1;
+}
+.ui-search:focus-within {
+	outline: var(--focus-outline);
+	outline-offset: 2px;
+}
+.ui-search input:focus-visible {
+	outline: none;
+}
+.ui-search kbd {
+	flex-shrink: 0;
+	font-size: 11px;
+	color: var(--text-muted);
 }

--- a/frontend/src/styles/ui.css
+++ b/frontend/src/styles/ui.css
@@ -286,7 +286,7 @@
 .ui-list-detail > * {
 	min-width: 0;
 }
-.ui-collection-toolbar {
+:where(.ui-collection-toolbar) {
 	display: flex;
 	flex-wrap: wrap;
 	align-items: end;
@@ -340,7 +340,7 @@
 	}
 }
 @media (max-width: 600px) {
-	.ui-collection-toolbar {
+	:where(.ui-collection-toolbar) {
 		align-items: stretch;
 	}
 	.ui-collection-toolbar > * {

--- a/frontend/src/styles/ui.css
+++ b/frontend/src/styles/ui.css
@@ -1,0 +1,357 @@
+/* Shared component appearance. Feature styles own composition, not these values. */
+.ui-button {
+	font-family: var(--font-sans);
+	font-size: var(--font-body);
+	font-weight: 600;
+	border-radius: var(--radius-sm);
+	cursor: pointer;
+}
+.ui-button[data-variant="primary"],
+.ui-button[data-variant="secondary"],
+.ui-button[data-variant="danger"] {
+	min-height: var(--control-height);
+	padding: 10px 16px;
+	border: 1px solid transparent;
+	box-shadow: none;
+	transform: none;
+	line-height: 1.4;
+}
+.ui-button[data-variant="primary"] {
+	background: var(--primary);
+	color: white;
+}
+.ui-button[data-variant="primary"]:hover:not(:disabled) {
+	background: var(--primary-hover);
+}
+.ui-button[data-variant="secondary"] {
+	background: var(--card-bg);
+	border-color: var(--border-strong);
+	color: var(--primary-hover);
+}
+.ui-button[data-variant="secondary"]:hover:not(:disabled) {
+	background: var(--primary-tonal);
+	border-color: var(--primary);
+}
+.ui-button[data-variant="danger"] {
+	background: var(--danger);
+	color: white;
+}
+.ui-button[data-variant="danger"]:hover:not(:disabled) {
+	background: var(--text-main);
+}
+.ui-button[data-variant="plain"],
+.ui-button[data-variant="tab"] {
+	box-shadow: none;
+	transform: none;
+}
+.ui-button[data-size="compact"],
+.ui-button.small {
+	min-height: var(--control-height-compact);
+	padding: 6px 12px;
+	font-size: var(--font-secondary);
+}
+.ui-button:disabled {
+	cursor: not-allowed;
+	box-shadow: none;
+	transform: none;
+	opacity: 0.65;
+}
+.ui-button[data-variant]:disabled {
+	background: var(--surface-container-high);
+	color: var(--text-muted);
+	border-color: var(--border-color);
+}
+.ui-button:focus-visible,
+.ui-link:focus-visible,
+.ui-input:focus-visible,
+.ui-selectable-item:focus-visible,
+.ui-disclosure > summary:focus-visible {
+	outline: var(--focus-outline);
+	outline-offset: 3px;
+}
+.ui-link {
+	text-underline-offset: 3px;
+}
+.ui-input:not([type="checkbox"]):not([type="radio"]):not([type="file"]) {
+	box-sizing: border-box;
+	width: 100%;
+	min-width: 0;
+	min-height: var(--control-height);
+	padding: 10px 12px;
+	border: 1px solid var(--border-strong);
+	border-radius: var(--radius-sm);
+	font: inherit;
+	color: var(--text-main);
+	background: var(--card-bg);
+	box-shadow: none;
+}
+.ui-input[type="checkbox"],
+.ui-input[type="radio"] {
+	width: 18px;
+	min-width: 18px;
+	height: 18px;
+	padding: 0;
+	margin: 0;
+	accent-color: var(--primary);
+	box-shadow: none;
+}
+.ui-input[aria-invalid="true"] {
+	border-color: var(--danger);
+}
+.ui-input:disabled {
+	background: var(--surface-container);
+	color: var(--text-muted);
+	cursor: not-allowed;
+}
+.ui-field {
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-2);
+	min-width: 0;
+}
+.ui-field > label {
+	font-size: var(--font-secondary);
+	font-weight: 600;
+}
+.ui-field-hint,
+.ui-field-error {
+	margin: 0;
+	font-size: var(--font-secondary);
+}
+.ui-field-hint {
+	color: var(--text-muted);
+}
+.ui-field-error {
+	color: var(--danger);
+}
+.ui-badge {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	max-width: 100%;
+	font-size: var(--font-secondary);
+	line-height: 1.4;
+	overflow-wrap: anywhere;
+}
+.ui-badge > svg {
+	flex-shrink: 0;
+}
+.ui-badge[data-tone="success"] {
+	color: var(--success);
+}
+.ui-badge[data-tone="warning"],
+.ui-badge[data-tone="blocked"] {
+	color: #8b5500;
+}
+.ui-badge[data-tone="danger"] {
+	color: var(--danger);
+}
+.ui-badge[data-tone="neutral"],
+.ui-badge[data-tone="pending"] {
+	color: var(--text-muted);
+}
+.ui-badge[data-tone="info"],
+.ui-badge[data-tone="running"] {
+	color: var(--primary);
+}
+.ui-surface {
+	min-width: 0;
+	border-radius: var(--radius-md);
+}
+.ui-alert {
+	min-width: 0;
+	overflow-wrap: anywhere;
+	border-radius: var(--radius-sm);
+}
+.ui-alert[data-tone="warning"] {
+	background: var(--warning-tonal);
+}
+.ui-alert[data-tone="danger"] {
+	background: var(--danger-tonal);
+}
+.ui-alert[data-tone="success"] {
+	background: var(--success-tonal);
+}
+.ui-disclosure {
+	min-width: 0;
+}
+.ui-disclosure > summary {
+	cursor: pointer;
+}
+.ui-disclosure > summary:hover {
+	color: var(--primary-hover);
+}
+.ui-table-scroll {
+	max-width: 100%;
+	min-width: 0;
+	overflow-x: auto;
+	overscroll-behavior-x: contain;
+	border: 1px solid var(--border-color);
+	border-radius: var(--radius-md);
+}
+.ui-table {
+	width: 100%;
+	border-collapse: collapse;
+	font-size: var(--font-body);
+	color: var(--text-main);
+}
+.ui-table th,
+.ui-table td {
+	padding: var(--table-cell-padding);
+	border-bottom: 1px solid var(--border-color);
+	text-align: left;
+	vertical-align: top;
+}
+.ui-table[data-density="compact"] th,
+.ui-table[data-density="compact"] td {
+	padding: var(--table-cell-padding-compact);
+}
+.ui-table th {
+	font-size: var(--font-secondary);
+	font-weight: 600;
+	color: var(--text-muted);
+	background: var(--surface-container);
+}
+.ui-table tbody tr:last-child > td {
+	border-bottom: 0;
+}
+.ui-table tbody tr:hover {
+	background: var(--surface-container);
+}
+.ui-table [aria-selected="true"] {
+	background: var(--primary-tonal);
+}
+.ui-table td[data-align="numeric"],
+.ui-table th[data-align="numeric"] {
+	text-align: right;
+	font-variant-numeric: tabular-nums;
+}
+.ui-table td {
+	overflow-wrap: anywhere;
+}
+.ui-list {
+	min-width: 0;
+}
+.ui-list[data-variant="collection"],
+.ui-list[data-variant="selectable"],
+.ui-list[data-variant="grouped"] {
+	padding: 0;
+	margin: 0;
+	list-style: none;
+}
+.ui-list-item {
+	min-width: 0;
+	overflow-wrap: anywhere;
+}
+.ui-selectable-item {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: var(--space-3);
+	width: 100%;
+	padding: var(--space-4);
+	text-align: left;
+	white-space: normal;
+	overflow-wrap: anywhere;
+	border: 0;
+	border-bottom: 1px solid var(--border-color);
+	border-radius: var(--radius-sm);
+	font: inherit;
+	background: var(--card-bg);
+	color: var(--text-main);
+	box-shadow: none;
+	transform: none;
+}
+.ui-selectable-item[aria-pressed="true"] {
+	background: var(--primary-tonal);
+}
+.ui-selectable-item:hover:not(:disabled) {
+	background: var(--surface-container);
+	color: var(--text-main);
+	box-shadow: none;
+	transform: none;
+}
+.ui-selectable-item[aria-pressed="true"]:hover {
+	background: var(--primary-container);
+}
+.ui-selectable-item > svg {
+	flex-shrink: 0;
+}
+.ui-list-detail {
+	display: grid;
+	grid-template-columns: minmax(260px, 0.38fr) minmax(0, 0.62fr);
+	gap: var(--space-6);
+	min-width: 0;
+}
+.ui-list-detail > * {
+	min-width: 0;
+}
+.ui-collection-toolbar {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: end;
+	gap: var(--space-4);
+	min-width: 0;
+}
+.ui-result-count {
+	color: var(--text-muted);
+	font-size: var(--font-secondary);
+}
+.ui-collection-state {
+	min-width: 0;
+	overflow-wrap: anywhere;
+}
+.ui-tablist {
+	min-width: 0;
+}
+.ui-tab[data-variant="tab"] {
+	box-shadow: none;
+	transform: none;
+}
+.ui-tabpanel:focus-visible,
+.ui-table-scroll:focus-visible {
+	outline: var(--focus-outline);
+	outline-offset: 2px;
+}
+.ui-dialog {
+	max-width: calc(100vw - 32px);
+	max-height: calc(100dvh - 32px);
+	overflow: auto;
+	background: var(--card-bg);
+	border: 1px solid var(--border-color);
+	border-radius: var(--radius-lg);
+	box-shadow: var(--shadow-lg);
+}
+.ui-dialog:focus {
+	outline: none;
+}
+.ui-menu {
+	background: var(--card-bg);
+	border: 1px solid var(--border-color);
+	border-radius: var(--radius-md);
+	box-shadow: var(--shadow-md);
+}
+.ui-progress {
+	accent-color: var(--primary);
+}
+@media (max-width: 1200px) {
+	.ui-list-detail {
+		grid-template-columns: minmax(0, 1fr);
+	}
+}
+@media (max-width: 600px) {
+	.ui-collection-toolbar {
+		align-items: stretch;
+	}
+	.ui-collection-toolbar > * {
+		min-width: 0;
+		max-width: 100%;
+	}
+}
+@media (prefers-reduced-motion: reduce) {
+	.ui-button,
+	.ui-input,
+	.ui-selectable-item {
+		transition: none;
+	}
+}


### PR DESCRIPTION
Closes #245. Part of #241; stacked on #249.

All remaining native product controls now consume the shared library, including navigation, context, export, settings, integrations, authentication and diagnostics. Shared fields associate existing labels and help text. Settings and sign-in dialogs use common focus trapping/restoration; regeneration retains its submission guard with shared focus handling. Settings and result tabs use shared keyboard activation. Existing domain status adapters now use Badge.

Validation: lint, formatting and production build passed; all 60 targeted browser checks passed. New actual-page tests cover arrow-key result tabs, table keyboard focus, modal focus trapping/restoration and labeled integration fields. Existing review, generation, navigation and responsive tests remain green. No backend changes.
