### PR TITLE
Group Use Cases by requirement with synchronized table widths

### DIFF
--- a/docs/github-issues-backlog.md
+++ b/docs/github-issues-backlog.md
@@ -1,5 +1,7 @@
 # GitHub Issue Backlog for Test Case Engine Improvements
 
+- Implemented, awaiting review: #265 — Group Use Cases under source requirement headings with synchronized four-column resizing. Builds on #263 / PR #264; parent #241.
+
 - Implemented, awaiting review: #263 — Remove scenario Details, use direct Quality flags dropdowns, and add shared resizable table columns. Builds on #261 / PR #262; parent #241.
 
 - Implemented, awaiting review: #261 — Use Cases scenario table with persisted row decisions, multi-select flags, filters and explicit bulk approval; builds on #259 / PR #260. Parent #241. Validation: 386 backend tests, both offline benchmarks and 161 frontend workflow tests pass.

--- a/docs/project-design.md
+++ b/docs/project-design.md
@@ -99,4 +99,12 @@ See [scenario review persistence](scenario-review-persistence.md) for the API an
 
 Use Cases uses shared `MultiSelect` and `ResizableTable` components. Quality flags have a uniform visible label and selected count; the accessible label retains scenario context. The checkbox popup uses the native popover top layer to avoid table-scroll clipping, and supports Escape/light dismissal and a Done action. Opening it does not expand the row. Titles/objectives no longer include nested Details.
 
-Drag a divider at the right edge of any column header. Keyboard Left/Right adjusts by 10px (Shift: 40px), Home/End applies limits, and Enter/double-click restores that column's default width. Width preferences persist under `tcg.columns.use-cases`; unavailable storage does not block resizing. Minimum widths preserve usable controls, and wider tables scroll within their labeled container. Layout changes never submit or clear row reviews.
+Drag a divider at the right edge of any column header. Keyboard Left/Right adjusts by 10px (Shift: 40px), Home/End applies limits, and Enter/double-click restores that column's default width. Width preferences persist locally (the current grouped-table key is documented below); unavailable storage does not block resizing. Minimum widths preserve usable controls, and wider tables scroll within their labeled container. Layout changes never submit or clear row reviews.
+
+## Requirement-grouped tables (#265)
+
+Use Cases displays each requirement ID, full text and visible use-case count once in a non-collapsible `.ui-table-group-heading`, followed by a named four-column table. Columns are Use Case ID, Title / objective, Review status and Quality flags. Search, filters, save/discard controls and overall review actions remain page-level; groups without matching rows disappear without discarding draft reviews.
+
+`ResizableTable` supports controlled `widths` (pixel array or `null` for default proportions) and `onWidthsChange(nextWidths)`. A page owning multiple tables should call `useTableColumnWidths(columns, storageKey)` once and pass the returned state/setter to every table. Standalone tables may continue using `storageKey` for internal persistence. Pass `aria-labelledby` to name each table from its requirement heading. Group headings wrap outside each labeled horizontal scroll container.
+
+Use Cases stores the synchronized layout under `tcg.columns.use-cases-grouped-v1`; the previous five-column preference remains unused. Dragging or keyboard-resizing any group's header updates every visible table and groups restored by clearing filters. Review draft identity and persistence remain owned by the page.

--- a/frontend/e2e/scenario-review-table.spec.js
+++ b/frontend/e2e/scenario-review-table.spec.js
@@ -83,7 +83,7 @@ for (const width of [390, 1488])
 	test(`scenario controls are accessible and the table scrolls inside the page at ${width}px`, async ({ page }) => {
 		await page.setViewportSize({ width, height: 900 });
 		await open(page);
-		const region = page.getByRole("region", { name: "Use case scenarios table", exact: true });
+		const region = page.getByRole("region", { name: "Use cases for REQ-101", exact: true });
 		await expect(region).toHaveAttribute("tabindex", "0");
 		expect(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth)).toBe(true);
 		const results = await new AxeBuilder({ page }).include(".scenario-table-scroll").analyze();
@@ -94,8 +94,10 @@ test("column dividers support pointer and keyboard resizing without losing draft
 	await page.setViewportSize({ width: 1488, height: 900 });
 	const api = await open(page);
 	await status(page).selectOption("approved");
-	const divider = page.getByRole("separator", { name: "Resize Title / objective column", exact: true });
-	const header = page.getByRole("columnheader", { name: /^Title \/ objective/ });
+	const dividers = page.getByRole("separator", { name: "Resize Title / objective column", exact: true });
+	const divider = dividers.first();
+	const headers = page.getByRole("columnheader", { name: /^Title \/ objective/ });
+	const header = headers.first();
 	const before = (await header.boundingBox()).width;
 	const box = await divider.boundingBox();
 	await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
@@ -108,11 +110,25 @@ test("column dividers support pointer and keyboard resizing without losing draft
 	await expect(divider).toHaveAttribute("aria-valuenow", "200");
 	await page.keyboard.press("ArrowRight");
 	await expect(divider).toHaveAttribute("aria-valuenow", "210");
+	await expect(dividers.nth(1)).toHaveAttribute("aria-valuenow", "210");
+	expect((await headers.nth(1).boundingBox()).width).toBe((await header.boundingBox()).width);
+	await expect(status(page)).toHaveValue("approved");
+	const search = page.getByRole("searchbox", { name: "Search use cases", exact: true });
+	await search.fill("supervisor");
+	await expect(dividers).toHaveCount(1);
+	await divider.focus();
+	await page.keyboard.press("ArrowRight");
+	await search.fill("");
+	await expect(dividers).toHaveCount(2);
+	await expect(dividers.first()).toHaveAttribute("aria-valuenow", "220");
+	await expect(dividers.nth(1)).toHaveAttribute("aria-valuenow", "220");
 	await expect(status(page)).toHaveValue("approved");
 	expect(api.requests.review).toHaveLength(0);
 	await page.getByRole("button", { name: "Discard edits", exact: true }).click();
 	await page.reload();
-	await expect(divider).toHaveAttribute("aria-valuenow", "210");
+	await expect(divider).toHaveAttribute("aria-valuenow", "220");
+	await expect(dividers.nth(1)).toHaveAttribute("aria-valuenow", "220");
+	expect((await headers.nth(1).boundingBox()).width).toBe((await header.boundingBox()).width);
 	await page.setViewportSize({ width: 390, height: 844 });
 	expect(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth)).toBe(true);
 });
@@ -134,4 +150,49 @@ test("quality dropdown does not expand rows and restores focus on Escape", async
 	await trigger.click();
 	await page.setViewportSize({ width: 390, height: 844 });
 	await expect(group).not.toBeVisible();
+});
+
+test("requirement headings replace repeated cells and filtering preserves cross-group drafts", async ({ page }) => {
+	const api = await open(page);
+	await expect(page.getByRole("table")).toHaveCount(2);
+	await expect(page.getByRole("columnheader", { name: /^Source requirement/ })).toHaveCount(0);
+	await expect(page.getByRole("heading", { name: "REQ-101", exact: true })).toHaveCount(1);
+	await expect(page.getByText("Customers can complete express checkout with a saved payment method.", { exact: true })).toHaveCount(1);
+	await expect(page.getByRole("table", { name: "REQ-101", exact: true }).getByRole("rowheader")).toHaveText([
+		"REQ-101-SCN-01",
+		"REQ-101-SCN-02",
+	]);
+	await status(page).selectOption("approved");
+	const search = page.getByRole("searchbox", { name: "Search use cases", exact: true });
+	await search.fill("supervisor");
+	await expect(page.getByRole("table", { name: "REQ-101", exact: true })).toHaveCount(0);
+	await page.getByRole("combobox", { name: "Review status for REQ-202-SCN-01", exact: true }).selectOption("request_changes");
+	await search.fill("");
+	await expect(status(page)).toHaveValue("approved");
+	await page.getByRole("button", { name: "Save reviews", exact: true }).click();
+	await expect(page.getByRole("status", { name: "Review outcome" })).toHaveText("Scenario reviews saved.");
+	expect(api.requests.review[0].payload.scenario_reviews).toEqual([
+		{ requirement_id: "REQ-101", scenario_id: "REQ-101-SCN-01", status: "approved", quality_flags: [] },
+		{ requirement_id: "REQ-202", scenario_id: "REQ-202-SCN-01", status: "request_changes", quality_flags: [] },
+	]);
+	await page.getByRole("combobox", { name: "Filter by review status", exact: true }).selectOption("approved");
+	await expect(page.getByRole("table")).toHaveCount(1);
+	await expect(page.getByText("1 use case", { exact: true })).toBeVisible();
+	await search.fill("no matching use case");
+	await expect(page.getByRole("table")).toHaveCount(0);
+	await expect(page.getByText("No scenarios match these filters.")).toBeVisible();
+});
+
+test("long requirement headings and single-row groups wrap without page overflow", async ({ page }) => {
+	const project = useCaseProjectFixture();
+	const groups = project.current_snapshots.use_cases.payload.coverage_plan;
+	groups[0].requirement_text = "Long requirement text ".repeat(30);
+	groups[0].scenarios = groups[0].scenarios.slice(0, 1);
+	await page.setViewportSize({ width: 390, height: 844 });
+	await page.addInitScript(() => localStorage.setItem("tcg.columns.use-cases", JSON.stringify([220, 143, 352, 187, 198])));
+	await open(page, { initialProject: project });
+	await expect(page.getByText(groups[0].requirement_text.trim(), { exact: true })).toBeVisible();
+	await expect(page.getByText("1 use case", { exact: true })).toBeVisible();
+	await expect(page.getByRole("table", { name: "REQ-101", exact: true }).getByRole("columnheader")).toHaveCount(4);
+	expect(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth)).toBe(true);
 });

--- a/frontend/e2e/use-case-review.spec.js
+++ b/frontend/e2e/use-case-review.spec.js
@@ -113,10 +113,11 @@ test.describe("Use Cases review workbench", () => {
 		await expect(main).toContainText(/current|fresh/i);
 
 		const table = main.getByRole("table");
-		await expect(table.getByRole("row")).toHaveCount(5);
+		await expect(table).toHaveCount(2);
+		await expect(table.getByRole("row")).toHaveCount(6);
 		const checkoutRow = table.getByRole("row").filter({ hasText: "REQ-101-SCN-01" });
 		await expect(checkoutRow).toContainText("Complete express checkout");
-		await expect(table).toContainText(/declined saved card/i);
+		await expect(main.getByRole("table", { name: "REQ-101", exact: true })).toContainText(/declined saved card/i);
 		await expect(checkoutRow.locator("details")).toHaveCount(0);
 		const approvalRow = table.getByRole("row").filter({ hasText: "REQ-202-SCN-01" });
 		await expect(approvalRow).toContainText("Require supervisor approval");

--- a/frontend/src/components/reviews/ScenarioReviewTable.jsx
+++ b/frontend/src/components/reviews/ScenarioReviewTable.jsx
@@ -1,17 +1,16 @@
 import { MultiSelect } from "../ui/multi-select";
-import { ResizableTable } from "../ui/resizable-table";
-import { useState } from "react";
+import { ResizableTable, useTableColumnWidths } from "../ui/resizable-table";
+import { useId, useState } from "react";
 import { Button, Select } from "../ui/controls";
 import { Alert } from "../ui/surfaces";
 import { TableScroll, CollectionState } from "../ui/collections";
 
 export const SCENARIO_FLAGS = ["Ambiguous", "Duplicate", "Missing coverage", "Not testable", "Incorrect requirement mapping"];
 const COLUMNS = [
-	{ label: "Source requirement", percent: 20, min: 140, initial: 220 },
-	{ label: "Use Case ID", percent: 13, min: 100, initial: 143 },
-	{ label: "Title / objective", percent: 32, min: 200, initial: 352 },
-	{ label: "Review status", percent: 17, min: 150, initial: 187 },
-	{ label: "Quality flags", percent: 18, min: 150, initial: 198 },
+	{ label: "Use Case ID", percent: 18, min: 140, initial: 144 },
+	{ label: "Title / objective", percent: 42, min: 200, initial: 336 },
+	{ label: "Review status", percent: 20, min: 150, initial: 160 },
+	{ label: "Quality flags", percent: 20, min: 150, initial: 160 },
 ];
 const STATUSES = { needs_review: "Needs review", approved: "Approved", request_changes: "Changes requested" };
 const keyFor = (group, scenario) => JSON.stringify([group.requirement_id, scenario.id]);
@@ -28,6 +27,8 @@ export function scenarioReview(group, scenario, state, snapshotId) {
 }
 
 export default function ScenarioReviewTable({ groups, allGroups, state, snapshot, revision, review, drafts, setDrafts }) {
+	const headingPrefix = useId();
+	const [widths, setWidths] = useTableColumnWidths(COLUMNS, "use-cases-grouped-v1");
 	const [statusFilter, setStatusFilter] = useState("");
 	const [flagFilters, setFlagFilters] = useState([]);
 	const [draftRevision, setDraftRevision] = useState(revision);
@@ -47,6 +48,9 @@ export default function ScenarioReviewTable({ groups, allGroups, state, snapshot
 				(!statusFilter || row.value.status === statusFilter) &&
 				(!flagFilters.length || flagFilters.some((flag) => row.value.quality_flags.includes(flag)))
 		);
+	const visibleGroups = groups
+		.map((group) => ({ group, rows: rows.filter((row) => row.group === group) }))
+		.filter(({ rows }) => rows.length);
 	const approved = allGroups.reduce(
 		(total, group) =>
 			total +
@@ -134,51 +138,64 @@ export default function ScenarioReviewTable({ groups, allGroups, state, snapshot
 					)}
 				</Alert>
 			) : null}
-			<TableScroll label="Use case scenarios table" aria-label="Use case scenarios table" className="scenario-table-scroll">
-				<ResizableTable columns={COLUMNS} storageKey="use-cases" className="scenario-review-table">
-					<tbody>
-						{rows.map((row) => (
-							<tr key={row.key}>
-								<td>
-									<strong>{row.group.requirement_id}</strong>
-									<p>{row.group.requirement_text}</p>
-								</td>
-								<th scope="row">{row.scenario.id}</th>
-								<td>
-									<strong>{row.scenario.title || row.scenario.objective}</strong>
-									<p>{row.scenario.objective}</p>
-								</td>
-								<td>
-									<div className="scenario-status-filter">
-										<Select
-											aria-label={`Review status for ${row.scenario.id}`}
-											value={row.value.status}
-											disabled={disabled || !row.scenario.id || !row.group.requirement_id}
-											onChange={(event) => change(row, { status: event.target.value })}
-										>
-											{Object.entries(STATUSES).map(([value, label]) => (
-												<option key={value} value={value} disabled={value === "approved" && state?.stale}>
-													{label}
-												</option>
-											))}
-										</Select>
-									</div>
-								</td>
-								<td>
-									<MultiSelect
-										label="Quality flags"
-										accessibleLabel={`Quality flags for ${row.scenario.id}`}
-										options={SCENARIO_FLAGS}
-										value={row.value.quality_flags}
-										disabled={disabled || !row.scenario.id || !row.group.requirement_id}
-										onChange={(quality_flags) => change(row, { quality_flags })}
-									/>
-								</td>
-							</tr>
-						))}
-					</tbody>
-				</ResizableTable>
-			</TableScroll>
+			{visibleGroups.map(({ group, rows: groupRows }, index) => (
+				<section key={group.requirement_id} className="ui-table-group">
+					<header className="ui-table-group-heading">
+						<h3 id={`${headingPrefix}-${index}`}>{group.requirement_id}</h3>
+						<span>
+							{groupRows.length} {groupRows.length === 1 ? "use case" : "use cases"}
+						</span>
+						<p>{group.requirement_text}</p>
+					</header>
+					<TableScroll aria-label={`Use cases for ${group.requirement_id}`} className="scenario-table-scroll">
+						<ResizableTable
+							columns={COLUMNS}
+							widths={widths}
+							onWidthsChange={setWidths}
+							aria-labelledby={`${headingPrefix}-${index}`}
+							className="scenario-review-table"
+						>
+							<tbody>
+								{groupRows.map((row) => (
+									<tr key={row.key}>
+										<th scope="row">{row.scenario.id}</th>
+										<td>
+											<strong>{row.scenario.title || row.scenario.objective}</strong>
+											<p>{row.scenario.objective}</p>
+										</td>
+										<td>
+											<div className="scenario-status-filter">
+												<Select
+													aria-label={`Review status for ${row.scenario.id}`}
+													value={row.value.status}
+													disabled={disabled || !row.scenario.id || !row.group.requirement_id}
+													onChange={(event) => change(row, { status: event.target.value })}
+												>
+													{Object.entries(STATUSES).map(([value, label]) => (
+														<option key={value} value={value} disabled={value === "approved" && state?.stale}>
+															{label}
+														</option>
+													))}
+												</Select>
+											</div>
+										</td>
+										<td>
+											<MultiSelect
+												label="Quality flags"
+												accessibleLabel={`Quality flags for ${row.scenario.id}`}
+												options={SCENARIO_FLAGS}
+												value={row.value.quality_flags}
+												disabled={disabled || !row.scenario.id || !row.group.requirement_id}
+												onChange={(quality_flags) => change(row, { quality_flags })}
+											/>
+										</td>
+									</tr>
+								))}
+							</tbody>
+						</ResizableTable>
+					</TableScroll>
+				</section>
+			))}
 			{!rows.length ? (
 				<CollectionState kind={total ? "filtered" : "empty"}>
 					{total ? "No scenarios match these filters." : "No scenarios have been generated."}

--- a/frontend/src/components/ui/resizable-table.jsx
+++ b/frontend/src/components/ui/resizable-table.jsx
@@ -1,19 +1,10 @@
 import { useEffect, useRef, useState } from "react";
 import { Table } from "./collections";
 
-export function ResizableTable({ columns, storageKey, children, className }) {
-	const table = useRef(null);
-	const drag = useRef(null);
-	const [measured, setMeasured] = useState(null);
-	useEffect(() => {
-		const observer = new ResizeObserver(() =>
-			setMeasured([...table.current.querySelectorAll("thead th")].map((cell) => cell.getBoundingClientRect().width))
-		);
-		observer.observe(table.current);
-		return () => observer.disconnect();
-	}, []);
+export function useTableColumnWidths(columns, storageKey) {
 	const [widths, setWidths] = useState(() => {
 		try {
+			if (!storageKey) return null;
 			const saved = JSON.parse(localStorage.getItem(`tcg.columns.${storageKey}`));
 			return Array.isArray(saved) &&
 				saved.length === columns.length &&
@@ -25,7 +16,7 @@ export function ResizableTable({ columns, storageKey, children, className }) {
 		}
 	});
 	useEffect(() => {
-		if (widths) {
+		if (widths && storageKey) {
 			try {
 				localStorage.setItem(`tcg.columns.${storageKey}`, JSON.stringify(widths));
 			} catch {
@@ -33,11 +24,29 @@ export function ResizableTable({ columns, storageKey, children, className }) {
 			}
 		}
 	}, [widths, storageKey]);
+	return [widths, setWidths];
+}
+
+export function ResizableTable({ columns, storageKey, widths: controlledWidths, onWidthsChange, children, className, ...props }) {
+	const table = useRef(null);
+	const drag = useRef(null);
+	const [measured, setMeasured] = useState(null);
+	useEffect(() => {
+		const observer = new ResizeObserver(() =>
+			setMeasured([...table.current.querySelectorAll("thead th")].map((cell) => cell.getBoundingClientRect().width))
+		);
+		observer.observe(table.current);
+		return () => observer.disconnect();
+	}, []);
+	const [localWidths, setLocalWidths] = useTableColumnWidths(columns, controlledWidths === undefined ? storageKey : undefined);
+	const widths = controlledWidths === undefined ? localWidths : controlledWidths;
+	const setWidths = onWidthsChange || setLocalWidths;
 	const actualWidths = () => [...table.current.querySelectorAll("thead th")].map((cell) => cell.getBoundingClientRect().width);
 	const resize = (index, width, baseline = widths || actualWidths()) =>
 		setWidths(baseline.map((value, i) => (i === index ? Math.round(Math.max(columns[i].min, Math.min(1200, width))) : value)));
 	return (
 		<Table
+			{...props}
 			ref={table}
 			className={className}
 			style={{

--- a/frontend/src/styles/project-design.css
+++ b/frontend/src/styles/project-design.css
@@ -1002,7 +1002,7 @@ select {
 	max-width: 100%;
 }
 .scenario-review-table {
-	min-width: 950px;
+	min-width: 800px;
 	table-layout: fixed;
 	width: 100%;
 }

--- a/frontend/src/styles/ui.css
+++ b/frontend/src/styles/ui.css
@@ -633,3 +633,31 @@
 	outline: var(--focus-outline);
 	outline-offset: -2px;
 }
+
+.ui-table-group {
+	min-width: 0;
+	margin-block: var(--space-6);
+}
+.ui-table-group-heading {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: baseline;
+	gap: var(--space-2) var(--space-3);
+	padding: var(--space-3) var(--space-4);
+	background: var(--surface-container);
+	border: 1px solid var(--border-color);
+	border-bottom: 0;
+	overflow-wrap: anywhere;
+}
+.ui-table-group-heading h3 {
+	margin: 0;
+	font-size: inherit;
+}
+.ui-table-group-heading span {
+	color: var(--text-muted);
+	font-size: var(--font-secondary);
+}
+.ui-table-group-heading p {
+	flex-basis: 100%;
+	margin: 0;
+}


### PR DESCRIPTION
Use Cases now shows each requirement ID, full text and visible use-case count once above its own four-column table. All groups stay expanded, and groups with no matching rows disappear when filtering.

Column widths are controlled once per page, so resizing any table updates every group, including groups restored after filtering. The new preference key avoids reusing the previous five-column layout. Page-level review controls, draft identity, retry and conflict handling remain unchanged; no backend/API changes.

Closes #265. Parent #241. Stacked on PR #264; merge that prerequisite first.

Validation:
- Build, lint, formatting and git diff checks passed (existing Vite bundle-size advisory remains).
- 64 focused scenario/review/accessibility/responsive browser tests passed.
- Final 10-test scenario suite covers synchronized pointer/keyboard resizing, resizing a filtered second group, reload persistence, cross-group draft saves, long headings and single-row groups.
- Inspected the live product page at desktop and 390px mobile width without submitting real review changes.

Design usage and backlog updated.
