### PR TITLE
Keep table right edge fixed while resizing columns

### DIFF
--- a/docs/github-issues-backlog.md
+++ b/docs/github-issues-backlog.md
@@ -1,5 +1,7 @@
 # GitHub Issue Backlog for Test Case Engine Improvements
 
+- Implemented, awaiting review: #267 — Fix the outer table edge and resize only internal boundaries by exchanging adjacent column widths. Builds on #265 / PR #266; parent #241.
+
 - Implemented, awaiting review: #265 — Group Use Cases under source requirement headings with synchronized four-column resizing. Builds on #263 / PR #264; parent #241.
 
 - Implemented, awaiting review: #263 — Remove scenario Details, use direct Quality flags dropdowns, and add shared resizable table columns. Builds on #261 / PR #262; parent #241.

--- a/docs/project-design.md
+++ b/docs/project-design.md
@@ -99,7 +99,7 @@ See [scenario review persistence](scenario-review-persistence.md) for the API an
 
 Use Cases uses shared `MultiSelect` and `ResizableTable` components. Quality flags have a uniform visible label and selected count; the accessible label retains scenario context. The checkbox popup uses the native popover top layer to avoid table-scroll clipping, and supports Escape/light dismissal and a Done action. Opening it does not expand the row. Titles/objectives no longer include nested Details.
 
-Drag a divider at the right edge of any column header. Keyboard Left/Right adjusts by 10px (Shift: 40px), Home/End applies limits, and Enter/double-click restores that column's default width. Width preferences persist locally (the current grouped-table key is documented below); unavailable storage does not block resizing. Minimum widths preserve usable controls, and wider tables scroll within their labeled container. Layout changes never submit or clear row reviews.
+Drag an internal divider between column headers; the final column has no outer resize handle. Adjacent columns exchange width while the table width stays fixed. Keyboard Left/Right adjusts by 10px (Shift: 40px), Home/End applies the neighboring columns’ limits, and Enter/double-click restores that column's default width. Width preferences persist locally (the current grouped-table key is documented below); unavailable storage does not block resizing. Minimum widths preserve usable controls, and wider tables scroll within their labeled container. Layout changes never submit or clear row reviews.
 
 ## Requirement-grouped tables (#265)
 
@@ -108,3 +108,5 @@ Use Cases displays each requirement ID, full text and visible use-case count onc
 `ResizableTable` supports controlled `widths` (pixel array or `null` for default proportions) and `onWidthsChange(nextWidths)`. A page owning multiple tables should call `useTableColumnWidths(columns, storageKey)` once and pass the returned state/setter to every table. Standalone tables may continue using `storageKey` for internal persistence. Pass `aria-labelledby` to name each table from its requirement heading. Group headings wrap outside each labeled horizontal scroll container.
 
 Use Cases stores the synchronized layout under `tcg.columns.use-cases-grouped-v1`; the previous five-column preference remains unused. Dragging or keyboard-resizing any group's header updates every visible table and groups restored by clearing filters. Review draft identity and persistence remain owned by the page.
+
+The fixed outer-edge behavior (#267) preserves both neighboring minimum widths during pointer and keyboard resizing. Quality flags can be resized only from its left divider; the table border is not an interactive separator.

--- a/frontend/e2e/scenario-review-table.spec.js
+++ b/frontend/e2e/scenario-review-table.spec.js
@@ -98,13 +98,19 @@ test("column dividers support pointer and keyboard resizing without losing draft
 	const divider = dividers.first();
 	const headers = page.getByRole("columnheader", { name: /^Title \/ objective/ });
 	const header = headers.first();
+	const table = page.getByRole("table", { name: "REQ-101", exact: true });
+	const tableWidth = (await table.boundingBox()).width;
+	await expect(table.getByRole("separator")).toHaveCount(3);
+	await expect(page.getByRole("separator", { name: "Resize Quality flags column", exact: true })).toHaveCount(0);
 	const before = (await header.boundingBox()).width;
+	const neighborWidth = (await table.getByRole("columnheader", { name: /^Review status/ }).boundingBox()).width;
 	const box = await divider.boundingBox();
 	await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
 	await page.mouse.down();
 	await page.mouse.move(box.x + box.width / 2 + 100, box.y + box.height / 2, { steps: 5 });
 	await page.mouse.up();
-	expect((await header.boundingBox()).width).toBeGreaterThan(before + 80);
+	expect((await header.boundingBox()).width).toBeCloseTo(before + Math.min(100, neighborWidth - 150), 0);
+	expect((await table.boundingBox()).width).toBeCloseTo(tableWidth, 0);
 	await divider.focus();
 	await page.keyboard.press("Home");
 	await expect(divider).toHaveAttribute("aria-valuenow", "200");
@@ -113,6 +119,7 @@ test("column dividers support pointer and keyboard resizing without losing draft
 	await expect(dividers.nth(1)).toHaveAttribute("aria-valuenow", "210");
 	expect((await headers.nth(1).boundingBox()).width).toBe((await header.boundingBox()).width);
 	await expect(status(page)).toHaveValue("approved");
+	expect((await table.boundingBox()).width).toBeCloseTo(tableWidth, 0);
 	const search = page.getByRole("searchbox", { name: "Search use cases", exact: true });
 	await search.fill("supervisor");
 	await expect(dividers).toHaveCount(1);
@@ -195,4 +202,34 @@ test("long requirement headings and single-row groups wrap without page overflow
 	await expect(page.getByText("1 use case", { exact: true })).toBeVisible();
 	await expect(page.getByRole("table", { name: "REQ-101", exact: true }).getByRole("columnheader")).toHaveCount(4);
 	expect(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth)).toBe(true);
+});
+
+test("last internal divider changes Quality flags from the left without moving the outer edge", async ({ page }) => {
+	await page.setViewportSize({ width: 1488, height: 900 });
+	await open(page);
+	const table = page.getByRole("table", { name: "REQ-101", exact: true });
+	const divider = table.getByRole("separator", { name: "Resize Review status column", exact: true });
+	const flags = table.getByRole("columnheader", { name: "Quality flags", exact: true });
+	const original = await table.boundingBox();
+	await divider.focus();
+	await page.keyboard.press("End");
+	expect((await flags.boundingBox()).width).toBeCloseTo(150, 0);
+	const resized = await table.boundingBox();
+	expect(resized.x + resized.width).toBeCloseTo(original.x + original.width, 0);
+	await page.keyboard.press("ArrowRight");
+	expect((await flags.boundingBox()).width).toBeCloseTo(150, 0);
+	await page.keyboard.press("Home");
+	await expect(divider).toHaveAttribute("aria-valuenow", "150");
+	expect((await table.boundingBox()).width).toBeCloseTo(original.width, 0);
+});
+
+test("older narrow saved widths still fill the table container", async ({ page }) => {
+	await page.setViewportSize({ width: 1488, height: 900 });
+	await page.addInitScript(() => localStorage.setItem("tcg.columns.use-cases-grouped-v1", JSON.stringify([144, 336, 160, 160])));
+	await open(page);
+	const table = page.getByRole("table", { name: "REQ-101", exact: true });
+	const region = page.getByRole("region", { name: "Use cases for REQ-101", exact: true });
+	const outer = await region.boundingBox();
+	const bounds = await table.boundingBox();
+	expect(Math.abs(outer.x + outer.width - bounds.x - bounds.width)).toBeLessThanOrEqual(2);
 });

--- a/frontend/src/components/ui/resizable-table.jsx
+++ b/frontend/src/components/ui/resizable-table.jsx
@@ -35,15 +35,22 @@ export function ResizableTable({ columns, storageKey, widths: controlledWidths, 
 		const observer = new ResizeObserver(() =>
 			setMeasured([...table.current.querySelectorAll("thead th")].map((cell) => cell.getBoundingClientRect().width))
 		);
-		observer.observe(table.current);
+		table.current.querySelectorAll("thead th").forEach((cell) => observer.observe(cell));
 		return () => observer.disconnect();
 	}, []);
 	const [localWidths, setLocalWidths] = useTableColumnWidths(columns, controlledWidths === undefined ? storageKey : undefined);
 	const widths = controlledWidths === undefined ? localWidths : controlledWidths;
 	const setWidths = onWidthsChange || setLocalWidths;
 	const actualWidths = () => [...table.current.querySelectorAll("thead th")].map((cell) => cell.getBoundingClientRect().width);
-	const resize = (index, width, baseline = widths || actualWidths()) =>
-		setWidths(baseline.map((value, i) => (i === index ? Math.round(Math.max(columns[i].min, Math.min(1200, width))) : value)));
+	const limits = (index, baseline) => {
+		const combined = baseline[index] + baseline[index + 1];
+		return { min: Math.max(columns[index].min, combined - 1200), max: Math.min(1200, combined - columns[index + 1].min) };
+	};
+	const resize = (index, width, baseline = actualWidths()) => {
+		const { min, max } = limits(index, baseline);
+		const next = Math.max(min, Math.min(max, Math.round(width)));
+		setWidths(baseline.map((value, i) => (i === index ? next : i === index + 1 ? value + baseline[index] - next : value)));
+	};
 	return (
 		<Table
 			{...props}
@@ -51,7 +58,7 @@ export function ResizableTable({ columns, storageKey, widths: controlledWidths, 
 			className={className}
 			style={{
 				tableLayout: "fixed",
-				minWidth: widths ? widths.reduce((sum, value) => sum + value, 0) : undefined,
+				minWidth: widths ? "100%" : undefined,
 				width: widths ? widths.reduce((sum, value) => sum + value, 0) : "100%",
 			}}
 		>
@@ -62,58 +69,65 @@ export function ResizableTable({ columns, storageKey, widths: controlledWidths, 
 			</colgroup>
 			<thead>
 				<tr>
-					{columns.map((column, i) => (
-						<th scope="col" key={column.label} className="ui-resizable-column">
-							{column.label}
-							<span
-								role="separator"
-								tabIndex={0}
-								aria-orientation="vertical"
-								aria-label={`Resize ${column.label} column`}
-								aria-valuemin={column.min}
-								aria-valuemax={1200}
-								aria-valuenow={Math.round(widths?.[i] || measured?.[i] || column.initial)}
-								className="ui-column-divider"
-								onPointerDown={(event) => {
-									if (event.button !== 0) return;
-									event.preventDefault();
-									event.currentTarget.focus();
-									event.currentTarget.setPointerCapture(event.pointerId);
-									drag.current = { start: event.clientX, widths: actualWidths() };
-								}}
-								onPointerMove={(event) => {
-									if (drag.current && event.currentTarget.hasPointerCapture(event.pointerId))
-										resize(i, drag.current.widths[i] + event.clientX - drag.current.start, drag.current.widths);
-								}}
-								onPointerUp={(event) => {
-									drag.current = null;
-									if (event.currentTarget.hasPointerCapture(event.pointerId)) event.currentTarget.releasePointerCapture(event.pointerId);
-								}}
-								onPointerCancel={() => {
-									drag.current = null;
-								}}
-								onLostPointerCapture={() => {
-									drag.current = null;
-								}}
-								onDoubleClick={() => resize(i, column.initial)}
-								onKeyDown={(event) => {
-									const current = widths || actualWidths();
-									const step = event.shiftKey ? 40 : 10;
-									const next = {
-										ArrowLeft: current[i] - step,
-										ArrowRight: current[i] + step,
-										Home: column.min,
-										End: 1200,
-										Enter: column.initial,
-									}[event.key];
-									if (next !== undefined) {
-										event.preventDefault();
-										resize(i, next, current);
-									}
-								}}
-							/>
-						</th>
-					))}
+					{columns.map((column, i) => {
+						const resizable = i < columns.length - 1;
+						const bounds = resizable ? limits(i, measured || widths || columns.map((item) => item.initial)) : null;
+						return (
+							<th scope="col" key={column.label} className={resizable ? "ui-resizable-column" : undefined}>
+								{column.label}
+								{resizable && (
+									<span
+										role="separator"
+										tabIndex={0}
+										aria-orientation="vertical"
+										aria-label={`Resize ${column.label} column`}
+										aria-valuemin={bounds.min}
+										aria-valuemax={bounds.max}
+										aria-valuenow={Math.round(measured?.[i] || widths?.[i] || column.initial)}
+										className="ui-column-divider"
+										onPointerDown={(event) => {
+											if (event.button !== 0) return;
+											event.preventDefault();
+											event.currentTarget.focus();
+											event.currentTarget.setPointerCapture(event.pointerId);
+											drag.current = { start: event.clientX, widths: actualWidths() };
+										}}
+										onPointerMove={(event) => {
+											if (drag.current && event.currentTarget.hasPointerCapture(event.pointerId))
+												resize(i, drag.current.widths[i] + event.clientX - drag.current.start, drag.current.widths);
+										}}
+										onPointerUp={(event) => {
+											drag.current = null;
+											if (event.currentTarget.hasPointerCapture(event.pointerId))
+												event.currentTarget.releasePointerCapture(event.pointerId);
+										}}
+										onPointerCancel={() => {
+											drag.current = null;
+										}}
+										onLostPointerCapture={() => {
+											drag.current = null;
+										}}
+										onDoubleClick={() => resize(i, column.initial)}
+										onKeyDown={(event) => {
+											const current = actualWidths();
+											const step = event.shiftKey ? 40 : 10;
+											const next = {
+												ArrowLeft: current[i] - step,
+												ArrowRight: current[i] + step,
+												Home: limits(i, current).min,
+												End: limits(i, current).max,
+												Enter: column.initial,
+											}[event.key];
+											if (next !== undefined) {
+												event.preventDefault();
+												resize(i, next, current);
+											}
+										}}
+									/>
+								)}
+							</th>
+						);
+					})}
 				</tr>
 			</thead>
 			{children}


### PR DESCRIPTION
The final Quality flags column no longer exposes a resize handle on the table's right border. Internal dividers exchange width between adjacent columns, keeping the outer edge fixed while enforcing usable minimums for both columns. Previously saved narrow layouts fill the table container instead of leaving a gap at the right.

Grouped widths remain synchronized and persisted. Pointer, keyboard and reset actions share the same limits; review drafts and backend contracts are unchanged.

Closes #267. Parent #241. Stacked on PR #266; merge prerequisite first.

Validation: build, lint, formatting and diff checks passed. All 12 scenario browser tests passed, including pointer/keyboard bounds, fixed right edge, saved widths, grouped persistence, review workflows and desktop/mobile accessibility. Verified the live page exposes only three internal dividers. Existing Vite bundle-size advisory remains.
