### PR TITLE
Add durable approved project and personal knowledge

### DIFF
--- a/backend/app/contracts/knowledge.py
+++ b/backend/app/contracts/knowledge.py
@@ -1,0 +1,50 @@
+"""Knowledge is a separately approved, versioned product input."""
+from typing import Literal
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+from .guidance import GuidanceStage
+
+
+class KnowledgeDraft(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    text: str = Field(min_length=1, max_length=1000)
+    stages: list[GuidanceStage] = Field(min_length=1, max_length=4)
+    kind: Literal["convention", "terminology", "business_fact"] = "convention"
+    requirement_ids: list[str] = Field(default_factory=list, max_length=30)
+
+    @field_validator("text")
+    @classmethod
+    def clean_text(cls, value):
+        import re
+        value = value.strip()
+        if not value:
+            raise ValueError("Guidance cannot be blank")
+        if re.search(r"(?i)(-----BEGIN .*PRIVATE KEY|Bearer\s+\S+|AIza[\w-]{20,}|(?:password|api[_ -]?key|secret|token)\s*[:=]\s*\S+)", value):
+            raise ValueError("Do not store credentials or secrets in knowledge")
+        return value.replace("\x00", "")
+
+
+class KnowledgeMutation(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    action: Literal["propose", "revise", "approve", "dismiss", "retire", "delete", "promote", "select", "unselect"]
+    entry_id: str | None = None
+    base_revision: int = Field(default=0, ge=0)
+    draft: KnowledgeDraft | None = None
+
+
+class KnowledgeEntry(BaseModel):
+    id: str
+    scope: Literal["project", "personal"]
+    project_id: str | None = None
+    revision: int
+    status: str
+    active: dict | None = None
+    pending: dict | None = None
+    selected: bool = False
+    selected_by_projects: list[str] = Field(default_factory=list)
+
+
+class KnowledgeCollection(BaseModel):
+    entries: list[KnowledgeEntry] = Field(default_factory=list)
+    revision: str = ""
+    skills: list[dict] = Field(default_factory=list)
+    features: dict = Field(default_factory=dict)

--- a/backend/app/contracts/knowledge.py
+++ b/backend/app/contracts/knowledge.py
@@ -1,4 +1,5 @@
 """Knowledge is a separately approved, versioned product input."""
+
 from typing import Literal
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 from .guidance import GuidanceStage
@@ -15,6 +16,7 @@ class KnowledgeDraft(BaseModel):
     @classmethod
     def clean_text(cls, value):
         import re
+
         value = value.strip()
         if not value:
             raise ValueError("Guidance cannot be blank")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -10,6 +10,7 @@ from .observability.logging import bind_log_context, configure_logging, reset_lo
 from .observability.metrics import record_http_request, render_prometheus_metrics
 from .observability.tracing import configure_tracing, resolve_trace_id
 
+from .routers.knowledge import router as knowledge_router
 from .routers.auth import router as auth_router
 from .routers.automation import router as automation_router
 from .routers.billing import router as billing_router
@@ -39,6 +40,7 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+app.include_router(knowledge_router)
 app.include_router(auth_router)
 app.include_router(billing_router)
 app.include_router(reports_router)

--- a/backend/app/routers/knowledge.py
+++ b/backend/app/routers/knowledge.py
@@ -1,0 +1,56 @@
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.concurrency import run_in_threadpool
+from ..auth.jwt_auth import get_current_user
+from ..contracts.knowledge import KnowledgeCollection, KnowledgeEntry, KnowledgeMutation
+from ..models import AuthUser
+from ..services.guidance_service import skill_catalog
+from ..services.knowledge_service import list_knowledge, mutate_knowledge
+
+router = APIRouter()
+
+
+async def guarded(function, *args, **kwargs):
+    try:
+        return await run_in_threadpool(function, *args, **kwargs)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        raise HTTPException(503, "Knowledge is unavailable. Retry; no changes were confirmed.") from exc
+
+
+@router.get("/skills")
+async def skills(actor: AuthUser = Depends(get_current_user)):
+    return await guarded(skill_catalog)
+
+
+@router.get("/projects/{project_id}/knowledge", response_model=KnowledgeCollection)
+async def project_knowledge(project_id: str, actor: AuthUser = Depends(get_current_user)):
+    return await guarded(list_knowledge, actor, project_id)
+
+
+@router.get("/me/knowledge", response_model=KnowledgeCollection)
+async def personal_knowledge(actor: AuthUser = Depends(get_current_user)):
+    return await guarded(list_knowledge, actor)
+
+
+async def mutate(request, actor, project_id, payload):
+    request_id = request.headers.get("X-Request-ID")
+    if not request_id or len(request_id) > 160:
+        raise HTTPException(422, "A bounded X-Request-ID is required for knowledge mutations")
+    return await guarded(mutate_knowledge, actor, project_id, payload, request_id)
+
+
+@router.post("/projects/{project_id}/knowledge", response_model=KnowledgeEntry)
+async def change_project_knowledge(project_id: str, payload: KnowledgeMutation, request: Request, actor: AuthUser = Depends(get_current_user)):
+    return await mutate(request, actor, project_id, payload)
+
+
+@router.post("/me/knowledge", response_model=KnowledgeEntry)
+async def change_personal_knowledge(payload: KnowledgeMutation, request: Request, actor: AuthUser = Depends(get_current_user)):
+    return await mutate(request, actor, None, payload)
+
+
+@router.get("/projects/{project_id}/knowledge/{entry_id}/versions/{revision}")
+async def read_knowledge_version(project_id: str, entry_id: str, revision: int, actor: AuthUser = Depends(get_current_user)):
+    from ..services.knowledge_service import knowledge_version
+    return await guarded(knowledge_version, actor, project_id, entry_id, revision)

--- a/backend/app/routers/knowledge.py
+++ b/backend/app/routers/knowledge.py
@@ -53,4 +53,5 @@ async def change_personal_knowledge(payload: KnowledgeMutation, request: Request
 @router.get("/projects/{project_id}/knowledge/{entry_id}/versions/{revision}")
 async def read_knowledge_version(project_id: str, entry_id: str, revision: int, actor: AuthUser = Depends(get_current_user)):
     from ..services.knowledge_service import knowledge_version
+
     return await guarded(knowledge_version, actor, project_id, entry_id, revision)

--- a/backend/app/services/knowledge_memory.py
+++ b/backend/app/services/knowledge_memory.py
@@ -1,0 +1,19 @@
+"""Read-only ADK adapter, bound to an authenticated owner's frozen run manifest."""
+from google.adk.memory.base_memory_service import BaseMemoryService, SearchMemoryResponse
+from google.adk.memory.memory_entry import MemoryEntry
+from google.genai import types
+
+
+class ApprovedKnowledgeMemory(BaseMemoryService):
+    def __init__(self, owner_id, manifest):
+        self.owner_id, self.manifest = owner_id, manifest
+
+    async def add_session_to_memory(self, session):
+        raise PermissionError("Sessions cannot approve or ingest knowledge; use the review API")
+
+    async def search_memory(self, *, app_name, user_id, query):
+        if user_id != self.owner_id:
+            raise PermissionError("Memory owner does not match this run")
+        # Retrieval was already scoped and frozen before any worker started.
+        return SearchMemoryResponse(memories=[MemoryEntry(author="approved_knowledge", content=types.Content(
+            role="user", parts=[types.Part(text=item.text)])) for item in self.manifest.memories])

--- a/backend/app/services/knowledge_memory.py
+++ b/backend/app/services/knowledge_memory.py
@@ -1,4 +1,5 @@
 """Read-only ADK adapter, bound to an authenticated owner's frozen run manifest."""
+
 from google.adk.memory.base_memory_service import BaseMemoryService, SearchMemoryResponse
 from google.adk.memory.memory_entry import MemoryEntry
 from google.genai import types
@@ -15,5 +16,9 @@ class ApprovedKnowledgeMemory(BaseMemoryService):
         if user_id != self.owner_id:
             raise PermissionError("Memory owner does not match this run")
         # Retrieval was already scoped and frozen before any worker started.
-        return SearchMemoryResponse(memories=[MemoryEntry(author="approved_knowledge", content=types.Content(
-            role="user", parts=[types.Part(text=item.text)])) for item in self.manifest.memories])
+        return SearchMemoryResponse(
+            memories=[
+                MemoryEntry(author="approved_knowledge", content=types.Content(role="user", parts=[types.Part(text=item.text)]))
+                for item in self.manifest.memories
+            ]
+        )

--- a/backend/app/services/knowledge_repository.py
+++ b/backend/app/services/knowledge_repository.py
@@ -1,0 +1,53 @@
+"""Firestore boundary: a bounded owner document serializes knowledge changes.
+
+Receipts contain identifiers only, so deleting an entry cannot leave its text
+in an idempotency response cache. The owner document is capped below Firestore's
+size limit; future adapters may split records without changing the service.
+"""
+from copy import deepcopy
+from hashlib import sha256
+import json
+from google.cloud.firestore_v1 import transactional
+from fastapi import HTTPException
+from .firestore_repository import get_required_firestore_client
+
+
+def empty_state():
+    return {"revision": 0, "entries": {}, "selections": {}}
+
+
+class FirestoreKnowledgeRepository:
+    def __init__(self):
+        self.client = get_required_firestore_client(unavailable_message="Knowledge storage is unavailable")
+
+    def document(self, owner):
+        return self.client.collection("agent_knowledge").document(sha256(owner.encode()).hexdigest())
+
+    def read(self, owner):
+        return self.document(owner).get().to_dict() or empty_state()
+
+    def mutate(self, owner, request_id, fingerprint, apply, project_id=None):
+        doc = self.document(owner)
+        receipt = doc.collection("requests").document(sha256(request_id.encode()).hexdigest())
+        @transactional
+        def run(transaction):
+            # Check project ownership within the same transaction as the write.
+            if project_id:
+                project = self.client.collection("qa_projects").document(project_id).get(transaction=transaction).to_dict()
+                if not project or project.get("owner_user_id") != owner:
+                    raise HTTPException(404, "Project not found")
+            saved = receipt.get(transaction=transaction).to_dict()
+            state = doc.get(transaction=transaction).to_dict() or empty_state()
+            if saved:
+                if saved["fingerprint"] != fingerprint:
+                    raise HTTPException(409, "Request ID already used for different knowledge changes")
+                return state, saved["entry_id"]
+            updated = deepcopy(state)
+            entry_id = apply(updated)
+            updated["revision"] += 1
+            if len(json.dumps(updated).encode()) > 750_000:
+                raise HTTPException(422, "Knowledge storage limit reached; delete unused entries before adding more")
+            transaction.set(doc, updated)
+            transaction.set(receipt, {"fingerprint": fingerprint, "entry_id": entry_id})
+            return updated, entry_id
+        return run(self.client.transaction())

--- a/backend/app/services/knowledge_repository.py
+++ b/backend/app/services/knowledge_repository.py
@@ -4,6 +4,7 @@ Receipts contain identifiers only, so deleting an entry cannot leave its text
 in an idempotency response cache. The owner document is capped below Firestore's
 size limit; future adapters may split records without changing the service.
 """
+
 from copy import deepcopy
 from hashlib import sha256
 import json
@@ -29,6 +30,7 @@ class FirestoreKnowledgeRepository:
     def mutate(self, owner, request_id, fingerprint, apply, project_id=None):
         doc = self.document(owner)
         receipt = doc.collection("requests").document(sha256(request_id.encode()).hexdigest())
+
         @transactional
         def run(transaction):
             # Check project ownership within the same transaction as the write.
@@ -50,4 +52,5 @@ class FirestoreKnowledgeRepository:
             transaction.set(doc, updated)
             transaction.set(receipt, {"fingerprint": fingerprint, "entry_id": entry_id})
             return updated, entry_id
+
         return run(self.client.transaction())

--- a/backend/app/services/knowledge_service.py
+++ b/backend/app/services/knowledge_service.py
@@ -1,0 +1,201 @@
+from copy import deepcopy
+from datetime import datetime, timezone
+from hashlib import sha256
+import json
+
+from fastapi import HTTPException
+from ..contracts.knowledge import KnowledgeMutation, KnowledgeDraft, KnowledgeEntry, KnowledgeCollection
+from ..contracts.guidance import MemoryGuidance, OmittedGuidance
+from .knowledge_repository import FirestoreKnowledgeRepository
+from .guidance_service import STAGES, enabled, skill_catalog
+from .workflow_project_service import get_project, project_error_to_http
+
+
+def repository():
+    return FirestoreKnowledgeRepository()
+
+
+def project_for(project_id, actor):
+    if not project_id:
+        return None
+    try:
+        return get_project(project_id, actor)
+    except Exception as exc:
+        raise project_error_to_http(exc) from exc
+
+
+def requirement_hashes(project):
+    if project is None:
+        return {}
+    snapshot = project.current_snapshots.get("requirements")
+    rows = snapshot.payload.get("requirements", []) if snapshot else []
+    return {str(r.get("id")): sha256(json.dumps(r.get("text", ""), sort_keys=True).encode()).hexdigest() for r in rows}
+
+
+def version(entry, number):
+    return next((v for v in entry.get("versions", []) if v["revision"] == number), None)
+
+
+def current_version(entry):
+    return version(entry, entry.get("active_revision"))
+
+
+def needs_confirmation(value, hashes):
+    return bool(value and any(hashes.get(key) != old for key, old in value.get("requirement_hashes", {}).items()))
+
+
+def public_entry(entry, state, project_id=None, hashes=None):
+    active = current_version(entry)
+    status = entry["status"]
+    if status == "active" and needs_confirmation(active, hashes or {}):
+        status = "needs_confirmation"
+    return KnowledgeEntry(id=entry["id"], project_id=entry.get("project_id"), scope="project" if entry.get("project_id") else "personal",
+        revision=entry["revision"], status=status, active=active, pending=version(entry, entry.get("pending_revision")),
+        selected=entry["id"] in state["selections"].get(project_id, []),
+        selected_by_projects=[p for p, ids in state["selections"].items() if entry["id"] in ids])
+
+
+def knowledge_signature(entries):
+    canonical = [(e.id, e.status, e.active and e.active["revision"], e.selected) for e in entries]
+    return sha256(json.dumps(canonical, sort_keys=True).encode()).hexdigest()
+
+
+def list_knowledge(actor, project_id=None):
+    project = project_for(project_id, actor)
+    state = repository().read(actor.sub)
+    selected = state["selections"].get(project_id, [])
+    entries = [public_entry(e, state, project_id, requirement_hashes(project)) for e in state["entries"].values()
+               if (e.get("project_id") == project_id or (project_id and e["id"] in selected and not e.get("project_id"))) and e["status"] != "deleted"]
+    entries.sort(key=lambda e: e.id)
+    return KnowledgeCollection(entries=entries, revision=knowledge_signature(entries), skills=skill_catalog(),
+        features={s: {"skills": enabled("skills", s), "memory": enabled("memory", s)} for s in STAGES})
+
+
+def mutate_knowledge(actor, project_id, mutation: KnowledgeMutation, request_id: str, *, source="Manual guidance"):
+    project = project_for(project_id, actor)
+    hashes = requirement_hashes(project)
+    values = mutation.model_dump()
+    fingerprint = sha256(json.dumps([project_id, values, source], sort_keys=True).encode()).hexdigest()
+    generated_id = "knowledge_" + sha256(f"{actor.sub}:{project_id}:{request_id}".encode()).hexdigest()[:24]
+    now = datetime.now(timezone.utc).isoformat()
+
+    def content(draft, revision, source_text):
+        if draft is None:
+            raise HTTPException(422, "Guidance text and stages are required")
+        data = draft.model_dump()
+        data["stages"] = sorted(set(data["stages"]))
+        data["requirement_ids"] = sorted(set(data["requirement_ids"]))
+        if not project_id and (data["kind"] == "business_fact" or data["requirement_ids"]):
+            raise HTTPException(422, "Project-specific facts cannot enter the personal library")
+        if data["kind"] == "business_fact" and not data["requirement_ids"]:
+            raise HTTPException(422, "Link business facts to their source requirements")
+        missing = set(data["requirement_ids"]) - hashes.keys()
+        if missing:
+            raise HTTPException(422, "Linked requirements must exist in the current project")
+        return {**data, "revision": revision, "source": source_text, "created_at": now,
+                "requirement_hashes": {r: hashes[r] for r in data["requirement_ids"]}}
+
+    def apply(state):
+        action, entry_id = mutation.action, mutation.entry_id
+        entries = state["entries"]
+        if action == "propose":
+            if len([e for e in entries.values() if e["status"] != "deleted"]) >= 200:
+                raise HTTPException(422, "Knowledge entry limit reached")
+            entries[generated_id] = {"id": generated_id, "project_id": project_id, "revision": 1, "status": "suggested",
+                "active_revision": None, "pending_revision": 1, "versions": [content(mutation.draft, 1, source)]}
+            return generated_id
+        entry = entries.get(entry_id)
+        if not entry or entry["status"] == "deleted":
+            raise HTTPException(404, "Knowledge entry not found")
+        if action in ("select", "unselect"):
+            if not project_id or entry.get("project_id"):
+                raise HTTPException(422, "Only personal entries can be selected for a project")
+        elif entry.get("project_id") != project_id:
+            raise HTTPException(404, "Knowledge entry not found in this scope")
+        if mutation.base_revision != entry["revision"]:
+            raise HTTPException(409, "Knowledge changed; reload before saving")
+        if action in ("select", "unselect"):
+            if action == "select" and entry["status"] != "active":
+                raise HTTPException(422, "Approve personal guidance before selecting it")
+            ids = set(state["selections"].get(project_id, []))
+            if action == "select": ids.add(entry_id)
+            else: ids.discard(entry_id)
+            state["selections"][project_id] = sorted(ids)
+            return entry_id
+        next_revision = entry["revision"] + 1
+        if action == "revise":
+            entry["versions"].append(content(mutation.draft, next_revision, source))
+            entry["pending_revision"] = next_revision
+            if not entry["active_revision"]: entry["status"] = "suggested"
+        elif action == "approve":
+            pending = version(entry, entry.get("pending_revision"))
+            if pending is None:
+                # Re-confirming changed linked requirements creates a new version.
+                old = current_version(entry)
+                if not old or not needs_confirmation(old, hashes):
+                    raise HTTPException(422, "No proposed revision to approve")
+                pending = content(KnowledgeDraft(**{k: old[k] for k in ("text", "stages", "kind", "requirement_ids")}), next_revision, old["source"])
+                entry["versions"].append(pending)
+            if needs_confirmation(pending, hashes):
+                raise HTTPException(409, "Source requirements changed; edit the proposal before approving")
+            pending.update(approved_at=now, approved_by=actor.sub)
+            entry.update(status="active", active_revision=pending["revision"], pending_revision=None)
+        elif action == "dismiss":
+            entry["pending_revision"] = None
+            entry["status"] = "active" if entry["active_revision"] else "dismissed"
+        elif action == "retire":
+            entry.update(status="retired", active_revision=None, pending_revision=None)
+        elif action == "delete":
+            entry.update(status="deleted", active_revision=None, pending_revision=None, versions=[])
+            for ids in state["selections"].values():
+                if entry_id in ids: ids.remove(entry_id)
+        elif action == "promote":
+            original = current_version(entry)
+            if not project_id or entry["status"] != "active" or original is None:
+                raise HTTPException(422, "Only active project guidance can be promoted")
+            if mutation.draft is None or mutation.draft.kind == "business_fact" or mutation.draft.requirement_ids:
+                raise HTTPException(422, "Review generalized wording without project-specific facts or requirement links")
+            if original["kind"] == "business_fact":
+                raise HTTPException(422, "Business facts must remain project-scoped")
+            promoted = content(mutation.draft, 1, f"Promoted from {entry_id}")
+            entries[generated_id] = {"id": generated_id, "project_id": None, "revision": 1, "status": "suggested",
+                "active_revision": None, "pending_revision": 1, "versions": [promoted]}
+            return generated_id
+        entry["revision"] = next_revision
+        return entry_id
+
+    state, entry_id = repository().mutate(actor.sub, request_id, fingerprint, apply, project_id)
+    entry = state["entries"].get(entry_id)
+    return public_entry(entry, state, project_id, hashes)
+
+
+def resolve_memories(actor, project_id, stage, requirement_ids=None):
+    collection = list_knowledge(actor, project_id)
+    selected, omitted = [], []
+    requested = set(requirement_ids or ())
+    for entry in collection.entries:
+        value = entry.active
+        reason = None
+        if entry.status != "active" or value is None: reason = entry.status
+        elif stage not in value["stages"]: reason = "different_stage"
+        elif value["requirement_ids"] and not requested.intersection(value["requirement_ids"]): reason = "different_requirement"
+        if reason:
+            omitted.append(OmittedGuidance(id=entry.id, revision=entry.revision, reason=reason))
+        else:
+            selected.append(MemoryGuidance(id=entry.id, revision=value["revision"], scope=entry.scope,
+                text=value["text"], source=value["source"], requirement_ids=tuple(value["requirement_ids"]),
+                reason="linked_requirement" if value["requirement_ids"] else "selected_personal" if entry.scope == "personal" else "project_stage"))
+    selected.sort(key=lambda e: (e.scope != "project", not bool(e.requirement_ids), e.id))
+    return selected, omitted, collection.revision
+
+
+def knowledge_version(actor, project_id, entry_id, revision):
+    project_for(project_id, actor)
+    state = repository().read(actor.sub)
+    entry = state["entries"].get(entry_id)
+    if not entry or entry.get("project_id") not in (None, project_id):
+        raise HTTPException(404, "Knowledge version unavailable")
+    value = version(entry, revision)
+    if value is None or entry["status"] == "deleted":
+        return {"id": entry_id, "revision": revision, "unavailable": True}
+    return {"id": entry_id, **value}

--- a/backend/app/services/knowledge_service.py
+++ b/backend/app/services/knowledge_service.py
@@ -19,7 +19,9 @@ def project_for(project_id, actor):
     if not project_id:
         return None
     try:
-        return get_project(project_id, actor)
+        return get_project(project_id, actor=actor)
+    except HTTPException:
+        raise
     except Exception as exc:
         raise project_error_to_http(exc) from exc
 
@@ -49,10 +51,17 @@ def public_entry(entry, state, project_id=None, hashes=None):
     status = entry["status"]
     if status == "active" and needs_confirmation(active, hashes or {}):
         status = "needs_confirmation"
-    return KnowledgeEntry(id=entry["id"], project_id=entry.get("project_id"), scope="project" if entry.get("project_id") else "personal",
-        revision=entry["revision"], status=status, active=active, pending=version(entry, entry.get("pending_revision")),
+    return KnowledgeEntry(
+        id=entry["id"],
+        project_id=entry.get("project_id"),
+        scope="project" if entry.get("project_id") else "personal",
+        revision=entry["revision"],
+        status=status,
+        active=active,
+        pending=version(entry, entry.get("pending_revision")),
         selected=entry["id"] in state["selections"].get(project_id, []),
-        selected_by_projects=[p for p, ids in state["selections"].items() if entry["id"] in ids])
+        selected_by_projects=[p for p, ids in state["selections"].items() if entry["id"] in ids],
+    )
 
 
 def knowledge_signature(entries):
@@ -64,11 +73,18 @@ def list_knowledge(actor, project_id=None):
     project = project_for(project_id, actor)
     state = repository().read(actor.sub)
     selected = state["selections"].get(project_id, [])
-    entries = [public_entry(e, state, project_id, requirement_hashes(project)) for e in state["entries"].values()
-               if (e.get("project_id") == project_id or (project_id and e["id"] in selected and not e.get("project_id"))) and e["status"] != "deleted"]
+    entries = [
+        public_entry(e, state, project_id, requirement_hashes(project))
+        for e in state["entries"].values()
+        if (e.get("project_id") == project_id or (project_id and e["id"] in selected and not e.get("project_id"))) and e["status"] != "deleted"
+    ]
     entries.sort(key=lambda e: e.id)
-    return KnowledgeCollection(entries=entries, revision=knowledge_signature(entries), skills=skill_catalog(),
-        features={s: {"skills": enabled("skills", s), "memory": enabled("memory", s)} for s in STAGES})
+    return KnowledgeCollection(
+        entries=entries,
+        revision=knowledge_signature(entries),
+        skills=skill_catalog(),
+        features={s: {"skills": enabled("skills", s), "memory": enabled("memory", s)} for s in STAGES},
+    )
 
 
 def mutate_knowledge(actor, project_id, mutation: KnowledgeMutation, request_id: str, *, source="Manual guidance"):
@@ -92,8 +108,7 @@ def mutate_knowledge(actor, project_id, mutation: KnowledgeMutation, request_id:
         missing = set(data["requirement_ids"]) - hashes.keys()
         if missing:
             raise HTTPException(422, "Linked requirements must exist in the current project")
-        return {**data, "revision": revision, "source": source_text, "created_at": now,
-                "requirement_hashes": {r: hashes[r] for r in data["requirement_ids"]}}
+        return {**data, "revision": revision, "source": source_text, "created_at": now, "requirement_hashes": {r: hashes[r] for r in data["requirement_ids"]}}
 
     def apply(state):
         action, entry_id = mutation.action, mutation.entry_id
@@ -101,8 +116,15 @@ def mutate_knowledge(actor, project_id, mutation: KnowledgeMutation, request_id:
         if action == "propose":
             if len([e for e in entries.values() if e["status"] != "deleted"]) >= 200:
                 raise HTTPException(422, "Knowledge entry limit reached")
-            entries[generated_id] = {"id": generated_id, "project_id": project_id, "revision": 1, "status": "suggested",
-                "active_revision": None, "pending_revision": 1, "versions": [content(mutation.draft, 1, source)]}
+            entries[generated_id] = {
+                "id": generated_id,
+                "project_id": project_id,
+                "revision": 1,
+                "status": "suggested",
+                "active_revision": None,
+                "pending_revision": 1,
+                "versions": [content(mutation.draft, 1, source)],
+            }
             return generated_id
         entry = entries.get(entry_id)
         if not entry or entry["status"] == "deleted":
@@ -118,15 +140,18 @@ def mutate_knowledge(actor, project_id, mutation: KnowledgeMutation, request_id:
             if action == "select" and entry["status"] != "active":
                 raise HTTPException(422, "Approve personal guidance before selecting it")
             ids = set(state["selections"].get(project_id, []))
-            if action == "select": ids.add(entry_id)
-            else: ids.discard(entry_id)
+            if action == "select":
+                ids.add(entry_id)
+            else:
+                ids.discard(entry_id)
             state["selections"][project_id] = sorted(ids)
             return entry_id
         next_revision = entry["revision"] + 1
         if action == "revise":
             entry["versions"].append(content(mutation.draft, next_revision, source))
             entry["pending_revision"] = next_revision
-            if not entry["active_revision"]: entry["status"] = "suggested"
+            if not entry["active_revision"]:
+                entry["status"] = "suggested"
         elif action == "approve":
             pending = version(entry, entry.get("pending_revision"))
             if pending is None:
@@ -148,7 +173,8 @@ def mutate_knowledge(actor, project_id, mutation: KnowledgeMutation, request_id:
         elif action == "delete":
             entry.update(status="deleted", active_revision=None, pending_revision=None, versions=[])
             for ids in state["selections"].values():
-                if entry_id in ids: ids.remove(entry_id)
+                if entry_id in ids:
+                    ids.remove(entry_id)
         elif action == "promote":
             original = current_version(entry)
             if not project_id or entry["status"] != "active" or original is None:
@@ -158,8 +184,15 @@ def mutate_knowledge(actor, project_id, mutation: KnowledgeMutation, request_id:
             if original["kind"] == "business_fact":
                 raise HTTPException(422, "Business facts must remain project-scoped")
             promoted = content(mutation.draft, 1, f"Promoted from {entry_id}")
-            entries[generated_id] = {"id": generated_id, "project_id": None, "revision": 1, "status": "suggested",
-                "active_revision": None, "pending_revision": 1, "versions": [promoted]}
+            entries[generated_id] = {
+                "id": generated_id,
+                "project_id": None,
+                "revision": 1,
+                "status": "suggested",
+                "active_revision": None,
+                "pending_revision": 1,
+                "versions": [promoted],
+            }
             return generated_id
         entry["revision"] = next_revision
         return entry_id
@@ -176,15 +209,26 @@ def resolve_memories(actor, project_id, stage, requirement_ids=None):
     for entry in collection.entries:
         value = entry.active
         reason = None
-        if entry.status != "active" or value is None: reason = entry.status
-        elif stage not in value["stages"]: reason = "different_stage"
-        elif value["requirement_ids"] and not requested.intersection(value["requirement_ids"]): reason = "different_requirement"
+        if entry.status != "active" or value is None:
+            reason = entry.status
+        elif stage not in value["stages"]:
+            reason = "different_stage"
+        elif value["requirement_ids"] and not requested.intersection(value["requirement_ids"]):
+            reason = "different_requirement"
         if reason:
             omitted.append(OmittedGuidance(id=entry.id, revision=entry.revision, reason=reason))
         else:
-            selected.append(MemoryGuidance(id=entry.id, revision=value["revision"], scope=entry.scope,
-                text=value["text"], source=value["source"], requirement_ids=tuple(value["requirement_ids"]),
-                reason="linked_requirement" if value["requirement_ids"] else "selected_personal" if entry.scope == "personal" else "project_stage"))
+            selected.append(
+                MemoryGuidance(
+                    id=entry.id,
+                    revision=value["revision"],
+                    scope=entry.scope,
+                    text=value["text"],
+                    source=value["source"],
+                    requirement_ids=tuple(value["requirement_ids"]),
+                    reason="linked_requirement" if value["requirement_ids"] else "selected_personal" if entry.scope == "personal" else "project_stage",
+                )
+            )
     selected.sort(key=lambda e: (e.scope != "project", not bool(e.requirement_ids), e.id))
     return selected, omitted, collection.revision
 

--- a/backend/tests/test_knowledge_service.py
+++ b/backend/tests/test_knowledge_service.py
@@ -1,0 +1,117 @@
+from copy import deepcopy
+from pathlib import Path
+from types import SimpleNamespace
+import sys
+import unittest
+from unittest.mock import patch
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+from app.main import app, get_current_user
+from app.models import AuthUser
+from app.contracts.knowledge import KnowledgeMutation
+from app.services.knowledge_repository import empty_state
+from app.services import knowledge_service as service
+
+class MemoryRepository:
+    def __init__(self): self.states, self.receipts = {}, {}
+    def read(self, owner): return deepcopy(self.states.get(owner, empty_state()))
+    def mutate(self, owner, key, fingerprint, apply, project_id=None):
+        existing = self.receipts.get((owner,key))
+        if existing:
+            if existing[0] != fingerprint: raise HTTPException(409,'Different request')
+            return self.read(owner), existing[1]
+        state = self.read(owner)
+        result = apply(state)
+        state['revision'] += 1
+        self.states[owner] = deepcopy(state)
+        self.receipts[(owner,key)] = fingerprint, result
+        return state, result
+
+class KnowledgeTests(unittest.TestCase):
+    def setUp(self):
+        self.actor = AuthUser(sub='owner', name='Owner', email='owner@example.com')
+        self.repo = MemoryRepository()
+        self.counter = 0
+        self.project = SimpleNamespace(current_snapshots={'requirements':SimpleNamespace(payload={'requirements':[{'id':'R1','text':'Original rule'}]})})
+        self.patches=[patch.object(service,'repository',return_value=self.repo),patch.object(service,'project_for',side_effect=lambda p,a: self.project if p else None)]
+        for item in self.patches: item.start()
+        self.addCleanup(lambda: [p.stop() for p in self.patches])
+    def mutate(self, action, entry=None, project='p1', draft=None, key=None):
+        self.counter += 1
+        return service.mutate_knowledge(self.actor, project, KnowledgeMutation(action=action,entry_id=entry.id if entry else None,
+            base_revision=entry.revision if entry else 0,draft=draft), key or str(self.counter))
+    def draft(self, **kwargs):
+        return {'text':'Include boundary values','stages':['use_cases'],**kwargs}
+    def test_approval_revisions_preserve_old_active_until_approved(self):
+        entry=self.mutate('propose',draft=self.draft())
+        self.assertIsNone(entry.active)
+        self.assertEqual(service.resolve_memories(self.actor,'p1','use_cases')[0],[])
+        entry=self.mutate('approve',entry)
+        updated=self.mutate('revise',entry,draft=self.draft(text='Include both boundaries'))
+        self.assertEqual(updated.active['text'],'Include boundary values')
+        self.assertEqual(updated.pending['text'],'Include both boundaries')
+        with self.assertRaises(HTTPException) as error: self.mutate('retire',entry)
+        self.assertEqual(error.exception.status_code,409)
+        updated=self.mutate('approve',updated)
+        self.assertEqual(updated.active['text'],'Include both boundaries')
+    def test_selection_is_explicit_and_scoped_and_retirement_is_global(self):
+        entry=self.mutate('propose',project=None,draft=self.draft())
+        entry=self.mutate('approve',entry,project=None)
+        self.assertEqual(service.resolve_memories(self.actor,'p1','use_cases')[0],[])
+        self.mutate('select',entry)
+        self.assertEqual(len(service.resolve_memories(self.actor,'p1','use_cases')[0]),1)
+        self.assertEqual(service.resolve_memories(self.actor,'p2','use_cases')[0],[])
+        self.mutate('retire',entry,project=None)
+        self.assertEqual(service.resolve_memories(self.actor,'p1','use_cases')[0],[])
+    def test_requirement_changes_exclude_knowledge(self):
+        entry=self.mutate('propose',draft=self.draft(requirement_ids=['R1']))
+        entry=self.mutate('approve',entry)
+        self.assertEqual(len(service.resolve_memories(self.actor,'p1','use_cases',['R1'])[0]),1)
+        self.project.current_snapshots['requirements'].payload['requirements'][0]['text']='Changed rule'
+        self.assertEqual(service.list_knowledge(self.actor,'p1').entries[0].status,'needs_confirmation')
+        self.assertEqual(service.resolve_memories(self.actor,'p1','use_cases',['R1'])[0],[])
+        entry=self.mutate('approve',entry)
+        self.assertEqual(entry.status,'active')
+    def test_request_idempotency_and_owner_isolation(self):
+        a=self.mutate('propose',draft=self.draft(),key='same')
+        b=self.mutate('propose',draft=self.draft(),key='same')
+        self.assertEqual(a,b)
+        with self.assertRaises(HTTPException): self.mutate('propose',draft=self.draft(text='different'),key='same')
+        other=AuthUser(sub='other',name='Other',email='other@example.com')
+        self.assertEqual(service.list_knowledge(other,'p1').entries,[])
+        with self.assertRaises(HTTPException): self.mutate('retire',a,project='p2')
+    def test_promotion_requires_generalization_and_separate_approval(self):
+        entry=self.mutate('propose',draft=self.draft())
+        entry=self.mutate('approve',entry)
+        promoted=self.mutate('promote',entry,draft=self.draft())
+        self.assertEqual(promoted.scope,'personal')
+        self.assertIsNone(promoted.active)
+        with self.assertRaises(HTTPException): self.mutate('promote',entry,draft=self.draft(kind='business_fact'))
+    def test_delete_purges_versions_and_selections(self):
+        entry=self.mutate('propose',project=None,draft=self.draft())
+        entry=self.mutate('approve',entry,project=None)
+        self.mutate('select',entry)
+        self.mutate('delete',entry,project=None)
+        state=self.repo.read(self.actor.sub)
+        self.assertEqual(state['entries'][entry.id]['versions'],[])
+        self.assertEqual(state['selections']['p1'],[])
+    def test_secrets_rejected(self):
+        with self.assertRaises(ValueError): KnowledgeMutation(action='propose',draft=self.draft(text='password=secret123'))
+    def test_api_requires_idempotency_key(self):
+        app.dependency_overrides[get_current_user]=lambda:self.actor
+        try:
+            with TestClient(app) as client:
+                self.assertEqual(client.post('/me/knowledge',json={'action':'propose','draft':self.draft()}).status_code,422)
+                response=client.post('/me/knowledge',json={'action':'propose','draft':self.draft()},headers={'X-Request-ID':'api'})
+                self.assertEqual(response.status_code,200,response.text)
+        finally: app.dependency_overrides.clear()
+
+class MemoryAdapterTests(unittest.IsolatedAsyncioTestCase):
+    async def test_read_only_owner_bound_snapshot(self):
+        from app.services.knowledge_memory import ApprovedKnowledgeMemory
+        from app.services.guidance_service import build_manifest
+        adapter=ApprovedKnowledgeMemory('owner',build_manifest('use_cases','test'))
+        with self.assertRaises(PermissionError): await adapter.add_session_to_memory(None)
+        with self.assertRaises(PermissionError): await adapter.search_memory(app_name='app',user_id='other',query='all')
+        self.assertEqual((await adapter.search_memory(app_name='app',user_id='owner',query='all')).memories,[])

--- a/backend/tests/test_knowledge_service.py
+++ b/backend/tests/test_knowledge_service.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 import sys
 import unittest
 from unittest.mock import patch
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
@@ -13,105 +14,155 @@ from app.contracts.knowledge import KnowledgeMutation
 from app.services.knowledge_repository import empty_state
 from app.services import knowledge_service as service
 
+
 class MemoryRepository:
-    def __init__(self): self.states, self.receipts = {}, {}
-    def read(self, owner): return deepcopy(self.states.get(owner, empty_state()))
+    def __init__(self):
+        self.states, self.receipts = {}, {}
+
+    def read(self, owner):
+        return deepcopy(self.states.get(owner, empty_state()))
+
     def mutate(self, owner, key, fingerprint, apply, project_id=None):
-        existing = self.receipts.get((owner,key))
+        existing = self.receipts.get((owner, key))
         if existing:
-            if existing[0] != fingerprint: raise HTTPException(409,'Different request')
+            if existing[0] != fingerprint:
+                raise HTTPException(409, "Different request")
             return self.read(owner), existing[1]
         state = self.read(owner)
         result = apply(state)
-        state['revision'] += 1
+        state["revision"] += 1
         self.states[owner] = deepcopy(state)
-        self.receipts[(owner,key)] = fingerprint, result
+        self.receipts[(owner, key)] = fingerprint, result
         return state, result
+
 
 class KnowledgeTests(unittest.TestCase):
     def setUp(self):
-        self.actor = AuthUser(sub='owner', name='Owner', email='owner@example.com')
+        self.actor = AuthUser(sub="owner", name="Owner", email="owner@example.com")
         self.repo = MemoryRepository()
         self.counter = 0
-        self.project = SimpleNamespace(current_snapshots={'requirements':SimpleNamespace(payload={'requirements':[{'id':'R1','text':'Original rule'}]})})
-        self.patches=[patch.object(service,'repository',return_value=self.repo),patch.object(service,'project_for',side_effect=lambda p,a: self.project if p else None)]
-        for item in self.patches: item.start()
+        self.project = SimpleNamespace(current_snapshots={"requirements": SimpleNamespace(payload={"requirements": [{"id": "R1", "text": "Original rule"}]})})
+        self.patches = [
+            patch.object(service, "repository", return_value=self.repo),
+            patch.object(service, "project_for", side_effect=lambda p, a: self.project if p else None),
+        ]
+        for item in self.patches:
+            item.start()
         self.addCleanup(lambda: [p.stop() for p in self.patches])
-    def mutate(self, action, entry=None, project='p1', draft=None, key=None):
+
+    def mutate(self, action, entry=None, project="p1", draft=None, key=None):
         self.counter += 1
-        return service.mutate_knowledge(self.actor, project, KnowledgeMutation(action=action,entry_id=entry.id if entry else None,
-            base_revision=entry.revision if entry else 0,draft=draft), key or str(self.counter))
+        return service.mutate_knowledge(
+            self.actor,
+            project,
+            KnowledgeMutation(action=action, entry_id=entry.id if entry else None, base_revision=entry.revision if entry else 0, draft=draft),
+            key or str(self.counter),
+        )
+
     def draft(self, **kwargs):
-        return {'text':'Include boundary values','stages':['use_cases'],**kwargs}
+        return {"text": "Include boundary values", "stages": ["use_cases"], **kwargs}
+
     def test_approval_revisions_preserve_old_active_until_approved(self):
-        entry=self.mutate('propose',draft=self.draft())
+        entry = self.mutate("propose", draft=self.draft())
         self.assertIsNone(entry.active)
-        self.assertEqual(service.resolve_memories(self.actor,'p1','use_cases')[0],[])
-        entry=self.mutate('approve',entry)
-        updated=self.mutate('revise',entry,draft=self.draft(text='Include both boundaries'))
-        self.assertEqual(updated.active['text'],'Include boundary values')
-        self.assertEqual(updated.pending['text'],'Include both boundaries')
-        with self.assertRaises(HTTPException) as error: self.mutate('retire',entry)
-        self.assertEqual(error.exception.status_code,409)
-        updated=self.mutate('approve',updated)
-        self.assertEqual(updated.active['text'],'Include both boundaries')
+        self.assertEqual(service.resolve_memories(self.actor, "p1", "use_cases")[0], [])
+        entry = self.mutate("approve", entry)
+        updated = self.mutate("revise", entry, draft=self.draft(text="Include both boundaries"))
+        self.assertEqual(updated.active["text"], "Include boundary values")
+        self.assertEqual(updated.pending["text"], "Include both boundaries")
+        with self.assertRaises(HTTPException) as error:
+            self.mutate("retire", entry)
+        self.assertEqual(error.exception.status_code, 409)
+        updated = self.mutate("approve", updated)
+        self.assertEqual(updated.active["text"], "Include both boundaries")
+
     def test_selection_is_explicit_and_scoped_and_retirement_is_global(self):
-        entry=self.mutate('propose',project=None,draft=self.draft())
-        entry=self.mutate('approve',entry,project=None)
-        self.assertEqual(service.resolve_memories(self.actor,'p1','use_cases')[0],[])
-        self.mutate('select',entry)
-        self.assertEqual(len(service.resolve_memories(self.actor,'p1','use_cases')[0]),1)
-        self.assertEqual(service.resolve_memories(self.actor,'p2','use_cases')[0],[])
-        self.mutate('retire',entry,project=None)
-        self.assertEqual(service.resolve_memories(self.actor,'p1','use_cases')[0],[])
+        entry = self.mutate("propose", project=None, draft=self.draft())
+        entry = self.mutate("approve", entry, project=None)
+        self.assertEqual(service.resolve_memories(self.actor, "p1", "use_cases")[0], [])
+        self.mutate("select", entry)
+        self.assertEqual(len(service.resolve_memories(self.actor, "p1", "use_cases")[0]), 1)
+        self.assertEqual(service.resolve_memories(self.actor, "p2", "use_cases")[0], [])
+        self.mutate("retire", entry, project=None)
+        self.assertEqual(service.resolve_memories(self.actor, "p1", "use_cases")[0], [])
+
     def test_requirement_changes_exclude_knowledge(self):
-        entry=self.mutate('propose',draft=self.draft(requirement_ids=['R1']))
-        entry=self.mutate('approve',entry)
-        self.assertEqual(len(service.resolve_memories(self.actor,'p1','use_cases',['R1'])[0]),1)
-        self.project.current_snapshots['requirements'].payload['requirements'][0]['text']='Changed rule'
-        self.assertEqual(service.list_knowledge(self.actor,'p1').entries[0].status,'needs_confirmation')
-        self.assertEqual(service.resolve_memories(self.actor,'p1','use_cases',['R1'])[0],[])
-        entry=self.mutate('approve',entry)
-        self.assertEqual(entry.status,'active')
+        entry = self.mutate("propose", draft=self.draft(requirement_ids=["R1"]))
+        entry = self.mutate("approve", entry)
+        self.assertEqual(len(service.resolve_memories(self.actor, "p1", "use_cases", ["R1"])[0]), 1)
+        self.project.current_snapshots["requirements"].payload["requirements"][0]["text"] = "Changed rule"
+        self.assertEqual(service.list_knowledge(self.actor, "p1").entries[0].status, "needs_confirmation")
+        self.assertEqual(service.resolve_memories(self.actor, "p1", "use_cases", ["R1"])[0], [])
+        entry = self.mutate("approve", entry)
+        self.assertEqual(entry.status, "active")
+
     def test_request_idempotency_and_owner_isolation(self):
-        a=self.mutate('propose',draft=self.draft(),key='same')
-        b=self.mutate('propose',draft=self.draft(),key='same')
-        self.assertEqual(a,b)
-        with self.assertRaises(HTTPException): self.mutate('propose',draft=self.draft(text='different'),key='same')
-        other=AuthUser(sub='other',name='Other',email='other@example.com')
-        self.assertEqual(service.list_knowledge(other,'p1').entries,[])
-        with self.assertRaises(HTTPException): self.mutate('retire',a,project='p2')
+        a = self.mutate("propose", draft=self.draft(), key="same")
+        b = self.mutate("propose", draft=self.draft(), key="same")
+        self.assertEqual(a, b)
+        with self.assertRaises(HTTPException):
+            self.mutate("propose", draft=self.draft(text="different"), key="same")
+        other = AuthUser(sub="other", name="Other", email="other@example.com")
+        self.assertEqual(service.list_knowledge(other, "p1").entries, [])
+        with self.assertRaises(HTTPException):
+            self.mutate("retire", a, project="p2")
+
     def test_promotion_requires_generalization_and_separate_approval(self):
-        entry=self.mutate('propose',draft=self.draft())
-        entry=self.mutate('approve',entry)
-        promoted=self.mutate('promote',entry,draft=self.draft())
-        self.assertEqual(promoted.scope,'personal')
+        entry = self.mutate("propose", draft=self.draft())
+        entry = self.mutate("approve", entry)
+        promoted = self.mutate("promote", entry, draft=self.draft())
+        self.assertEqual(promoted.scope, "personal")
         self.assertIsNone(promoted.active)
-        with self.assertRaises(HTTPException): self.mutate('promote',entry,draft=self.draft(kind='business_fact'))
+        with self.assertRaises(HTTPException):
+            self.mutate("promote", entry, draft=self.draft(kind="business_fact"))
+
     def test_delete_purges_versions_and_selections(self):
-        entry=self.mutate('propose',project=None,draft=self.draft())
-        entry=self.mutate('approve',entry,project=None)
-        self.mutate('select',entry)
-        self.mutate('delete',entry,project=None)
-        state=self.repo.read(self.actor.sub)
-        self.assertEqual(state['entries'][entry.id]['versions'],[])
-        self.assertEqual(state['selections']['p1'],[])
+        entry = self.mutate("propose", project=None, draft=self.draft())
+        entry = self.mutate("approve", entry, project=None)
+        self.mutate("select", entry)
+        self.mutate("delete", entry, project=None)
+        state = self.repo.read(self.actor.sub)
+        self.assertEqual(state["entries"][entry.id]["versions"], [])
+        self.assertEqual(state["selections"]["p1"], [])
+
     def test_secrets_rejected(self):
-        with self.assertRaises(ValueError): KnowledgeMutation(action='propose',draft=self.draft(text='password=secret123'))
+        with self.assertRaises(ValueError):
+            KnowledgeMutation(action="propose", draft=self.draft(text="password=secret123"))
+
     def test_api_requires_idempotency_key(self):
-        app.dependency_overrides[get_current_user]=lambda:self.actor
+        app.dependency_overrides[get_current_user] = lambda: self.actor
         try:
             with TestClient(app) as client:
-                self.assertEqual(client.post('/me/knowledge',json={'action':'propose','draft':self.draft()}).status_code,422)
-                response=client.post('/me/knowledge',json={'action':'propose','draft':self.draft()},headers={'X-Request-ID':'api'})
-                self.assertEqual(response.status_code,200,response.text)
-        finally: app.dependency_overrides.clear()
+                self.assertEqual(client.post("/me/knowledge", json={"action": "propose", "draft": self.draft()}).status_code, 422)
+                response = client.post("/me/knowledge", json={"action": "propose", "draft": self.draft()}, headers={"X-Request-ID": "api"})
+                self.assertEqual(response.status_code, 200, response.text)
+        finally:
+            app.dependency_overrides.clear()
+
 
 class MemoryAdapterTests(unittest.IsolatedAsyncioTestCase):
     async def test_read_only_owner_bound_snapshot(self):
         from app.services.knowledge_memory import ApprovedKnowledgeMemory
         from app.services.guidance_service import build_manifest
-        adapter=ApprovedKnowledgeMemory('owner',build_manifest('use_cases','test'))
-        with self.assertRaises(PermissionError): await adapter.add_session_to_memory(None)
-        with self.assertRaises(PermissionError): await adapter.search_memory(app_name='app',user_id='other',query='all')
-        self.assertEqual((await adapter.search_memory(app_name='app',user_id='owner',query='all')).memories,[])
+
+        adapter = ApprovedKnowledgeMemory("owner", build_manifest("use_cases", "test"))
+        with self.assertRaises(PermissionError):
+            await adapter.add_session_to_memory(None)
+        with self.assertRaises(PermissionError):
+            await adapter.search_memory(app_name="app", user_id="other", query="all")
+        self.assertEqual((await adapter.search_memory(app_name="app", user_id="owner", query="all")).memories, [])
+
+
+class OwnershipBoundaryTests(unittest.TestCase):
+    def test_project_lookup_uses_existing_keyword_only_owner_contract(self):
+        actor = AuthUser(sub="owner", name="Owner", email="owner@example.com")
+        with patch.object(service, "get_project", autospec=True, return_value="project") as lookup:
+            self.assertEqual(service.project_for("p1", actor), "project")
+            lookup.assert_called_once_with("p1", actor=actor)
+
+    def test_project_permission_failure_is_preserved(self):
+        actor = AuthUser(sub="owner", name="Owner", email="owner@example.com")
+        with patch.object(service, "get_project", autospec=True, side_effect=HTTPException(404, "Project not found")):
+            with self.assertRaises(HTTPException) as caught:
+                service.project_for("someone-elses-project", actor)
+            self.assertEqual(caught.exception.status_code, 404)

--- a/docs/agent-knowledge.md
+++ b/docs/agent-knowledge.md
@@ -14,3 +14,10 @@ One immutable manifest records model, skill versions/hashes, selected memory rev
 - #272: shared management and provenance UI
 - #273: generation and successful-feedback integration
 - #274: validation, evaluation and rollout evidence
+
+## Durable lifecycle (#271)
+`GET /skills`, `GET/POST /projects/{id}/knowledge`, and `GET/POST /me/knowledge` expose the approved lifecycle. POST requires `X-Request-ID` and an action, entry ID/base revision where applicable, and draft content. An action accepts propose, revise, approve, dismiss, retire, delete, promote, select or unselect. Personal facts/requirement links are rejected; business facts require current source requirement links. Promotion creates an inactive personal proposal requiring separate approval.
+
+Firestore stores bounded, owner-isolated knowledge state in `agent_knowledge`, accessed only through authenticated backend services. A transaction checks project ownership, optimistic entry revision and a separate idempotency receipt before committing. Reusing an ID with different input is a conflict. Receipts contain identifiers, not guidance text. Deletion purges version text and selections; artifact provenance uses IDs/hashes, and missing historical content is shown as unavailable. Required links are hashed; changed/missing sources cause effective `needs_confirmation` status and retrieval exclusion.
+
+The read-only ADK adapter accepts only the frozen run manifest and owner. Session ingestion is rejected. Selected personal records remain owned by that user and are never automatically included in other projects. Source-based exclusion and retrieval order are deterministic.


### PR DESCRIPTION
Add owner-isolated, durable knowledge with explicit proposal/approval revisions, personal promotion/selection, requirement-change exclusion and deletion. Firestore writes check project ownership, entry revisions and idempotency inside a transaction. The ADK adapter is read-only and bound to one owner's frozen run manifest.

Closes #271. Parent #269. Stacked on #275.

Validation: nine focused lifecycle/API/memory-adapter tests passed; OpenAPI export and diff checks passed. Existing Firestore instance was verified read-only as Standard edition. No live knowledge records or cloud configuration were changed. Full integration regression gates follow #273/#274.
