### PR TITLE
Remove the Test Cases Diagnostics and Generation Summary tab

### DIFF
--- a/docs/github-issues-backlog.md
+++ b/docs/github-issues-backlog.md
@@ -1,5 +1,7 @@
 # GitHub Issue Backlog for Test Case Engine Improvements
 
+- Implemented; PR review pending: #288 — Remove the Test Cases Diagnostics / Generation Summary tab entirely; retain Generated Test Cases and Traceability Matrix. Parent #241; stacked on PR #287. Build, lint, changed-file formatting and 27 focused browser tests passed.
+
 - Implemented; PR review pending: #286 — Simplify Test Cases to Generated Test Cases, Traceability Matrix, and Diagnostics; show requirement IDs only and remove Story / source path. Parent #241; stacked on PR #285. Validation: 21 focused browser checks, build, lint, and changed-file formatting pass.
 
 - Implemented; PR review pending: #284 — Responsive Use Cases tables after browser/column resizing, inline wrapping requirement ID/title, and removal of per-group counts. Parent #241; frontend-only follow-up. Validation: 14 scenario review E2E tests, frontend build, lint, and focused formatting pass.

--- a/docs/project-design.md
+++ b/docs/project-design.md
@@ -127,6 +127,10 @@ Use Cases opts into `ResizableTable`'s `responsiveMinWidth={800}` (#284). On con
 
 ## Focused Test Cases results (#286)
 
-Test Cases presents Generated Test Cases, Traceability Matrix, and Diagnostics. Scenario Coverage and Requirement Analysis tabs are removed from this page. Requirement or scenario coverage gaps open Traceability Matrix; a loaded project without generated cases opens the Generated Test Cases empty state. Stored coverage/analysis artifacts and generation/review/export rules remain unchanged.
+Test Cases presents Generated Test Cases and Traceability Matrix (#288). Scenario Coverage and Requirement Analysis tabs are removed from this page. Requirement or scenario coverage gaps open Traceability Matrix; a loaded project without generated cases opens the Generated Test Cases empty state. Stored coverage/analysis artifacts and generation/review/export rules remain unchanged.
 
 Traceability Matrix shows requirement IDs without repeating their full text or Story / source path. Linked test cases, scenario coverage, and Covered/Gap status remain visible.
+
+## Two-tab Test Cases results (#288)
+
+The Diagnostics / Generation Summary tab is removed entirely. Generation and reload select Generated Test Cases or Traceability Matrix when coverage gaps exist; technical run problems never select a hidden panel. Quality/export notices above the tabs remain available. Diagnostic data remains stored; no backend or review/export policy changes are made. The previously proposed Generation Summary mockup is superseded.

--- a/frontend/e2e/export-approval-gate.spec.js
+++ b/frontend/e2e/export-approval-gate.spec.js
@@ -281,19 +281,8 @@ test.describe("Export approval gate", () => {
 		await expect(page.getByRole("region", { name: "Selected test case", exact: true })).toBeVisible();
 		await page.getByRole("tab", { name: /traceability/i }).click();
 		await expect(page.getByRole("region", { name: "Requirement traceability table" })).toHaveAttribute("tabindex", "0");
-		await page.getByRole("tab", { name: /diagnostics/i }).click();
-		await expect(page.getByText("Route Direct Parallel")).toBeVisible();
-		await expect(page.getByText("Generation sources")).toBeVisible();
-		await expect(page.locator(".workflow-diagnostics-stat", { hasText: "Model-authored" }).getByText("1")).toBeVisible();
-		await expect(page.locator(".workflow-diagnostics-stat", { hasText: "Deterministic completion" }).getByText("1")).toBeVisible();
-		await expect(page.getByText("Completion source")).toBeVisible();
-		await expect(page.getByText("Coverage Completion")).toBeVisible();
-		await expect(page.locator(".workflow-diagnostics-stat", { hasText: "Must-have gaps" }).getByText("1")).toBeVisible();
-		await expect(page.locator(".workflow-diagnostics-stat", { hasText: "Optional/planned gaps" }).getByText("1")).toBeVisible();
-		await expect(page.locator(".workflow-diagnostics-stat", { hasText: "Total additions" }).getByText("2")).toBeVisible();
-		await expect(page.getByText("Parser recoveries")).toBeVisible();
-		await expect(page.getByText(/recovered 1 complete test_cases entry/i)).toBeVisible();
-		await expect(page.locator(".workflow-diagnostics-block.warning")).toHaveCount(0);
+		await expect(page.getByRole("tab", { name: /diagnostics|generation summary/i })).toHaveCount(0);
+
 		await page.getByRole("button", { name: /^Next$/ }).click();
 		await expect(page).toHaveURL(automationPath);
 		await expect(page.getByRole("heading", { name: /^Automation$/i })).toBeVisible();

--- a/frontend/e2e/shared-project-design.spec.js
+++ b/frontend/e2e/shared-project-design.spec.js
@@ -332,12 +332,13 @@ test("stale Use Cases cannot be approved from either review entry point", async 
 	expect(api.requests.review).toEqual([]);
 });
 
-test("Test Cases keeps three result tabs and compact traceability rows", async ({ page }) => {
+test("Test Cases keeps two result tabs and compact traceability rows", async ({ page }) => {
 	const project = await openCases(page);
 	const tabs = page.getByRole("tablist", { name: "Generation result sections" });
-	await expect(tabs.getByRole("tab")).toHaveCount(3);
+	await expect(tabs.getByRole("tab")).toHaveCount(2);
 	await expect(tabs).not.toContainText("Scenario Coverage");
 	await expect(tabs).not.toContainText("Requirement Analysis");
+	await expect(tabs).not.toContainText(/Diagnostics|Generation Summary/);
 	await tabs.getByRole("tab", { name: /^Traceability Matrix/ }).click();
 	const table = page.getByRole("region", { name: "Requirement traceability table" }).getByRole("table");
 	await expect(table.getByRole("columnheader")).toHaveText(["Requirement", "Linked test cases", "Scenario coverage", "Status"]);
@@ -361,9 +362,6 @@ test("Test Cases keeps three result tabs and compact traceability rows", async (
 	}
 	await tabs.getByRole("tab", { name: /^Traceability Matrix/ }).focus();
 	await page.keyboard.press("ArrowRight");
-	await expect(tabs.getByRole("tab", { name: /^Diagnostics/ })).toHaveAttribute("aria-selected", "true");
-	await expect(page.getByRole("tabpanel", { name: "Diagnostics", exact: true })).toBeVisible();
-	await page.keyboard.press("ArrowRight");
 	await expect(tabs.getByRole("tab", { name: /^Generated Test Cases/ })).toHaveAttribute("aria-selected", "true");
 	await expect(page.getByRole("region", { name: "Selected test case" })).toBeVisible();
 });
@@ -384,3 +382,27 @@ test("loaded project without test cases selects a visible results tab", async ({
 	await expect(page.getByRole("tab", { name: /^Generated Test Cases/ })).toHaveAttribute("aria-selected", "true");
 	await expect(page.getByRole("tabpanel", { name: "Generated Test Cases", exact: true })).not.toBeEmpty();
 });
+
+for (const state of ["partial", "failed", "completed"]) {
+	for (const count of [0, 1])
+		test(`two-tab results remain usable for ${state} runs with ${count} cases`, async ({ page }) => {
+			await openCases(page, count ? [caseFixture("TC-001", "Checkout")] : [], {
+				workflow_diagnostics: {
+					status: state,
+					timed_out: state === "partial",
+					failure_reason: state === "failed" ? "internal_error" : null,
+					warnings: ["technical warning"],
+					parser_failures: ["internal parser message"],
+				},
+			});
+			const tabs = page.getByRole("tablist", { name: "Generation result sections" });
+			const panel = page.getByRole("tabpanel");
+			await expect(tabs.getByRole("tab")).toHaveCount(2);
+			await expect(tabs.getByRole("tab", { name: /^Generated Test Cases/ })).toHaveAttribute("aria-selected", "true");
+			await expect(panel).not.toBeEmpty();
+			await expect(panel).not.toContainText(/technical warning|internal parser message|Generation Summary|Diagnostics/);
+			await page.reload();
+			await expect(tabs.getByRole("tab", { name: /^Generated Test Cases/ })).toHaveAttribute("aria-selected", "true");
+			await expect(panel).not.toBeEmpty();
+		});
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4852,9 +4852,7 @@ export default function App() {
 													<div className="generate-results-header">
 														<div>
 															<h3>Generation Results</h3>
-															<p>
-																Review the generated test cases and their requirement coverage.
-															</p>
+															<p>Review the generated test cases and their requirement coverage.</p>
 														</div>
 														<span className="generate-results-summary-pill">
 															{testCases.length} test case{testCases.length === 1 ? "" : "s"}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -36,7 +36,6 @@ import RequirementReviewWorkbench from "./components/requirements/RequirementRev
 import SettingsDialog from "./components/settings/SettingsDialog";
 import TemplateSetupPanel from "./components/template/TemplateSetupPanel";
 import WorkflowNavigationDrawer from "./components/layout/WorkflowNavigationDrawer";
-import WorkflowDiagnostics from "./components/workflow/WorkflowDiagnostics";
 import useAppSessionState from "./hooks/useAppSessionState";
 import useBillingStatus from "./hooks/useBillingStatus";
 import useBrowserNavigation from "./hooks/useBrowserNavigation";
@@ -309,7 +308,6 @@ export default function App() {
 		setTestCaseWorkflowDiagnostics,
 		appliedTestCaseWorkflowSettings,
 		setAppliedTestCaseWorkflowSettings,
-		testCaseIterationHistory,
 		setTestCaseIterationHistory,
 		feedback,
 		setFeedback,
@@ -752,20 +750,7 @@ export default function App() {
 	const requirementReportDetailCount = requirementBlockingIssues.length + requirementWarnings.length + requirementParserFailures.length;
 
 	const chooseGenerateResultTab = (data) => {
-		const diagnostics = data?.workflow_diagnostics || null;
 		const metrics = data?.coverage_metrics || null;
-		const hasDiagnosticAttention = Boolean(
-			diagnostics?.failure_reason ||
-			diagnostics?.timed_out ||
-			diagnostics?.stalled ||
-			(diagnostics?.status && diagnostics.status !== "completed") ||
-			diagnostics?.warnings?.length ||
-			diagnostics?.parser_failures?.length
-		);
-
-		if (hasDiagnosticAttention) {
-			return "diagnostics";
-		}
 		if ((metrics?.requirements_without_tests || []).length > 0) {
 			return "traceability";
 		}
@@ -851,10 +836,6 @@ export default function App() {
 			},
 		};
 	};
-
-	const renderWorkflowDiagnostics = (title, diagnostics, appliedSettings, iterationHistory) => (
-		<WorkflowDiagnostics title={title} diagnostics={diagnostics} appliedSettings={appliedSettings} iterationHistory={iterationHistory} />
-	);
 
 	const renderRequirementReviewReport = () => {
 		if (!requirementReview && !requirementCoverageMetrics && !requirementWorkflowDiagnostics && !appliedRequirementWorkflowSettings) {
@@ -3591,15 +3572,6 @@ export default function App() {
 	});
 	const tracedRequirementCount = requirementTraceabilityRows.filter((row) => row.linkedTestCases.length > 0).length;
 	const traceabilityGapCount = Math.max(0, approvedRequirements.length - tracedRequirementCount);
-	const diagnosticsWarningCount =
-		(testCaseWorkflowDiagnostics?.warnings?.length || 0) + (testCaseWorkflowDiagnostics?.parser_failures?.length || 0);
-	const diagnosticsNeedsAttention = Boolean(
-		testCaseWorkflowDiagnostics?.failure_reason ||
-		testCaseWorkflowDiagnostics?.timed_out ||
-		testCaseWorkflowDiagnostics?.stalled ||
-		(testCaseWorkflowDiagnostics?.status && testCaseWorkflowDiagnostics.status !== "completed") ||
-		diagnosticsWarningCount > 0
-	);
 	const hasGenerateResults = Boolean(
 		testCases.length ||
 		coveragePlan.length ||
@@ -3620,12 +3592,6 @@ export default function App() {
 			label: "Traceability Matrix",
 			badge: approvedRequirements.length ? `${tracedRequirementCount}/${approvedRequirements.length}` : "—",
 			variant: traceabilityGapCount > 0 ? "warning" : tracedRequirementCount > 0 ? "success" : "muted",
-		},
-		{
-			id: "diagnostics",
-			label: "Diagnostics",
-			badge: diagnosticsWarningCount || testCaseWorkflowDiagnostics?.status || (appliedTestCaseWorkflowSettings ? "settings" : "—"),
-			variant: diagnosticsNeedsAttention ? "warning" : testCaseWorkflowDiagnostics || appliedTestCaseWorkflowSettings ? "muted" : "muted",
 		},
 	];
 
@@ -4887,8 +4853,7 @@ export default function App() {
 														<div>
 															<h3>Generation Results</h3>
 															<p>
-																Review the generated cases, requirement traceability, and workflow diagnostics without scrolling through a
-																wall of artifacts.
+																Review the generated test cases and their requirement coverage.
 															</p>
 														</div>
 														<span className="generate-results-summary-pill">
@@ -4921,19 +4886,6 @@ export default function App() {
 														role="tabpanel"
 														aria-label={generateResultTabs.find((tab) => tab.id === activeGenerateResultTab)?.label || "Generation result"}
 													>
-														{activeGenerateResultTab === "diagnostics" &&
-															(renderWorkflowDiagnostics(
-																"Test-case workflow diagnostics",
-																testCaseWorkflowDiagnostics,
-																appliedTestCaseWorkflowSettings,
-																testCaseIterationHistory
-															) || (
-																<CollectionState as="div" kind="empty" className="generate-result-empty">
-																	<h3>Diagnostics</h3>
-																	<p>No workflow diagnostics are available for this run.</p>
-																</CollectionState>
-															))}
-
 														{activeGenerateResultTab === "traceability" && (
 															<TraceabilityMatrixPanel
 																approvedRequirements={approvedRequirements}
@@ -4966,7 +4918,7 @@ export default function App() {
 												<Surface as="div" className="result-section">
 													<h3>Generated Test Cases</h3>
 													<span className="helper-text">
-														No generation run yet. Generate from approved requirements to view test cases, traceability, and diagnostics.
+														No generation run yet. Generate from approved requirements to view test cases and requirement traceability.
 													</span>
 												</Surface>
 											)}


### PR DESCRIPTION
## Summary
Test Cases now shows only Generated Test Cases and Traceability Matrix. The Diagnostics / Generation Summary tab, its content and badge, and automatic navigation to that panel are removed. Remaining guidance reflects the two available views.

Coverage gaps still select Traceability Matrix; other runs show Generated Test Cases, including failed, partial and empty results. Existing quality/export notices and stored diagnostic data are preserved.

Closes #288. Parent #241. Stacked on PR #287; merge #287 first, then retarget this PR to main.

## Validation
- Frontend build and lint passed; build retains the existing large-bundle warning.
- Prettier check of changed frontend files passed.
- `npm run test:e2e -- e2e/shared-project-design.spec.js e2e/export-approval-gate.spec.js --reporter=list --output=/tmp/issue-288-final-results --retries=0` — 27 passed.
- Tests cover two-tab keyboard navigation, coverage selection, reload, failed/partial/completed snapshots with zero and one case, and export approval safeguards.
- Desktop/mobile screenshots inspected on localhost with authenticated API fixtures; no browser errors or framework overlay. Responsive tests cover 390, 901 and 1488px.

No backend changes. Production data and other browser engines were not exercised.
