### PR TITLE
Make test quality findings actionable with Improve tests

### DIFF
--- a/docs/github-issues-backlog.md
+++ b/docs/github-issues-backlog.md
@@ -1,5 +1,7 @@
 # GitHub Issue Backlog for Test Case Engine Improvements
 
+- Implemented; PR review pending: #290 — Actionable Improve tests tab with selected findings, refinement, case navigation, and revision/impact safeguards. Parent #241; follows merged #284/#286/#288. Validation: build, lint, formatting, and 38 focused refinement, layout, export, and lifecycle browser tests pass.
+
 - Implemented; PR review pending: #288 — Remove the Test Cases Diagnostics / Generation Summary tab entirely; retain Generated Test Cases and Traceability Matrix. Parent #241; stacked on PR #287. Build, lint, changed-file formatting and 27 focused browser tests passed.
 
 - Implemented; PR review pending: #286 — Simplify Test Cases to Generated Test Cases, Traceability Matrix, and Diagnostics; show requirement IDs only and remove Story / source path. Parent #241; stacked on PR #285. Validation: 21 focused browser checks, build, lint, and changed-file formatting pass.

--- a/docs/project-design.md
+++ b/docs/project-design.md
@@ -127,10 +127,16 @@ Use Cases opts into `ResizableTable`'s `responsiveMinWidth={800}` (#284). On con
 
 ## Focused Test Cases results (#286)
 
-Test Cases presents Generated Test Cases and Traceability Matrix (#288). Scenario Coverage and Requirement Analysis tabs are removed from this page. Requirement or scenario coverage gaps open Traceability Matrix; a loaded project without generated cases opens the Generated Test Cases empty state. Stored coverage/analysis artifacts and generation/review/export rules remain unchanged.
+Test Cases presents Generated Test Cases, Traceability Matrix, and Improve tests (#290). Scenario Coverage and Requirement Analysis tabs are removed from this page. When machine quality has not failed, requirement or scenario coverage gaps open Traceability Matrix; otherwise the Generated Test Cases result or empty state opens. Stored coverage/analysis artifacts and generation/review/export rules remain unchanged.
 
 Traceability Matrix shows requirement IDs without repeating their full text or Story / source path. Linked test cases, scenario coverage, and Covered/Gap status remain visible.
 
-## Two-tab Test Cases results (#288)
+## Improve tests (#290)
 
-The Diagnostics / Generation Summary tab is removed entirely. Generation and reload select Generated Test Cases or Traceability Matrix when coverage gaps exist; technical run problems never select a hidden panel. Quality/export notices above the tabs remain available. Diagnostic data remains stored; no backend or review/export policy changes are made. The previously proposed Generation Summary mockup is superseded.
+The third result tab, Improve tests, replaces the large quality information box and the old free-text refinement form. Failed machine quality checks select it on generation and reload; otherwise coverage gaps select Traceability Matrix and other results select Generated Test Cases. Diagnostics and Generation Summary remain removed, with diagnostic data still stored.
+
+Improve tests shows the review summary, secondary quality/required scores, and deduplicated blocking issues and unmet criteria. Findings start unselected; Select all and Clear selection control the checklist. Existing test-case IDs link to that case. Selected findings and optional instructions become explicit feedback to the existing `/testcases/refine` endpoint. With no findings, nonempty instructions are sufficient. The request asks to preserve unrelated cases where possible; refinement still returns a complete suite.
+
+Draft selections survive tab changes and failures, but reset when the project or test-case source snapshot changes. Revision conflicts require reloading current findings before resubmission. Stale suites direct users to impact review. Authentication, billing, busy-state and revision checks remain enforced, including when project recommendations are present. Successful refinement stays on Improve tests, clears submitted drafts and displays the latest review. Passing machine quality never represents human approval. A compact export-status message remains above the tabs and existing export protections remain unchanged.
+
+Validation: `e2e/improve-tests.spec.js` covers checklist feedback, navigation/focus, retry, conflict, stale-suite guards, busy states, snapshot reset and desktop/mobile accessibility. Export and shared-layout regression tests cover the surrounding workflow.

--- a/frontend/e2e/export-approval-gate.spec.js
+++ b/frontend/e2e/export-approval-gate.spec.js
@@ -274,7 +274,7 @@ test.describe("Export approval gate", () => {
 		await page.getByRole("button", { name: /^Next$/ }).click();
 		await expect(page).toHaveURL(testCasesPath);
 		await page.getByRole("button", { name: /generate from \d+ approved/i }).click();
-		await page.getByText("View findings", { exact: true }).click();
+		await page.getByRole("tab", { name: /^Improve tests/ }).click();
 		await expect(page.getByText(/Needs additional negative coverage/i)).toBeVisible();
 		await page.getByRole("tab", { name: /test cases/i }).click();
 		await expect(page.getByRole("region", { name: "Generated test cases", exact: true })).toBeVisible();

--- a/frontend/e2e/improve-tests.spec.js
+++ b/frontend/e2e/improve-tests.spec.js
@@ -1,0 +1,206 @@
+import { expect, test } from "@playwright/test";
+import AxeBuilder from "@axe-core/playwright";
+import { seedAuthenticatedSession } from "./support/auth.js";
+import { installUseCaseReviewApi, useCaseProjectFixture, USE_CASE_PROJECT_ID } from "./support/use-case-review.js";
+const issue = "TC-002 needs a clear expected result.";
+const suiteIssue = "Add boundary coverage.";
+const cases = [1, 2].map((n) => ({
+	id: `TC-00${n}`,
+	title: `Checkout ${n}`,
+	tags: ["REQ-101"],
+	steps: [{ step: 1, action: "Submit", expected: "Saved" }],
+}));
+async function open(page, options = {}) {
+	const project = useCaseProjectFixture();
+	project.current_snapshots.test_cases = {
+		snapshot_id: "cases-v1",
+		project_id: USE_CASE_PROJECT_ID,
+		stage: "test_cases",
+		version: 1,
+		payload: {
+			test_cases: cases,
+			review: {
+				approved: false,
+				score: 65,
+				threshold: 90,
+				summary: "Improve expected results and coverage.",
+				blocking_issues: [issue, suiteIssue],
+				unmet_criteria: [issue],
+			},
+			...options.payload,
+		},
+	};
+	project.stage_state.test_cases = { current_snapshot_id: "cases-v1", stale: Boolean(options.stale), approved: false, version: 1 };
+	const api = await installUseCaseReviewApi(page, { initialProject: project });
+	const requests = [];
+	await page.route("**/testcases/refine", async (route) => {
+		requests.push(route.request().postDataJSON());
+		if (options.gate) await options.gate;
+		const failure = options.failures?.shift();
+		if (failure)
+			return route.fulfill({
+				status: failure,
+				contentType: "application/json",
+				body: JSON.stringify({ detail: "Could not apply fixes." }),
+			});
+		const payload = {
+			...project.current_snapshots.test_cases.payload,
+			review: options.resultReview || {
+				approved: true,
+				score: 95,
+				threshold: 90,
+				summary: "Quality targets met.",
+				blocking_issues: [],
+				unmet_criteria: [],
+			},
+			workflow_diagnostics: { status: "completed" },
+		};
+		project.current_revision += 1;
+		project.current_snapshots.test_cases = { ...project.current_snapshots.test_cases, snapshot_id: "cases-v2", version: 2, payload };
+		api.setProject(project);
+		await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(payload) });
+	});
+	await page.route("**/execution/preview", (route) =>
+		route.fulfill({
+			status: 200,
+			contentType: "application/json",
+			body: JSON.stringify({ executable: [], manual: [], unsupported: [], invalid: [], warnings: [], summary: {} }),
+		})
+	);
+	await seedAuthenticatedSession(page);
+	await page.goto(`/projects/${USE_CASE_PROJECT_ID}/test-cases`);
+	await expect(page.getByRole("tab", { name: /^Improve tests/ })).toBeVisible();
+	return { api, requests, project };
+}
+const panel = (page) => page.getByRole("region", { name: "Improve test quality" });
+const apply = (page) => panel(page).getByRole("button", { name: "Apply selected fixes", exact: true });
+
+test("failed review opens actionable findings; selection and instructions survive tab switches and navigate to the exact case", async ({
+	page,
+}) => {
+	await open(page);
+	await expect(page.getByRole("tab", { name: /^Improve tests/ })).toHaveAttribute("aria-selected", "true");
+	await expect(panel(page).getByRole("checkbox")).toHaveCount(2);
+	await expect(panel(page).getByRole("checkbox", { checked: true })).toHaveCount(0);
+	await expect(apply(page)).toBeDisabled();
+	await panel(page).getByRole("button", { name: "Select all", exact: true }).click();
+	await expect(panel(page).getByRole("checkbox", { checked: true })).toHaveCount(2);
+	await panel(page).getByRole("button", { name: "Clear selection", exact: true }).click();
+	await panel(page).getByRole("checkbox", { name: issue, exact: true }).check();
+	await panel(page).getByRole("textbox").fill("Use clear user-visible outcomes.");
+	await panel(page).getByRole("button", { name: "View test case TC-002", exact: true }).click();
+	await expect(page.getByRole("tabpanel", { name: "Generated Test Cases", exact: true })).toBeFocused();
+	await expect(page.getByRole("region", { name: "Selected test case", exact: true })).toContainText("Checkout 2");
+	await page.getByRole("tab", { name: /^Improve tests/ }).click();
+	await expect(panel(page).getByRole("checkbox", { name: issue, exact: true })).toBeChecked();
+	await expect(panel(page).getByRole("textbox")).toHaveValue("Use clear user-visible outcomes.");
+	await expect(panel(page).getByRole("button", { name: /^View test case/ })).toHaveCount(1);
+});
+
+test("applies explicit selected feedback with project recommendations, refreshes quality and clears drafts", async ({ page }) => {
+	const { requests } = await open(page);
+	await panel(page).getByRole("checkbox", { name: issue, exact: true }).check();
+	await panel(page).getByRole("textbox").fill("  Use visible outcomes.  ");
+	await apply(page).click();
+	await expect(panel(page).getByRole("heading", { name: "Machine quality check passed" })).toBeVisible();
+	expect(requests).toHaveLength(1);
+	expect(requests[0].feedback).toBe(
+		`Address the requested fixes below. Preserve unrelated test cases and their IDs where possible.\n\nSelected findings:\n- ${issue}\n\nAdditional instructions:\nUse visible outcomes.`
+	);
+	expect(requests[0].base_project_revision).toBe(7);
+	expect(requests[0].test_cases).toHaveLength(2);
+	await expect(panel(page).getByRole("textbox")).toHaveValue("");
+	await expect(panel(page)).toContainText("does not replace your review");
+	await expect(page.getByRole("tab", { name: /^Improve tests/ })).toHaveAttribute("aria-selected", "true");
+});
+
+test("failed save preserves drafts and suite; retry succeeds with remaining findings", async ({ page }) => {
+	const { requests } = await open(page, {
+		failures: [503],
+		resultReview: { approved: false, score: 80, threshold: 90, blocking_issues: [suiteIssue] },
+	});
+	await panel(page).getByRole("checkbox", { name: issue, exact: true }).check();
+	await apply(page).click();
+	await expect(panel(page).getByRole("alert")).toBeVisible();
+	await expect(panel(page).getByRole("checkbox", { name: issue, exact: true })).toBeChecked();
+	await apply(page).click();
+	await expect(panel(page).getByRole("checkbox")).toHaveCount(1);
+	await expect(panel(page).getByRole("checkbox")).not.toBeChecked();
+	expect(requests[1].feedback).toBe(requests[0].feedback);
+});
+
+test("revision conflict requires reload and new selection", async ({ page }) => {
+	await open(page, { failures: [409] });
+	await panel(page).getByRole("checkbox", { name: issue, exact: true }).check();
+	await apply(page).click();
+	await expect(panel(page).getByRole("alert")).toContainText("project changed");
+	await expect(apply(page)).toBeDisabled();
+	await panel(page).getByRole("button", { name: "Reload current findings" }).click();
+	await expect(panel(page).getByRole("checkbox", { name: issue, exact: true })).not.toBeChecked();
+	await expect(apply(page)).toBeDisabled();
+	await panel(page).getByRole("checkbox", { name: issue, exact: true }).check();
+	await expect(apply(page)).toBeEnabled();
+});
+
+test("stale suite blocks refinement and exposes impact review", async ({ page }) => {
+	const { requests } = await open(page, { stale: true });
+	await expect(apply(page)).toBeDisabled();
+	await expect(panel(page)).toContainText("Upstream inputs changed");
+	await panel(page).getByRole("button", { name: "Review impact" }).click();
+	await expect(page.locator(".generation-gate-card")).toContainText("impact analysis");
+	expect(requests).toHaveLength(0);
+});
+
+test("instructions-only refinement works when findings are unavailable", async ({ page }) => {
+	await open(page, { payload: { review: { approved: false, blocking_issues: [], unmet_criteria: [] } } });
+	const button = panel(page).getByRole("button", { name: "Apply improvements" });
+	await expect(button).toBeDisabled();
+	await panel(page).getByRole("textbox").fill("Add edge cases.");
+	await button.click();
+	await expect(panel(page).getByRole("heading", { name: "Machine quality check passed" })).toBeVisible();
+});
+
+for (const width of [390, 1488])
+	test(`Improve tests is accessible at ${width}px`, async ({ page }) => {
+		await page.setViewportSize({ width, height: 900 });
+		await open(page);
+		expect(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth)).toBe(true);
+		await expect(page.locator(".test-generation-panel")).toHaveCSS("opacity", "1");
+		const result = await new AxeBuilder({ page }).include(".improve-tests").analyze();
+		expect(result.violations).toEqual([]);
+	});
+
+test("busy refinement blocks duplicate requests and edits", async ({ page }) => {
+	let release;
+	const gate = new Promise((resolve) => {
+		release = resolve;
+	});
+	const { requests } = await open(page, { gate });
+	await panel(page).getByRole("checkbox", { name: issue, exact: true }).check();
+	await apply(page).click();
+	await expect(panel(page).getByRole("button", { name: "Applying fixes…" })).toBeDisabled();
+	await expect(panel(page).getByRole("textbox")).toBeDisabled();
+	await expect(panel(page).getByRole("checkbox", { name: issue, exact: true })).toBeDisabled();
+	expect(requests).toHaveLength(1);
+	release();
+	await expect(panel(page).getByRole("heading", { name: "Machine quality check passed" })).toBeVisible();
+});
+
+test("a changed source snapshot resets selections and instructions", async ({ page }) => {
+	const { api, project } = await open(page);
+	await panel(page).getByRole("checkbox", { name: issue, exact: true }).check();
+	await panel(page).getByRole("textbox").fill("Draft instructions");
+	project.current_snapshots.test_cases.snapshot_id = "external-v2";
+	project.current_revision += 1;
+	api.setProject(project);
+	await page
+		.getByRole("navigation", { name: "Project navigation", exact: true })
+		.getByRole("link", { name: /^Requirements,/ })
+		.click();
+	await page
+		.getByRole("navigation", { name: "Project navigation", exact: true })
+		.getByRole("link", { name: /^Test Cases,/ })
+		.click();
+	await expect(panel(page).getByRole("checkbox", { name: issue, exact: true })).not.toBeChecked();
+	await expect(panel(page).getByRole("textbox")).toHaveValue("");
+});

--- a/frontend/e2e/orchestrator-lifecycle.spec.js
+++ b/frontend/e2e/orchestrator-lifecycle.spec.js
@@ -724,7 +724,8 @@ test.describe("Orchestrator lifecycle validation", () => {
 		await expect(task.getByRole("heading", { name: /^Create Evidence Report$/i })).toBeVisible();
 		await task.getByText(/^Details$/i).click();
 		await task.getByRole("button", { name: /^Review Evidence$/i }).click();
-		await expect(page.getByLabel("Test case quality").getByText("Machine quality check passed")).toBeVisible();
+		await page.getByRole("tab", { name: /^Improve tests/ }).click();
+		await expect(page.getByLabel("Improve test quality").getByText("Machine quality check passed", { exact: true })).toBeVisible();
 
 		await page
 			.getByRole("navigation", { name: "Project navigation" })

--- a/frontend/e2e/shared-project-design.spec.js
+++ b/frontend/e2e/shared-project-design.spec.js
@@ -54,6 +54,7 @@ async function openCases(
 	await seedAuthenticatedSession(page);
 	await page.goto(`/projects/${USE_CASE_PROJECT_ID}/test-cases`);
 	await expect(page.getByRole("heading", { name: "Test Cases", exact: true, level: 1 })).toBeVisible();
+	await page.getByRole("tab", { name: /^Generated Test Cases/ }).click();
 	return project;
 }
 
@@ -77,10 +78,11 @@ test("selects cases and preserves all steps and metadata while searching", async
 	await expect(detail).toContainText("Select a test case");
 	await page.getByRole("searchbox", { name: "Search test cases" }).fill("");
 	await expect(detail.getByRole("heading", { name: "Declined card" })).toBeVisible();
-	await page.getByRole("region", { name: "Test case quality" }).getByText("View findings", { exact: true }).click();
-	await expect(page.getByRole("region", { name: "Test case quality" })).toContainText("TC-001 requires a grounded button label.");
+	await page.getByRole("tab", { name: /^Improve tests/ }).click();
+	await expect(page.getByRole("region", { name: "Improve test quality" })).toContainText("TC-001 requires a grounded button label.");
 	await page.getByRole("button", { name: "Template setup", exact: true }).click();
 	await page.getByRole("button", { name: "Generate and review", exact: true }).click();
+	await page.getByRole("tab", { name: /^Generated Test Cases/ }).click();
 	await expect(page.getByRole("heading", { name: "Generated Test Cases", exact: true })).toBeVisible();
 });
 
@@ -217,6 +219,7 @@ test("template setup is explicit and returns to the normal workbench across navi
 	await expect(page.getByRole("heading", { name: "Template Setup", exact: true })).toHaveCount(0);
 	await setup.click();
 	await page.reload();
+	await page.getByRole("tab", { name: /^Generated Test Cases/ }).click();
 	await expect(setup).toBeVisible();
 	await expect(page.getByRole("region", { name: "Selected test case", exact: true })).toBeVisible();
 });
@@ -235,6 +238,7 @@ test("pane divider supports drag, limits, reset and saved widths without changin
 	expect(Number(await divider.getAttribute("aria-valuenow"))).toBeGreaterThan(start);
 	const saved = await divider.getAttribute("aria-valuenow");
 	await page.reload();
+	await page.getByRole("tab", { name: /^Generated Test Cases/ }).click();
 	await expect(divider).toHaveAttribute("aria-valuenow", saved);
 	await expect(page.getByRole("region", { name: "Selected test case" })).toContainText("Valid checkout");
 	await divider.focus();
@@ -332,10 +336,10 @@ test("stale Use Cases cannot be approved from either review entry point", async 
 	expect(api.requests.review).toEqual([]);
 });
 
-test("Test Cases keeps two result tabs and compact traceability rows", async ({ page }) => {
+test("Test Cases keeps three result tabs and compact traceability rows", async ({ page }) => {
 	const project = await openCases(page);
 	const tabs = page.getByRole("tablist", { name: "Generation result sections" });
-	await expect(tabs.getByRole("tab")).toHaveCount(2);
+	await expect(tabs.getByRole("tab")).toHaveCount(3);
 	await expect(tabs).not.toContainText("Scenario Coverage");
 	await expect(tabs).not.toContainText("Requirement Analysis");
 	await expect(tabs).not.toContainText(/Diagnostics|Generation Summary/);
@@ -362,15 +366,19 @@ test("Test Cases keeps two result tabs and compact traceability rows", async ({ 
 	}
 	await tabs.getByRole("tab", { name: /^Traceability Matrix/ }).focus();
 	await page.keyboard.press("ArrowRight");
+	await expect(tabs.getByRole("tab", { name: /^Improve tests/ })).toHaveAttribute("aria-selected", "true");
+	await page.keyboard.press("ArrowRight");
 	await expect(tabs.getByRole("tab", { name: /^Generated Test Cases/ })).toHaveAttribute("aria-selected", "true");
 	await expect(page.getByRole("region", { name: "Selected test case" })).toBeVisible();
 });
 
 test("coverage gaps select the remaining traceability tab after load and reload", async ({ page }) => {
 	await openCases(page, [caseFixture("TC-001", "Valid checkout")], {
+		review: { approved: true },
 		coverage_metrics: { missing_must_have_scenarios: ["negative"], missing_scenarios: ["boundary"], requirements_without_tests: [] },
 	});
 	const selected = page.getByRole("tab", { name: /^Traceability Matrix/ });
+	await page.reload();
 	await expect(selected).toHaveAttribute("aria-selected", "true");
 	await expect(page.getByRole("region", { name: "Requirement traceability table" })).toBeVisible();
 	await page.reload();
@@ -385,7 +393,7 @@ test("loaded project without test cases selects a visible results tab", async ({
 
 for (const state of ["partial", "failed", "completed"]) {
 	for (const count of [0, 1])
-		test(`two-tab results remain usable for ${state} runs with ${count} cases`, async ({ page }) => {
+		test(`result tabs remain usable for ${state} runs with ${count} cases`, async ({ page }) => {
 			await openCases(page, count ? [caseFixture("TC-001", "Checkout")] : [], {
 				workflow_diagnostics: {
 					status: state,
@@ -397,12 +405,12 @@ for (const state of ["partial", "failed", "completed"]) {
 			});
 			const tabs = page.getByRole("tablist", { name: "Generation result sections" });
 			const panel = page.getByRole("tabpanel");
-			await expect(tabs.getByRole("tab")).toHaveCount(2);
+			await expect(tabs.getByRole("tab")).toHaveCount(3);
 			await expect(tabs.getByRole("tab", { name: /^Generated Test Cases/ })).toHaveAttribute("aria-selected", "true");
 			await expect(panel).not.toBeEmpty();
 			await expect(panel).not.toContainText(/technical warning|internal parser message|Generation Summary|Diagnostics/);
 			await page.reload();
-			await expect(tabs.getByRole("tab", { name: /^Generated Test Cases/ })).toHaveAttribute("aria-selected", "true");
+			await expect(tabs.getByRole("tab", { name: /^Improve tests/ })).toHaveAttribute("aria-selected", "true");
 			await expect(panel).not.toBeEmpty();
 		});
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,36 +1,36 @@
 {
-  "name": "agentic-tc-ui",
-  "version": "0.1.0",
-  "private": true,
-  "type": "module",
-  "scripts": {
-    "dev": "vite",
-    "build": "vite build",
-    "lint": "eslint .",
-    "format": "prettier --write \"src/**/*.{js,jsx,css}\" \"e2e/**/*.{js,mjs}\" \"*.js\"",
-    "format:check": "prettier --check \"src/**/*.{js,jsx,css}\" \"e2e/**/*.{js,mjs}\" \"*.js\"",
-    "preview": "vite preview",
-    "test:e2e": "playwright test",
-    "test:e2e:home-first": "playwright test e2e/knowledge.spec.js e2e/scenario-review-table.spec.js e2e/shared-project-design.spec.js e2e/export-approval-gate.spec.js e2e/home-workspace.spec.js e2e/workflow-navigation.spec.js e2e/contextual-next-action.spec.js e2e/use-case-review.spec.js e2e/review-inbox.spec.js e2e/automation-preview-consistency.spec.js e2e/multi-environment-execution.spec.js e2e/responsive-reflow.spec.js e2e/runs-reports-index.spec.js e2e/accessibility-navigation.spec.js",
-    "test:e2e:headed": "playwright test --headed"
-  },
-  "dependencies": {
-    "@react-oauth/google": "^0.13.5",
-    "firebase": "^12.17.1",
-    "lucide-react": "^1.32.0",
-    "react": "^19.2.8",
-    "react-dom": "^19.2.8"
-  },
-  "devDependencies": {
-    "@axe-core/playwright": "^4.13.0",
-    "@eslint/js": "^10.0.1",
-    "@playwright/test": "^1.62.1",
-    "@vitejs/plugin-react": "^6.0.5",
-    "dotenv": "^17.4.2",
-    "eslint": "^10.8.1",
-    "globals": "^17.11.0",
-    "jsonwebtoken": "^9.0.3",
-    "prettier": "^3.9.6",
-    "vite": "^8.2.1"
-  }
+	"name": "agentic-tc-ui",
+	"version": "0.1.0",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"dev": "vite",
+		"build": "vite build",
+		"lint": "eslint .",
+		"format": "prettier --write \"src/**/*.{js,jsx,css}\" \"e2e/**/*.{js,mjs}\" \"*.js\"",
+		"format:check": "prettier --check \"src/**/*.{js,jsx,css}\" \"e2e/**/*.{js,mjs}\" \"*.js\"",
+		"preview": "vite preview",
+		"test:e2e": "playwright test",
+		"test:e2e:home-first": "playwright test e2e/knowledge.spec.js e2e/scenario-review-table.spec.js e2e/shared-project-design.spec.js e2e/export-approval-gate.spec.js e2e/improve-tests.spec.js e2e/home-workspace.spec.js e2e/workflow-navigation.spec.js e2e/contextual-next-action.spec.js e2e/use-case-review.spec.js e2e/review-inbox.spec.js e2e/automation-preview-consistency.spec.js e2e/multi-environment-execution.spec.js e2e/responsive-reflow.spec.js e2e/runs-reports-index.spec.js e2e/accessibility-navigation.spec.js",
+		"test:e2e:headed": "playwright test --headed"
+	},
+	"dependencies": {
+		"@react-oauth/google": "^0.13.5",
+		"firebase": "^12.17.1",
+		"lucide-react": "^1.32.0",
+		"react": "^19.2.8",
+		"react-dom": "^19.2.8"
+	},
+	"devDependencies": {
+		"@axe-core/playwright": "^4.13.0",
+		"@eslint/js": "^10.0.1",
+		"@playwright/test": "^1.62.1",
+		"@vitejs/plugin-react": "^6.0.5",
+		"dotenv": "^17.4.2",
+		"eslint": "^10.8.1",
+		"globals": "^17.11.0",
+		"jsonwebtoken": "^9.0.3",
+		"prettier": "^3.9.6",
+		"vite": "^8.2.1"
+	}
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,7 +6,8 @@ import { Button, Link, Radio, Field, Input, Select, Textarea } from "./component
 import { TabList, Tab, TabPanel } from "./components/ui/tabs";
 import { TableScroll, Table, List, ListItem, CollectionState } from "./components/ui/collections";
 import ProjectPageHeader from "./components/layout/ProjectPageHeader";
-import TestCaseQualitySummary from "./components/generation/TestCaseQualitySummary";
+import ImproveTestsPanel from "./components/generation/ImproveTestsPanel";
+import { improvementFindings } from "./components/generation/improvementFindings";
 import { useEffect, useRef, useState } from "react";
 import { onAuthStateChanged, signInWithPopup, signOut } from "firebase/auth";
 import GlobalAppShell from "./app/GlobalAppShell";
@@ -657,6 +658,24 @@ export default function App() {
 		!isApplyingImpactUpdate
 	);
 	const requirementReviewMeta = getReviewScoreMeta(requirementReview);
+	const [selectedTestCaseId, setSelectedTestCaseId] = useState(null);
+	const [improvementReload, setImprovementReload] = useState(0);
+	const sourceCaseSnapshot = `${currentProjectId}:${currentProject?.current_snapshots?.test_cases?.snapshot_id || "draft"}`;
+	const focusResultContent = useRef(false);
+	useEffect(() => {
+		setSelectedTestCaseId(null);
+	}, [sourceCaseSnapshot]);
+	useEffect(() => {
+		if (focusResultContent.current) {
+			document.getElementById("generate-result-panel")?.focus();
+			focusResultContent.current = false;
+		}
+	}, [activeGenerateResultTab]);
+	const openCaseResults = (id = null) => {
+		setSelectedTestCaseId(id);
+		focusResultContent.current = true;
+		setActiveGenerateResultTab("test-cases");
+	};
 	const testCaseReviewMeta = getReviewScoreMeta(testCaseReview);
 	const requirementSourceMetricMeta = getRequirementSourceMetricMeta(requirementCoverageMetrics);
 	const requirementReportStats = [
@@ -750,6 +769,7 @@ export default function App() {
 	const requirementReportDetailCount = requirementBlockingIssues.length + requirementWarnings.length + requirementParserFailures.length;
 
 	const chooseGenerateResultTab = (data) => {
+		if (data?.review?.approved === false) return "improve";
 		const metrics = data?.coverage_metrics || null;
 		if ((metrics?.requirements_without_tests || []).length > 0) {
 			return "traceability";
@@ -1479,9 +1499,7 @@ export default function App() {
 		setTestCaseIterationHistory(generationPayload.iteration_history || []);
 		setImpactAnalysis(impactPayload || generationPayload.impact_analysis || null);
 		setImpactUpdateMessage("");
-		setActiveGenerateResultTab(
-			(generationPayload.test_cases || []).length ? chooseGenerateResultTab(hydratedGenerationPayload) : "test-cases"
-		);
+		setActiveGenerateResultTab(chooseGenerateResultTab(hydratedGenerationPayload));
 		resetExportWorkflowState();
 		setExportMessage("");
 
@@ -3140,7 +3158,8 @@ export default function App() {
 		}
 	};
 
-	const generateTestCases = async (withFeedback = false, { fullRegeneration = false } = {}) => {
+	const generateTestCases = async (withFeedback = false, { fullRegeneration = false, feedbackText = feedback } = {}) => {
+		if (withFeedback && (testCaseActionDisabled || isGenerating || upstreamChangedForImpact || !testCases.length)) return false;
 		if (testCaseWorkflowLocked) {
 			const contactEmail = billingEntitlements?.account?.support_contact_email || "hello@spica-digital.eu";
 			setStatus(`Test-case workflows are locked. Contact ${contactEmail} to upgrade.`);
@@ -3208,7 +3227,7 @@ export default function App() {
 				? {
 						...sharedPayload,
 						test_cases: testCases,
-						feedback: feedback.trim(),
+						feedback: feedbackText.trim(),
 					}
 				: {
 						...sharedPayload,
@@ -3226,12 +3245,14 @@ export default function App() {
 			});
 			if (!res.ok) {
 				const errorMessage = await parseApiError(res, "Failed to generate test cases");
-				throw new Error(errorMessage);
+				throw Object.assign(new Error(errorMessage), { status: res.status });
 			}
 			const data = await res.json();
 			if (!isProjectOperationCurrent(operationScope)) {
 				return false;
 			}
+			if (withFeedback && (!Array.isArray(data.test_cases) || !data.test_cases.length))
+				throw new Error("No updated test cases were returned. Your current suite has been kept.");
 			rememberGeneration("test_cases", data);
 			setTestCases(data.test_cases || []);
 			setRequirementAnalysis(data.requirement_analysis || []);
@@ -3241,7 +3262,7 @@ export default function App() {
 			setTestCaseWorkflowDiagnostics(data.workflow_diagnostics || null);
 			setAppliedTestCaseWorkflowSettings(data.workflow_settings || null);
 			setTestCaseIterationHistory(data.iteration_history || []);
-			setActiveGenerateResultTab(chooseGenerateResultTab(data));
+			setActiveGenerateResultTab(withFeedback ? "improve" : chooseGenerateResultTab(data));
 			setDraftExportOverrideRequested(false);
 			setDraftExportOverrideReason("");
 			resetExecutionWorkflowState();
@@ -3264,11 +3285,15 @@ export default function App() {
 			setStatus(
 				`${withFeedback ? "Test cases refined" : fullRegeneration ? "Regenerated" : "Generated"}${generatedCount ? ` ${generatedCount} test case${generatedCount === 1 ? "" : "s"}` : ""} from ${requirementsForGeneration.length} approved requirement${requirementsForGeneration.length === 1 ? "" : "s"}.${reviewStatus}`.trim()
 			);
-			if (withFeedback) setFeedback("");
+			if (withFeedback) {
+				setFeedback("");
+				setActiveGenerateResultTab("improve");
+			}
 			return true;
 		} catch (error) {
 			if (isProjectOperationCurrent(operationScope)) {
 				setStatus(`Generation failed: ${error.message}`);
+				if (withFeedback) throw error;
 			}
 			return false;
 		} finally {
@@ -3592,6 +3617,12 @@ export default function App() {
 			label: "Traceability Matrix",
 			badge: approvedRequirements.length ? `${tracedRequirementCount}/${approvedRequirements.length}` : "—",
 			variant: traceabilityGapCount > 0 ? "warning" : tracedRequirementCount > 0 ? "success" : "muted",
+		},
+		{
+			id: "improve",
+			label: "Improve tests",
+			badge: improvementFindings(testCaseReview).length,
+			variant: testCaseReview?.approved === false ? "warning" : "muted",
 		},
 	];
 
@@ -4845,7 +4876,11 @@ export default function App() {
 											<p className="test-suite-summary">
 												{testCases.length} test cases · {approvedRequirementCount} approved requirements
 											</p>
-											<TestCaseQualitySummary review={testCaseReview} meta={testCaseReviewMeta} exportLocked={exportGateLocked} />
+											<p className="test-export-status">
+												{exportGateLocked
+													? "Export is blocked until the quality gate is met or an explicit draft override is provided."
+													: "Export remains subject to the review and export controls."}
+											</p>
 
 											{hasGenerateResults ? (
 												<div className="generate-results-workspace">
@@ -4884,6 +4919,51 @@ export default function App() {
 														role="tabpanel"
 														aria-label={generateResultTabs.find((tab) => tab.id === activeGenerateResultTab)?.label || "Generation result"}
 													>
+														<div hidden={activeGenerateResultTab !== "improve"}>
+															<ImproveTestsPanel
+																key={`${sourceCaseSnapshot}:${improvementReload}`}
+																review={testCaseReview}
+																meta={testCaseReviewMeta}
+																testCases={testCases}
+																busy={isGenerating}
+																disabled={
+																	testCaseActionDisabled ||
+																	upstreamChangedForImpact ||
+																	!canGenerateFromApprovedRequirements ||
+																	!testCases.length
+																}
+																stale={upstreamChangedForImpact}
+																blockedReason={
+																	upstreamChangedForImpact
+																		? "Upstream inputs changed. Review their impact before applying fixes."
+																		: !testCases.length
+																			? "Generate test cases before applying improvements."
+																			: !canGenerateFromApprovedRequirements
+																				? "Approve requirements before applying fixes."
+																				: testCaseActionDisabled
+																					? "Refinement is unavailable while another operation is running or your account is restricted."
+																					: ""
+																}
+																onImpact={() => {
+																	setActiveGenerateResultTab("test-cases");
+																	document.querySelector(".generation-gate-card")?.scrollIntoView({ block: "center" });
+																}}
+																onApply={(feedbackText) => generateTestCases(true, { feedbackText })}
+																onReload={async () => {
+																	const project = await refreshCurrentProject({
+																		hydrate: true,
+																		operationScope: captureProjectOperationScope(),
+																	});
+																	if (project) {
+																		setImprovementReload((value) => value + 1);
+																		setActiveGenerateResultTab("improve");
+																	}
+																	return Boolean(project);
+																}}
+																onViewCase={openCaseResults}
+																onReviewCases={() => openCaseResults()}
+															/>
+														</div>
 														{activeGenerateResultTab === "traceability" && (
 															<TraceabilityMatrixPanel
 																approvedRequirements={approvedRequirements}
@@ -4901,12 +4981,8 @@ export default function App() {
 																<GeneratedTestCasesView
 																	testCases={testCases}
 																	qualityIssues={testCaseReview?.blocking_issues || []}
-																	feedback={feedback}
-																	onFeedbackChange={setFeedback}
-																	onRefineTestCases={() => generateTestCases(true)}
-																	isGenerating={isGenerating}
-																	testCaseActionDisabled={testCaseActionDisabled}
-																	allowRefinement={allowLegacyTestCaseMutations}
+																	selectedId={selectedTestCaseId}
+																	setSelectedId={setSelectedTestCaseId}
 																/>
 															</>
 														)}

--- a/frontend/src/components/generation/GeneratedTestCasesView.jsx
+++ b/frontend/src/components/generation/GeneratedTestCasesView.jsx
@@ -1,24 +1,13 @@
 import { Table, TableScroll, ListDetail, ResultCount, List, SelectableItem, ListItem, CollectionState } from "../ui/collections";
-import { Input, Button, Textarea } from "../ui/controls";
+import { Input, Button } from "../ui/controls";
 import { Disclosure, Badge } from "../ui/surfaces";
 import { useId, useState } from "react";
 import { ChevronRight } from "lucide-react";
 import { getTestCaseLinkedRequirementIds } from "../../utils/requirements";
 
-export default function GeneratedTestCasesView({
-	testCases,
-	feedback,
-	onFeedbackChange,
-	onRefineTestCases,
-	isGenerating,
-	testCaseActionDisabled,
-	allowRefinement = true,
-	qualityIssues = [],
-}) {
-	const [selectedId, setSelectedId] = useState(null);
+export default function GeneratedTestCasesView({ testCases, selectedId, setSelectedId, qualityIssues = [] }) {
 	const [query, setQuery] = useState("");
 	const searchId = useId();
-	const feedbackId = useId();
 	const cases = testCases.filter((tc) =>
 		[tc.id, tc.title, ...getTestCaseLinkedRequirementIds(tc)].join(" ").toLowerCase().includes(query.toLowerCase().trim())
 	);
@@ -166,23 +155,6 @@ export default function GeneratedTestCasesView({
 					)}
 				</section>
 			</ListDetail>
-			{testCases.length > 0 && allowRefinement && (
-				<section className="feedback-section">
-					<h3>Human Feedback</h3>
-					<label htmlFor={feedbackId}>Changes to the test suite</label>
-					<Textarea
-						id={feedbackId}
-						className="feedback-textarea"
-						placeholder="Describe the changes needed…"
-						value={feedback}
-						onChange={(event) => onFeedbackChange(event.target.value)}
-						rows={4}
-					/>
-					<Button onClick={onRefineTestCases} disabled={!feedback.trim() || isGenerating || testCaseActionDisabled}>
-						{isGenerating ? "Updating test cases…" : "Implement Changes"}
-					</Button>
-				</section>
-			)}
 		</>
 	);
 }

--- a/frontend/src/components/generation/ImproveTestsPanel.jsx
+++ b/frontend/src/components/generation/ImproveTestsPanel.jsx
@@ -1,0 +1,147 @@
+import { useId, useState } from "react";
+import { Button, Checkbox, Textarea } from "../ui/controls";
+import { improvementFindings, findingCaseIds, improvementFeedback } from "./improvementFindings";
+
+export default function ImproveTestsPanel({
+	review,
+	meta,
+	testCases,
+	busy,
+	disabled,
+	blockedReason,
+	stale,
+	onImpact,
+	onApply,
+	onReload,
+	onViewCase,
+	onReviewCases,
+}) {
+	const findings = improvementFindings(review);
+	const [selected, setSelected] = useState([]);
+	const [instructions, setInstructions] = useState("");
+	const [error, setError] = useState("");
+	const [conflict, setConflict] = useState(false);
+	const [reloading, setReloading] = useState(false);
+	const [saved, setSaved] = useState(false);
+	const instructionsId = useId();
+	const locked = busy || disabled || conflict || reloading;
+	const chosen = findings.filter((finding) => selected.includes(finding));
+	const canApply = !locked && testCases.length > 0 && (findings.length ? chosen.length > 0 : Boolean(instructions.trim()));
+	const apply = async () => {
+		if (!canApply) return;
+		setError("");
+		setSaved(false);
+		try {
+			if (await onApply(improvementFeedback(chosen, instructions))) {
+				setSelected([]);
+				setInstructions("");
+				setSaved(true);
+			}
+		} catch (failure) {
+			setConflict(failure.status === 409);
+			setError(
+				failure.status === 409
+					? "The project changed. Reload the current findings before applying fixes."
+					: failure.message || "The fixes could not be applied. Your selections and instructions are kept."
+			);
+		}
+	};
+	return (
+		<section className="improve-tests" aria-label="Improve test quality">
+			<h2>{review?.approved ? "Machine quality check passed" : review ? "What needs fixing" : "Review your test cases"}</h2>
+			<p>{review?.summary || "Describe the improvements you want to make to this test suite."}</p>
+			{review && (
+				<p className="helper-text">
+					{meta.scoreLabel}
+					{meta.thresholdLabel ? ` · ${meta.thresholdLabel.replace("Approval threshold", "Required score")}` : ""}
+				</p>
+			)}
+			{review?.approved && (
+				<>
+					<p>This machine check does not replace your review.</p>
+					<Button variant="secondary" onClick={onReviewCases}>
+						Review test cases
+					</Button>
+				</>
+			)}
+			{blockedReason && <p role="status">{blockedReason}</p>}
+			{stale && (
+				<Button variant="secondary" onClick={onImpact}>
+					Review impact
+				</Button>
+			)}
+			{error && (
+				<div role="alert">
+					<p>{error}</p>
+					{conflict && (
+						<Button
+							disabled={reloading || busy}
+							onClick={async () => {
+								setReloading(true);
+								try {
+									if (await onReload()) {
+										setConflict(false);
+										setError("");
+										setSelected([]);
+										setInstructions("");
+									} else setError("The project could not be reloaded. Try reloading again before applying fixes.");
+								} finally {
+									setReloading(false);
+								}
+							}}
+						>
+							Reload current findings
+						</Button>
+					)}
+				</div>
+			)}
+			{saved && <p role="status">Test cases updated. Review the latest quality result and remaining findings.</p>}
+			{findings.length > 0 && (
+				<fieldset disabled={locked} className="improve-tests-findings">
+					<legend>Select findings to address</legend>
+					<div className="button-row">
+						<Button variant="secondary" onClick={() => setSelected(findings)}>
+							Select all
+						</Button>
+						<Button variant="secondary" onClick={() => setSelected([])}>
+							Clear selection
+						</Button>
+					</div>
+					{findings.map((finding) => (
+						<div key={finding} className="improve-tests-finding">
+							<label>
+								<Checkbox
+									checked={selected.includes(finding)}
+									onChange={(event) =>
+										setSelected((previous) => (event.target.checked ? [...previous, finding] : previous.filter((item) => item !== finding)))
+									}
+								/>{" "}
+								<span>{finding}</span>
+							</label>
+							{findingCaseIds(finding, testCases).map((id) => (
+								<Button key={id} variant="secondary" size="compact" onClick={() => onViewCase(id)} aria-label={`View test case ${id}`}>
+									View test case {id}
+								</Button>
+							))}
+						</div>
+					))}
+				</fieldset>
+			)}
+			<label htmlFor={instructionsId}>Additional instructions (optional)</label>
+			<Textarea
+				id={instructionsId}
+				value={instructions}
+				onChange={(event) => setInstructions(event.target.value)}
+				disabled={locked}
+				rows={4}
+				placeholder="Describe any details the fixes should take into account…"
+			/>
+			<div className="button-row improve-tests-actions">
+				<Button disabled={!canApply} onClick={() => void apply()}>
+					{busy ? "Applying fixes…" : findings.length ? "Apply selected fixes" : "Apply improvements"}
+				</Button>
+				<span>{chosen.length} selected</span>
+			</div>
+		</section>
+	);
+}

--- a/frontend/src/components/generation/improvementFindings.js
+++ b/frontend/src/components/generation/improvementFindings.js
@@ -1,0 +1,19 @@
+export function improvementFindings(review) {
+	return [
+		...new Set([...(review?.blocking_issues || []), ...(review?.unmet_criteria || [])].map((item) => String(item).trim()).filter(Boolean)),
+	];
+}
+export function findingCaseIds(finding, testCases) {
+	return testCases
+		.filter(({ id }) => id && new RegExp(`(?<![\\w-])${id.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}(?![\\w-])`).test(finding))
+		.map(({ id }) => id);
+}
+export function improvementFeedback(findings, instructions) {
+	return [
+		"Address the requested fixes below. Preserve unrelated test cases and their IDs where possible.",
+		findings.length ? `Selected findings:\n${findings.map((finding) => `- ${finding}`).join("\n")}` : "",
+		instructions.trim() ? `Additional instructions:\n${instructions.trim()}` : "",
+	]
+		.filter(Boolean)
+		.join("\n\n");
+}

--- a/frontend/src/styles/generation-results.css
+++ b/frontend/src/styles/generation-results.css
@@ -701,3 +701,57 @@ button.small {
 	margin-top: 0;
 	margin-bottom: 0.75rem;
 }
+
+.improve-tests {
+	max-width: 960px;
+	padding-block: var(--space-4);
+}
+.improve-tests h2 {
+	font-size: 24px;
+	margin-top: 0;
+}
+.improve-tests p {
+	max-width: 70ch;
+}
+.improve-tests-findings {
+	border: 0;
+	padding: 0;
+	margin-block: var(--space-5);
+	min-width: 0;
+}
+.improve-tests-findings legend {
+	font-weight: 700;
+	margin-bottom: var(--space-3);
+}
+.improve-tests-finding {
+	padding-block: var(--space-3);
+	border-bottom: 1px solid var(--border-color);
+}
+.improve-tests-finding label {
+	display: flex;
+	gap: var(--space-3);
+	align-items: flex-start;
+	overflow-wrap: anywhere;
+}
+.improve-tests-finding input {
+	flex-shrink: 0;
+}
+.improve-tests-finding button {
+	margin: var(--space-2) var(--space-2) 0 30px;
+}
+.improve-tests textarea {
+	margin-top: var(--space-2);
+}
+.improve-tests-actions {
+	margin-top: var(--space-4);
+	align-items: center;
+}
+.test-export-status {
+	color: var(--text-muted);
+}
+
+.improve-tests .button-row {
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--space-2);
+}


### PR DESCRIPTION
## Summary
Replace the passive Needs refinement box with an actionable Improve tests tab. Users select deduplicated findings, optionally add instructions, and submit explicit feedback through the existing refinement endpoint. Failed machine checks open the tab automatically; linked case IDs open the matching case.

Preserve drafts on failure, require reload after revision conflicts, and block stale suites through impact review. Successful updates show the latest findings and clear submitted drafts. Export safeguards remain unchanged; passing machine quality is distinct from human approval. No backend/API/schema changes or Diagnostics/Generation Summary restoration.

Closes #290. Parent epic #241.

## Validation
- Frontend build, lint, and full formatting check passed.
- 10 focused Improve tests browser tests passed, including exact feedback, selection controls, navigation/focus, busy state, failures, conflict/reload, stale-suite blocking, snapshot resets, and desktop/mobile accessibility.
- 28 shared-layout, export approval, and orchestrator lifecycle browser tests passed.
- Desktop/mobile screenshots inspected; new suite included in focused CI command.
- Build retains the existing bundle-size warning. AI responses are mocked in browser tests; no paid live generation was run.
