### PR TITLE
Remove Next task pane from Test Cases

### DIFF
--- a/docs/github-issues-backlog.md
+++ b/docs/github-issues-backlog.md
@@ -1,5 +1,7 @@
 # GitHub Issue Backlog for Test Case Engine Improvements
 
+- Implemented; PR review pending: #292 — Remove the Next task pane from Test Cases; retain Overview and compact guarded workflow controls. Parent #241.
+
 - Implemented; PR review pending: #290 — Actionable Improve tests tab with selected findings, refinement, case navigation, and revision/impact safeguards. Parent #241; follows merged #284/#286/#288. Validation: build, lint, formatting, and 38 focused refinement, layout, export, and lifecycle browser tests pass.
 
 - Implemented; PR review pending: #288 — Remove the Test Cases Diagnostics / Generation Summary tab entirely; retain Generated Test Cases and Traceability Matrix. Parent #241; stacked on PR #287. Build, lint, changed-file formatting and 27 focused browser tests passed.

--- a/docs/project-design.md
+++ b/docs/project-design.md
@@ -140,3 +140,7 @@ Improve tests shows the review summary, secondary quality/required scores, and d
 Draft selections survive tab changes and failures, but reset when the project or test-case source snapshot changes. Revision conflicts require reloading current findings before resubmission. Stale suites direct users to impact review. Authentication, billing, busy-state and revision checks remain enforced, including when project recommendations are present. Successful refinement stays on Improve tests, clears submitted drafts and displays the latest review. Passing machine quality never represents human approval. A compact export-status message remains above the tabs and existing export protections remain unchanged.
 
 Validation: `e2e/improve-tests.spec.js` covers checklist feedback, navigation/focus, retry, conflict, stale-suite guards, busy states, snapshot reset and desktop/mobile accessibility. Export and shared-layout regression tests cover the surrounding workflow.
+
+## Test Cases task controls (#292)
+
+Next task remains on Overview. Test Cases omits the task card, recommendation narrative and technical details. Compact workflow controls retain generation and impact actions, with optional actions under More actions and the existing regeneration confirmation, busy-state and approval safeguards. Template Setup continues to hide these controls.

--- a/frontend/e2e/contextual-next-action.spec.js
+++ b/frontend/e2e/contextual-next-action.spec.js
@@ -334,43 +334,52 @@ async function openTestCases(page) {
 }
 
 test.describe("Contextual next task", () => {
-	test("shows one scoped primary task, keeps provenance and rare actions in Details, and renders no unrelated or empty billboard", async ({
-		page,
-	}) => {
+	test("shows compact suite controls without the Next task pane or technical details", async ({ page }) => {
 		const scenario = { project: projectFixture(), status: statusFixture(staleActions()) };
 		await installApi(page, scenario);
 		await openTestCases(page);
 
-		const task = page.getByLabel("Contextual task");
+		const task = page.getByLabel("Test suite actions");
 		const reason = "Changed requirements should be compared with the current suite.";
-		await expect(task.getByRole("heading", { name: /^Analyze Impact$/i })).toBeVisible();
-		await expect(task.getByText(reason, { exact: true })).toHaveCount(1);
+		await expect(task.getByRole("button", { name: /^Start analysis$/i })).toBeVisible();
+		await expect(page.getByText("Next task", { exact: true })).toHaveCount(0);
+		await expect(task.getByText(reason, { exact: true })).toHaveCount(0);
 		await expect(task.locator(".contextual-task-controls > button")).toHaveCount(1);
 		await expect(task.getByText(/contract 1\.0/i)).not.toBeVisible();
 		await expect(task.getByRole("button", { name: /^Full Regenerate$/i })).toHaveCount(0);
 
-		await task.getByText(/^Details$/i).click();
-		await expect(task.getByText(/Based on Requirements v2 and Use Cases v1/i)).toBeVisible();
-		await expect(task.getByText(/Requirements: snap-req-v2/i)).toBeVisible();
-		await expect(task.getByText(/Use Cases: snap-use-v1/i)).toBeVisible();
-		await expect(task.getByText(/Impact · contract 1\.0 · local/i)).toBeVisible();
+		await task
+			.locator("summary")
+			.filter({ hasText: /^More actions$/i })
+			.click();
+		await expect(task.getByText(/Based on Requirements v2 and Use Cases v1/i)).toHaveCount(0);
+		await expect(task.getByText(/Requirements: snap-req-v2/i)).toHaveCount(0);
+		await expect(task.getByText(/Use Cases: snap-use-v1/i)).toHaveCount(0);
+		await expect(task.getByText(/Impact · contract 1\.0 · local/i)).toHaveCount(0);
 		await expect(task.getByRole("button", { name: /^Full Regenerate$/i })).toBeVisible();
 		await expect(task.getByRole("button", { name: /^Review Existing Evidence$/i })).toBeVisible();
+		await page.setViewportSize({ width: 390, height: 844 });
+		await expect.poll(() => page.evaluate(() => document.documentElement.scrollWidth <= innerWidth)).toBe(true);
+		await expect(task.getByRole("button", { name: /^Start analysis$/i })).toBeVisible();
+		await page.setViewportSize({ width: 1488, height: 900 });
 		await expect(page.getByRole("button", { name: /Full Regenerate from/i })).toHaveCount(0);
 
+		await page.goto(buildProjectPath(PROJECT_ID, "overview"));
+		await expect(page.getByLabel("Contextual task")).toBeVisible();
+		await expect(page.getByText("Next task", { exact: true })).toBeVisible();
 		for (const destination of ["context", "automation", "reports"]) {
 			await page.goto(buildProjectPath(PROJECT_ID, destination));
-			await expect(page.getByLabel("Contextual task")).toHaveCount(0);
+			await expect(page.getByLabel("Test suite actions")).toHaveCount(0);
 		}
 
 		await page.goto(buildProjectPath(PROJECT_ID, "test-cases"));
 		await page.getByRole("button", { name: /^Template setup$/i }).click();
-		await expect(page.getByLabel("Contextual task")).toHaveCount(0);
+		await expect(page.getByLabel("Test suite actions")).toHaveCount(0);
 
 		scenario.status = statusFixture([]);
 		await page.getByRole("button", { name: /^Generate and review$/i }).click();
 		await page.reload();
-		await expect(page.getByLabel("Contextual task")).toHaveCount(0);
+		await expect(page.getByLabel("Test suite actions")).toHaveCount(0);
 		await expect(page.getByRole("button", { name: /Analyze Impact for/i })).toBeVisible();
 
 		scenario.status = statusFixture([
@@ -384,9 +393,12 @@ test.describe("Contextual next task", () => {
 			}),
 		]);
 		await page.reload();
-		const safeTask = page.getByLabel("Contextual task");
-		await expect(safeTask.getByRole("heading", { name: /^Analyze Impact$/i })).toBeVisible();
-		await safeTask.getByText(/^Details$/i).click();
+		const safeTask = page.getByLabel("Test suite actions");
+		await expect(safeTask.getByRole("button", { name: /^Start analysis$/i })).toBeVisible();
+		await safeTask
+			.locator("summary")
+			.filter({ hasText: /^More actions$/i })
+			.click();
 		await expect(safeTask.getByRole("button", { name: /^Full Regenerate$/i })).toBeVisible();
 
 		scenario.project.stage_state.test_cases.stale = false;
@@ -398,7 +410,7 @@ test.describe("Contextual next task", () => {
 		scenario.status.stages.test_cases.status = "completed";
 		scenario.status.stages.test_cases.stale = false;
 		await page.reload();
-		await expect(page.getByLabel("Contextual task")).toHaveCount(0);
+		await expect(page.getByLabel("Test suite actions")).toHaveCount(0);
 		await expect(page.getByRole("button", { name: /Generate from \d+ Approved/i })).toHaveCount(0);
 	});
 
@@ -416,7 +428,7 @@ test.describe("Contextual next task", () => {
 		const requests = await installApi(page, scenario);
 		await openTestCases(page);
 
-		const task = page.getByLabel("Contextual task");
+		const task = page.getByLabel("Test suite actions");
 		const actionButton = task.getByRole("button", { name: /^Start generation$/i });
 		await expect(actionButton).toBeDisabled();
 		await expect(task.getByText(blocker, { exact: true })).toHaveCount(1);
@@ -468,11 +480,14 @@ test.describe("Contextual next task", () => {
 		const requests = await installApi(page, scenario);
 		await openTestCases(page);
 
-		const optionalTask = page.getByLabel("Contextual task");
+		const optionalTask = page.getByLabel("Test suite actions");
 		await page.getByText("More actions", { exact: true }).first().click();
-		await expect(optionalTask.getByRole("heading", { name: /^Optional test suite actions$/i })).toBeVisible();
+		await expect(optionalTask.getByRole("heading")).toHaveCount(0);
 		await expect(optionalTask.locator(".contextual-task-controls > button")).toHaveCount(0);
-		await optionalTask.getByText(/^Details$/i).click();
+		await optionalTask
+			.locator("summary")
+			.filter({ hasText: /^More actions$/i })
+			.click();
 		await expect(optionalTask.getByRole("button", { name: /^Full Regenerate$/i })).toBeVisible();
 		await expect(page.getByRole("button", { name: /Generate from \d+ Approved/i })).toHaveCount(0);
 		expect(requests.generation).toBe(0);
@@ -508,8 +523,11 @@ test.describe("Contextual next task", () => {
 		const newCaseRow = page.getByRole("button", { name: new RegExp(NEW_CASE_TITLE, "i") });
 		await expect(oldCaseRow).toBeVisible();
 
-		const task = page.getByLabel("Contextual task");
-		await task.getByText(/^Details$/i).click();
+		const task = page.getByLabel("Test suite actions");
+		await task
+			.locator("summary")
+			.filter({ hasText: /^More actions$/i })
+			.click();
 		const regenerate = task.getByRole("button", { name: /^Full Regenerate$/i });
 		await regenerate.click();
 		let dialog = page.getByRole("dialog", { name: /Regenerate the entire test suite/i });
@@ -542,7 +560,7 @@ test.describe("Contextual next task", () => {
 
 		releaseGeneration();
 		await expect(dialog).toHaveCount(0);
-		await expect(page.getByLabel("Contextual task")).toHaveCount(0);
+		await expect(page.getByLabel("Test suite actions")).toHaveCount(0);
 		await expect(page.getByRole("main", { name: "Workflow workspace: Test Cases" })).toBeFocused();
 		await expect(newCaseRow).toBeVisible();
 		await expect(oldCaseRow).toHaveCount(0);
@@ -558,8 +576,11 @@ test.describe("Contextual next task", () => {
 		const requests = await installApi(page, scenario);
 		await openTestCases(page);
 
-		const task = page.getByLabel("Contextual task");
-		await task.getByText(/^Details$/i).click();
+		const task = page.getByLabel("Test suite actions");
+		await task
+			.locator("summary")
+			.filter({ hasText: /^More actions$/i })
+			.click();
 		await task.getByRole("button", { name: /^Full Regenerate$/i }).click();
 		const dialog = page.getByRole("dialog", { name: /Regenerate the entire test suite/i });
 		await dialog.getByRole("button", { name: /^Confirm regeneration$/i }).click();

--- a/frontend/e2e/impact-update-flow.spec.js
+++ b/frontend/e2e/impact-update-flow.spec.js
@@ -487,8 +487,7 @@ test.describe("Impact update flow", () => {
 		await expect(page.getByRole("button", { name: "Open QA project menu" })).toContainText("Impact QA");
 		await expect(page.getByRole("button", { name: "Open QA project menu" })).toContainText("revision 5");
 
-		const task = page.getByLabel("Contextual task");
-		await expect(task.getByRole("heading", { name: /^Analyze Impact$/i })).toBeVisible();
+		const task = page.getByLabel("Test suite actions");
 		await expect(task.getByRole("button", { name: /^Start analysis$/i })).toBeVisible();
 		await expect(page.getByRole("button", { name: /Full Regenerate from 10 Approved/i })).toHaveCount(0);
 

--- a/frontend/e2e/orchestrator-cockpit.spec.js
+++ b/frontend/e2e/orchestrator-cockpit.spec.js
@@ -433,11 +433,10 @@ test.describe("Contextual task and project evidence", () => {
 		await page.goto(projectPath);
 		await expect(page).toHaveURL(projectPath);
 
-		const task = page.getByLabel("Contextual task");
+		const task = page.getByLabel("Test suite actions");
 		await expect(task).toBeVisible({ timeout: 30_000 });
 		await expect(page.getByLabel("Project information rail")).toHaveCount(0);
 		await expect(page.getByText(/^Operational status$/i)).toHaveCount(0);
-		await expect(task.getByRole("heading", { name: /^Generate Test Cases$/i })).toBeVisible();
 		await expect(task.getByRole("button", { name: /^Start generation$/i })).toBeVisible();
 		await expect(task.getByText(/Analyze Impact/i)).toHaveCount(0);
 	});
@@ -460,14 +459,16 @@ test.describe("Contextual task and project evidence", () => {
 		await page.goto(projectPath);
 		await expect(page).toHaveURL(projectPath);
 
-		const task = page.getByLabel("Contextual task");
+		const task = page.getByLabel("Test suite actions");
 		await expect(task).toBeVisible({ timeout: 30_000 });
 		await expect(page.getByLabel("Project information rail")).toHaveCount(0);
 		await expect(page.getByRole("button", { name: /^Refresh status$/i })).toHaveCount(0);
-		await expect(task.getByRole("heading", { name: /^Analyze Impact$/i })).toBeVisible();
 		await expect(task.getByRole("button", { name: /^Start analysis$/i })).toBeVisible();
 		await expect(task.getByRole("button", { name: /^Full Regenerate$/i })).toHaveCount(0);
-		await task.getByText(/^Details$/i).click();
+		await task
+			.locator("summary")
+			.filter({ hasText: /^More actions$/i })
+			.click();
 		await expect(task.getByRole("button", { name: /^Full Regenerate$/i })).toBeVisible();
 		await page.reload();
 		await expect(page).toHaveURL(projectPath);
@@ -476,7 +477,6 @@ test.describe("Contextual task and project evidence", () => {
 		await expect(task.getByRole("button", { name: /^Start analysis$/i })).toBeVisible();
 
 		await task.getByRole("button", { name: /^Start analysis$/i }).click();
-		await expect(task.getByRole("heading", { name: /^Apply Accepted Updates$/i })).toBeVisible();
 		await expect(task.getByRole("button", { name: /^Apply accepted changes$/i })).toBeVisible();
 	});
 });

--- a/frontend/e2e/orchestrator-lifecycle.spec.js
+++ b/frontend/e2e/orchestrator-lifecycle.spec.js
@@ -671,9 +671,8 @@ test.describe("Orchestrator lifecycle validation", () => {
 			.getByRole("navigation", { name: "Project navigation" })
 			.getByRole("link", { name: /^Test Cases,/i })
 			.click();
-		await expect(page.getByLabel("Contextual task").getByRole("heading", { name: /^Generate First Test Suite$/i })).toBeVisible();
 		await page
-			.getByLabel("Contextual task")
+			.getByLabel("Test suite actions")
 			.getByRole("button", { name: /^Start generation$/i })
 			.click();
 		await expect(page.locator(".test-suite-summary", { hasText: "10 test cases" })).toBeVisible({ timeout: 30_000 });
@@ -694,9 +693,8 @@ test.describe("Orchestrator lifecycle validation", () => {
 			.getByRole("navigation", { name: "Project navigation" })
 			.getByRole("link", { name: /^Test Cases,/i })
 			.click();
-		await expect(page.getByLabel("Contextual task").getByRole("heading", { name: /^Analyze Impact$/i })).toBeVisible();
 		await page
-			.getByLabel("Contextual task")
+			.getByLabel("Test suite actions")
 			.getByRole("button", { name: /^Start analysis$/i })
 			.click();
 		await expect(page.getByRole("heading", { name: /^Impact Analysis$/i })).toBeVisible();

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4128,6 +4128,7 @@ export default function App() {
 									status={orchestratorStatus}
 									currentDestination={route.destination}
 									hidden={route.destination === PROJECT_DESTINATIONS.TEST_CASES && activeTab === 2}
+									compact={route.destination === PROJECT_DESTINATIONS.TEST_CASES}
 									isLoading={isLoadingOrchestrator}
 									error={orchestratorError}
 									authActionDisabled={authActionDisabled}

--- a/frontend/src/components/projects/ContextualTaskCard.jsx
+++ b/frontend/src/components/projects/ContextualTaskCard.jsx
@@ -102,6 +102,7 @@ export default function ContextualTaskCard({
 	disabled = false,
 	disabledMap = {},
 	navigationOnly = false,
+	compact = false,
 	focusFallbackRef,
 	onAction,
 }) {
@@ -185,33 +186,40 @@ export default function ContextualTaskCard({
 	};
 
 	return (
-		<article className="contextual-task-card" aria-labelledby="contextual-task-title" aria-busy={hasPrimaryAction && isPrimaryBusy}>
-			<div className="contextual-task-copy">
-				<span className="contextual-task-kicker">{hasPrimaryAction ? "Next task" : "More actions"}</span>
-				<h2 id="contextual-task-title">{hasPrimaryAction ? actionLabel(action) : "Optional test suite actions"}</h2>
-				<p>{reason}</p>
-				{showSeparateBlocker ? (
-					<div className="contextual-task-blocker" role="note">
-						{blocker}
-					</div>
-				) : null}
-			</div>
+		<article
+			className={compact ? "test-suite-action-controls" : "contextual-task-card"}
+			aria-labelledby={compact ? undefined : "contextual-task-title"}
+			aria-busy={hasPrimaryAction && isPrimaryBusy}
+		>
+			{!compact && (
+				<div className="contextual-task-copy">
+					<span className="contextual-task-kicker">{hasPrimaryAction ? "Next task" : "More actions"}</span>
+					<h2 id="contextual-task-title">{hasPrimaryAction ? actionLabel(action) : "Optional test suite actions"}</h2>
+					<p>{reason}</p>
+					{showSeparateBlocker ? (
+						<div className="contextual-task-blocker" role="note">
+							{blocker}
+						</div>
+					) : null}
+				</div>
+			)}
+			{compact && blocker && <p role="note">{blocker}</p>}
 			<div className="contextual-task-controls">
 				{hasPrimaryAction ? (
 					<Button type="button" onClick={handlePrimaryAction} disabled={primaryDisabled}>
 						{isPrimaryBusy ? "Working…" : actionCtaLabel(action, navigationOnly)}
 					</Button>
 				) : null}
-				{hasDetails ? (
+				{(compact ? secondaryActions.length > 0 : hasDetails) ? (
 					<Disclosure className="contextual-task-details">
-						<summary>Details</summary>
+						<summary>{compact ? "More actions" : "Details"}</summary>
 						<div className="contextual-task-details-body">
-							{stage ? (
+							{!compact && stage ? (
 								<p>
 									<strong>Status</strong> {formatTaskLabel(action.stage)} · {formatTaskLabel(stage.status)}
 								</p>
 							) : null}
-							{provenanceLabel ? (
+							{!compact && provenanceLabel ? (
 								<div>
 									<p>
 										<strong>Sources</strong> {provenanceLabel}
@@ -229,7 +237,7 @@ export default function ContextualTaskCard({
 									) : null}
 								</div>
 							) : null}
-							{hasDiagnostics ? (
+							{!compact && hasDiagnostics ? (
 								<p className="contextual-task-diagnostics">
 									<strong>Diagnostics</strong> {formatTaskLabel(action.agent_kind)}
 									{action.agent_contract_version ? ` · contract ${action.agent_contract_version}` : ""}

--- a/frontend/src/components/projects/OrchestratorCockpitPanel.jsx
+++ b/frontend/src/components/projects/OrchestratorCockpitPanel.jsx
@@ -7,6 +7,7 @@ export default function OrchestratorCockpitPanel({
 	status,
 	currentDestination,
 	isOverview = false,
+	compact = false,
 	hidden = false,
 	isLoading,
 	error,
@@ -30,7 +31,7 @@ export default function OrchestratorCockpitPanel({
 	}
 
 	const content = (
-		<section className="contextual-task-region" aria-label="Contextual task">
+		<section className="contextual-task-region" aria-label={compact ? "Test suite actions" : "Contextual task"}>
 			{error ? (
 				<Alert as="div" tone="danger" className="orchestrator-error" role="alert">
 					{error}
@@ -45,6 +46,7 @@ export default function OrchestratorCockpitPanel({
 					disabled={authActionDisabled || isLoading}
 					disabledMap={actionDisabled || {}}
 					navigationOnly={isOverview}
+					compact={compact}
 					focusFallbackRef={focusFallbackRef}
 					onAction={onAction}
 				/>

--- a/frontend/src/styles/workflow.css
+++ b/frontend/src/styles/workflow.css
@@ -652,3 +652,13 @@
 	display: block;
 	margin-top: 0.15rem;
 }
+
+.test-suite-action-controls {
+	margin-bottom: var(--space-4);
+}
+.test-suite-action-controls .contextual-task-controls {
+	justify-content: flex-start;
+}
+.test-suite-action-controls .contextual-task-details-body {
+	box-sizing: border-box;
+}


### PR DESCRIPTION
## Summary
Remove the Next task card from Test Cases while keeping the Overview card unchanged. Retain its operational buttons as compact suite controls, with optional actions under More actions. Omit the recommendation narrative and technical details from Test Cases.

This preserves generation, impact analysis, blocked-action notices and the existing regeneration confirmation instead of leaving Overview workbench links without usable actions.

Closes #292. Parent epic #241.

## Validation
Frontend build, lint and formatting passed. Twenty focused browser tests cover Overview/Test Cases visibility, responsive controls, refinement/export safeguards, blocked actions, regeneration confirmation/retry and the full impact/lifecycle workflow. AI responses are mocked. The build retains its existing bundle-size warning.
