### PR TITLE
Route next tasks to the required review workbench

### DIFF
--- a/backend/app/services/orchestrator_service.py
+++ b/backend/app/services/orchestrator_service.py
@@ -476,37 +476,11 @@ def _build_actions(project: QaProjectDetail, *, has_baseline_test_suite: bool, u
             )
         ]
 
-    if has_baseline_test_suite and upstream_changed:
-        if impact_state and impact_state.current_snapshot_id and not impact_state.stale:
-            apply_blockers = _impact_apply_blockers(project)
-            actions.append(
-                _action(
-                    "apply_update",
-                    "Apply Accepted Updates",
-                    "test_cases",
-                    reason="Impact analysis is current; apply accepted update/add/deprecate recommendations to produce the next test-case snapshot.",
-                    primary=True,
-                    blockers=apply_blockers,
-                )
-            )
-        else:
-            actions.append(
-                _action(
-                    "analyze_impact",
-                    "Analyze Impact",
-                    "impact_analysis",
-                    reason="Upstream requirements/use cases changed after the baseline suite was generated.",
-                    primary=True,
-                )
-            )
-        actions.append(_full_regenerate_action(full_regenerate_blockers))
-        return actions
-
     if not requirements_state.approved or requirements_state.stale:
         actions.append(
             _action(
                 "approve",
-                "Approve Requirements",
+                "Review Requirements",
                 "requirements",
                 reason="Requirements must be approved before downstream updates are applied or exported.",
                 primary=True,
@@ -521,6 +495,70 @@ def _build_actions(project: QaProjectDetail, *, has_baseline_test_suite: bool, u
                 secondary=True,
             )
         )
+
+    elif use_cases_state and use_cases_state.current_snapshot_id and not use_cases_state.stale and not _use_cases_human_approved(use_cases_state):
+        latest_human_review = _matching_use_case_human_review(use_cases_state)
+        latest_review_comment = (
+            str(latest_human_review.get("comment") or "").strip()
+            if isinstance(latest_human_review, dict) and latest_human_review.get("decision") == "request_changes"
+            else ""
+        )
+        actions.append(
+            _action(
+                "approve",
+                "Review Use Cases",
+                "use_cases",
+                reason=(
+                    f"Changes were requested: {latest_review_comment}"
+                    if latest_review_comment
+                    else "Use cases must be approved before a test-suite update or export."
+                ),
+                primary=True,
+            )
+        )
+
+    if has_baseline_test_suite and upstream_changed:
+        review_pending = bool(actions)
+        if impact_state and impact_state.current_snapshot_id and not impact_state.stale:
+            apply_blockers = _impact_apply_blockers(project)
+            actions.append(
+                _action(
+                    "apply_update",
+                    "Apply Accepted Updates",
+                    "test_cases",
+                    reason="Impact analysis is current; apply accepted update/add/deprecate recommendations to produce the next test-case snapshot.",
+                    primary=not review_pending,
+                    secondary=review_pending,
+                    blockers=apply_blockers,
+                )
+            )
+            if review_pending:
+                actions.append(
+                    _action(
+                        "analyze_impact",
+                        "Analyze Impact",
+                        "impact_analysis",
+                        reason="Impact analysis can be rerun while upstream reviews are pending; applying changes still requires approval.",
+                        secondary=True,
+                    )
+                )
+        else:
+            actions.append(
+                _action(
+                    "analyze_impact",
+                    "Analyze Impact",
+                    "impact_analysis",
+                    reason="Upstream requirements/use cases changed after the baseline suite was generated.",
+                    primary=not review_pending,
+                    secondary=review_pending,
+                )
+            )
+        actions.append(_full_regenerate_action(full_regenerate_blockers))
+        return actions
+
+    if actions:
+        if actions[0].stage == "use_cases":
+            actions.append(_full_regenerate_action(full_regenerate_blockers))
         return actions
 
     if not use_cases_state or not use_cases_state.current_snapshot_id:
@@ -536,28 +574,17 @@ def _build_actions(project: QaProjectDetail, *, has_baseline_test_suite: bool, u
         )
         return actions
 
-    if not _use_cases_human_approved(use_cases_state) or use_cases_state.stale:
-        latest_human_review = _matching_use_case_human_review(use_cases_state)
-        latest_review_comment = (
-            str(latest_human_review.get("comment") or "").strip()
-            if isinstance(latest_human_review, dict) and latest_human_review.get("decision") == "request_changes"
-            else ""
-        )
-        actions.append(
+    if use_cases_state.stale:
+        return [
             _action(
-                "approve",
-                "Approve Use Cases",
-                "use_cases",
-                reason=(
-                    f"Changes were requested: {latest_review_comment}"
-                    if latest_review_comment
-                    else "Use cases must be approved before a test-suite update or export."
-                ),
+                "refine",
+                "Refresh Use Cases",
+                "test_cases",
+                reason="Use cases are stale. Refresh the generated coverage before reviewing a new snapshot.",
                 primary=True,
-            )
-        )
-        actions.append(_full_regenerate_action(full_regenerate_blockers))
-        return actions
+            ),
+            _full_regenerate_action(full_regenerate_blockers),
+        ]
 
     if not has_baseline_test_suite:
         actions.append(

--- a/backend/app/services/workspace_summary_service.py
+++ b/backend/app/services/workspace_summary_service.py
@@ -194,6 +194,7 @@ def _deduplicate_work_items(items: list[WorkspaceWorkItem]) -> list[WorkspaceWor
 def _sort_work_items(items: list[WorkspaceWorkItem]) -> list[WorkspaceWorkItem]:
     items.sort(key=lambda item: (item.project_id, item.stage, item.current_snapshot_id or ""))
     items.sort(key=lambda item: item.updated_at, reverse=True)
+    items.sort(key=lambda item: not item.primary)
     items.sort(key=lambda item: not item.enabled)
     return items
 

--- a/backend/tests/test_orchestrator_service.py
+++ b/backend/tests/test_orchestrator_service.py
@@ -15,7 +15,8 @@ from test_use_case_review_service import FakeFirestoreClient, _run_transaction
 
 from app.models import AuthUser, OrchestratorStatusResponse
 from app.services.orchestrator_service import build_orchestrator_status, get_project_orchestrator_status
-from app.services.workflow_project_service import append_stage_snapshot, create_project
+from app.services.workflow_project_service import append_stage_snapshot, create_project, get_project
+from app.services.workspace_summary_service import build_workspace_summary
 
 
 class FakeSnapshot:
@@ -314,20 +315,57 @@ class OrchestratorServiceTests(unittest.TestCase):
         self.assertTrue(full_regenerate.secondary)
         self.assertTrue(full_regenerate.enabled)
 
-    def test_unapproved_changed_upstream_can_still_run_impact_analysis(self) -> None:
+    def test_unapproved_changed_upstream_prioritizes_review_and_keeps_optional_analysis(self) -> None:
         project = self._seed_baseline_suite()
         self._append_requirements(project.project_id, approved=False, title="Requirements v2")
 
         status = get_project_orchestrator_status(project.project_id, actor=self.actor)
 
+        review = self._action(status, "approve")
         analyze = self._action(status, "analyze_impact")
-        full_regenerate = self._action(status, "full_regenerate")
         self.assertTrue(status.has_baseline_test_suite)
         self.assertTrue(status.upstream_changed)
-        self.assertEqual(status.current_stage, "impact_analysis")
-        self.assertTrue(analyze.primary)
+        self.assertEqual(status.current_stage, "requirements")
+        self.assertEqual(review.label, "Review Requirements")
+        self.assertTrue(review.primary)
+        self.assertTrue(review.enabled)
+        self.assertFalse(analyze.primary)
+        self.assertTrue(analyze.secondary)
         self.assertTrue(analyze.enabled)
-        self.assertTrue(full_regenerate.secondary)
+        self.assertFalse(self._action(status, "full_regenerate").enabled)
+
+        summary = build_workspace_summary([get_project(project.project_id, actor=self.actor)], work_items_limit=50, runs_limit=20, reports_limit=20)
+        self.assertEqual(summary.continue_working.action, "approve")
+        self.assertEqual(summary.continue_working.stage, "requirements")
+        self.assertEqual(summary.continue_working.reason, review.reason)
+        self.assertEqual(summary.projects[0].current_stage, "requirements")
+
+    def test_current_use_case_review_precedes_analysis_after_requirements_are_approved(self) -> None:
+        project = self._seed_baseline_suite()
+        self._append_use_cases(project.project_id, approved=True, human_reviewed=False)
+        status = get_project_orchestrator_status(project.project_id, actor=self.actor)
+        self.assertEqual(status.current_stage, "use_cases")
+        self.assertEqual(self._action(status, "approve").label, "Review Use Cases")
+        self.assertTrue(self._action(status, "analyze_impact").secondary)
+
+        self._append_requirements(project.project_id, approved=False, title="Requirements v2")
+        status = get_project_orchestrator_status(project.project_id, actor=self.actor)
+        self.assertEqual(status.current_stage, "requirements")
+
+        self._append_requirements(project.project_id, approved=True, title="Requirements approved")
+        status = get_project_orchestrator_status(project.project_id, actor=self.actor)
+        self.assertTrue(status.stages["use_cases"].stale)
+        self.assertEqual(status.current_stage, "impact_analysis")
+        self.assertFalse(any(a.action == "approve" and a.stage == "use_cases" for a in status.next_actions))
+
+    def test_stale_use_cases_without_suite_route_to_refresh_instead_of_disabled_approval(self) -> None:
+        project = self._seed_first_generation_ready()
+        self._append_requirements(project.project_id, title="Requirements v2")
+        status = get_project_orchestrator_status(project.project_id, actor=self.actor)
+        self.assertEqual(status.current_stage, "test_cases")
+        self.assertEqual(status.next_actions[0].label, "Refresh Use Cases")
+        self.assertFalse(any(a.action == "approve" for a in status.next_actions))
+        self.assertTrue(self._action(status, "full_regenerate").enabled)
 
     def test_current_impact_analysis_recommends_apply_update(self) -> None:
         project = self._seed_baseline_suite()
@@ -363,7 +401,11 @@ class OrchestratorServiceTests(unittest.TestCase):
         status = get_project_orchestrator_status(project.project_id, actor=self.actor)
 
         apply_update = self._action(status, "apply_update")
-        self.assertTrue(apply_update.primary)
+        self.assertFalse(apply_update.primary)
+        self.assertTrue(apply_update.secondary)
+        self.assertEqual(status.current_stage, "requirements")
+        self.assertTrue(self._action(status, "approve").primary)
+        self.assertTrue(self._action(status, "analyze_impact").enabled)
         self.assertFalse(apply_update.enabled)
         self.assertEqual(apply_update.blockers[0].code, "missing_approval")
         self.assertEqual(apply_update.blockers[0].source_stage, "requirements")

--- a/docs/codebase/ARCHITECTURE.md
+++ b/docs/codebase/ARCHITECTURE.md
@@ -221,15 +221,26 @@ metadata from `backend/app/agents/specialist_registry.py`. The status service
 does not call agents or decide human approvals; those remain explicit gates
 represented as blockers.
 
-Incremental impact updates are first-class orchestrator decisions. When a
-baseline suite exists and downstream test cases are stale because requirements
-or use cases changed, the orchestrator recommends impact analysis as the primary
-path and keeps full regeneration secondary. Impact analysis can run before the
-changed upstream artifact is approved, but apply is blocked until the changed
-requirement/use-case stage and changed items are approved. Once
-`impact.update.apply` writes the new test-case snapshot sourced from the current
-impact snapshot, the suite is no longer treated as needing another incremental
-update.
+Required reviews take precedence over downstream work, including when a baseline
+suite or current impact analysis exists. Pending requirements recommend Review
+Requirements; after approval, current use cases awaiting human review recommend
+Review Use Cases. Stale use cases follow the impact/refresh path rather than an
+approval that cannot be performed. Home, Reviews and Overview use the same
+recommendations and action/stage destinations, with explicit Open Requirements,
+Open Use Cases and other workbench labels. Overview navigation does not execute
+agents or save approvals.
+
+With upstream reviews complete, a changed baseline recommends incremental impact
+analysis (or accepted updates when analysis is current), keeping full regeneration
+secondary. Analysis remains an optional action during upstream review. Apply,
+generation and export approval gates remain in force. Once impact.update.apply
+writes a test-case snapshot sourced from the current impact snapshot, another
+incremental update is no longer recommended.
+
+Saving requirement reviews or applying an import refreshes both project guidance
+and workspace summaries. Request sequences, identity/project scopes and minimum
+observed project revisions reject obsolete responses. Failed refreshes retain
+saved requirements and surface a refresh error instead of showing outdated tasks.
 
 Orchestrator run persistence flow:
 

--- a/docs/github-issues-backlog.md
+++ b/docs/github-issues-backlog.md
@@ -1,5 +1,7 @@
 # GitHub Issue Backlog for Test Case Engine Improvements
 
+- Implemented; PR review pending: [#296](https://github.com/lumensparkxy/agentic_test_case_generator/issues/296) — Prioritize required reviews and route workbench actions consistently across Overview, Home and Reviews; refresh guidance after requirements changes. Follows #294 / PR #295. Phase 4 - Operational Readiness; P2.
+
 - Implemented; PR review pending: [#294](https://github.com/lumensparkxy/agentic_test_case_generator/issues/294) — Preserve project requirements with source-independent Import → Compare → Apply, stable identities, scoped retirement, atomic persistence, and an explicit recovery preview. Phase 4 - Operational Readiness; P1.
 
 - Implemented; PR review pending: #292 — Remove the Next task pane from Test Cases; retain Overview and compact guarded workflow controls. Parent #241.

--- a/docs/project-design.md
+++ b/docs/project-design.md
@@ -144,3 +144,7 @@ Validation: `e2e/improve-tests.spec.js` covers checklist feedback, navigation/fo
 ## Test Cases task controls (#292)
 
 Next task remains on Overview. Test Cases omits the task card, recommendation narrative and technical details. Compact workflow controls retain generation and impact actions, with optional actions under More actions and the existing regeneration confirmation, busy-state and approval safeguards. Template Setup continues to hide these controls.
+
+### Required-action navigation (#296)
+
+Overview prioritizes Review Requirements, then reviewable current Use Cases, before downstream impact work. Impact analysis remains optional while reviews are pending. Workbench links name their destination and share the action/stage resolver across Overview, Home and Reviews. Navigation moves keyboard focus to the destination and never performs analysis, generation or approval. Review/import commits refresh guidance; stale responses cannot replace a newer project revision.

--- a/frontend/e2e/contextual-next-action.spec.js
+++ b/frontend/e2e/contextual-next-action.spec.js
@@ -593,3 +593,236 @@ test.describe("Contextual next task", () => {
 		expect(requests.generation).toBe(1);
 	});
 });
+
+function reviewScenario() {
+	const project = projectFixture();
+	project.stage_state.requirements.approved = false;
+	project.current_snapshots.requirements.payload.requirements = [1, 2].map((n) => ({
+		id: `REQ-00${n}`,
+		requirement_uid: `requirement-${n}`,
+		text: `Review incoming behavior ${n}.`,
+		review_status: "Needs Review",
+		quality_flags: [],
+	}));
+	const action = recommendation("approve", {
+		stage: "requirements",
+		label: "Review Requirements",
+		primary: true,
+		secondary: false,
+		reason: "Review the two incoming requirements before applying changes.",
+	});
+	const status = statusFixture([
+		action,
+		...staleActions()
+			.slice(0, 2)
+			.map((a) => ({ ...a, primary: false, secondary: true })),
+	]);
+	status.current_stage = "requirements";
+	status.stages.requirements.approved = false;
+	status.stages.requirements.status = "attention_required";
+	return { project, status };
+}
+
+function workspaceForScenario(scenario) {
+	const primary = scenario.status.next_actions.find((a) => a.primary);
+	const item = {
+		...primary,
+		work_item_id: "next-review",
+		project_id: PROJECT_ID,
+		project_name: scenario.project.name,
+		project_revision: scenario.project.current_revision,
+		kind: ["approve", "review"].includes(primary.action) ? "review" : "action",
+		status: "attention_required",
+		current_snapshot_id: "current",
+		updated_at: scenario.project.updated_at,
+	};
+	return {
+		continue_working: item,
+		projects: [{ ...scenario.project, project_revision: scenario.project.current_revision, current_stage: primary.stage }],
+		work_items: [item],
+		recent_runs: [],
+		recent_reports: [],
+	};
+}
+
+for (const entry of ["overview", "home", "reviews"]) {
+	test(`${entry} opens the action's workbench without executing it`, async ({ page }) => {
+		const scenario = reviewScenario();
+		await installApi(page, scenario);
+		await page.route("**/workspace/summary?*", (route) => route.fulfill({ json: workspaceForScenario(scenario) }));
+		await seedAuthenticatedSession(page);
+		const mutations = [];
+		page.on("request", (request) => {
+			if (["POST", "PATCH", "DELETE"].includes(request.method()) && /\/(projects|testcases|automation)\//.test(request.url()))
+				mutations.push(request.url());
+		});
+		for (const [action, stage, destination, label] of [
+			["approve", "requirements", "requirements", "Requirements"],
+			["refine", "requirements", "requirements", "Requirements"],
+			["approve", "use_cases", "use-cases", "Use Cases"],
+			["review", "requirements", "requirements", "Requirements"],
+			["review", "use_cases", "use-cases", "Use Cases"],
+			["analyze_impact", "impact_analysis", "test-cases", "Test Cases"],
+			["apply_update", "test_cases", "test-cases", "Test Cases"],
+			["generate", "test_cases", "test-cases", "Test Cases"],
+			["review", "review", "test-cases", "Test Cases"],
+			["automate", "automation", "automation", "Automation"],
+			["execute", "execution", "automation", "Automation"],
+			["report", "reports", "reports", "Reports"],
+		]) {
+			scenario.status.next_actions = [recommendation(action, { stage, primary: true, secondary: false })];
+			scenario.status.current_stage = stage;
+			await page.goto(entry === "overview" ? buildProjectPath(PROJECT_ID) : entry === "home" ? "/" : "/reviews");
+			const container =
+				entry === "overview"
+					? page.getByLabel("Contextual task")
+					: entry === "home"
+						? page.getByRole("region", { name: "Continue working" })
+						: page.getByRole("main");
+			const link = container.getByRole(entry === "overview" ? "button" : "link", {
+				name: entry === "reviews" ? /^Open .* for / : `Open ${label}`,
+				exact: entry !== "reviews",
+			});
+			await expect(link).toHaveText(`Open ${label}`);
+			await link.focus();
+			await page.keyboard.press("Enter");
+			await expect(page).toHaveURL(new RegExp(`/projects/${PROJECT_ID}/${destination}$`));
+			await expect(page.locator("#main-content")).toBeFocused();
+		}
+		expect(mutations).toEqual([]);
+	});
+}
+
+test("reviewing requirements advances Overview and Home without reload and keeps optional analysis", async ({ page }) => {
+	const scenario = reviewScenario();
+	await installApi(page, scenario);
+	const summaryRevisions = [];
+	await page.route("**/workspace/summary?*", (route) => {
+		summaryRevisions.push(scenario.project.current_revision);
+		return route.fulfill({ json: workspaceForScenario(scenario) });
+	});
+	await page.route(`**/projects/${PROJECT_ID}/requirements/reviews`, (route) => {
+		const changes = route.request().postDataJSON().reviews;
+		for (const change of changes)
+			Object.assign(
+				scenario.project.current_snapshots.requirements.payload.requirements.find((r) => r.requirement_uid === change.requirement_uid),
+				change
+			);
+		scenario.project.current_revision++;
+		scenario.status.project_revision = scenario.project.current_revision;
+		const approved = scenario.project.current_snapshots.requirements.payload.requirements.every((r) => r.review_status === "Approved");
+		scenario.project.stage_state.requirements.approved = approved;
+		if (approved) {
+			scenario.status.next_actions = staleActions();
+			scenario.status.current_stage = "impact_analysis";
+		}
+		return route.fulfill({ json: scenario.project });
+	});
+	await seedAuthenticatedSession(page);
+	await page.goto(buildProjectPath(PROJECT_ID));
+	const task = page.getByLabel("Contextual task");
+	await expect(task.getByRole("heading", { name: "Review Requirements" })).toBeVisible();
+	await task.locator("summary").click();
+	await expect(task.getByRole("button", { name: "Analyze Impact", exact: true })).toBeEnabled();
+	await task.getByRole("button", { name: "Open Requirements", exact: true }).click();
+	for (const id of ["REQ-001", "REQ-002"]) {
+		await page.getByLabel(`Review status for ${id}`, { exact: true }).selectOption("Approved");
+		await expect(page.getByLabel(`Review status for ${id}`, { exact: true })).toBeEnabled();
+	}
+	await expect.poll(() => summaryRevisions.includes(10)).toBe(true);
+	await page.getByRole("link", { name: "Overview", exact: true }).click();
+	await expect(task.getByRole("heading", { name: "Analyze Impact" })).toBeVisible();
+	await expect(task.getByRole("button", { name: "Open Test Cases" })).toBeEnabled();
+	await page.getByRole("link", { name: "Home", exact: true }).click();
+	await expect(page.getByRole("region", { name: "Continue working" }).getByRole("link", { name: "Open Test Cases" })).toBeVisible();
+	await page.goto(buildProjectPath(PROJECT_ID));
+	await page.reload();
+	await expect(task.getByRole("heading", { name: "Analyze Impact" })).toBeVisible();
+});
+
+function approveScenarioRequirements(scenario) {
+	for (const row of scenario.project.current_snapshots.requirements.payload.requirements) row.review_status = "Approved";
+	scenario.project.stage_state.requirements.approved = true;
+	scenario.project.current_revision = 9;
+	scenario.status = { ...scenario.status, project_revision: 9, current_stage: "impact_analysis", next_actions: staleActions() };
+}
+
+test("late pre-review guidance cannot replace newer recommendations after leaving and reopening the project", async ({ page }) => {
+	const scenario = reviewScenario();
+	const oldStatus = structuredClone(scenario.status);
+	const oldSummary = workspaceForScenario(scenario);
+	await installApi(page, scenario);
+	let releaseStatus;
+	let releaseSummary;
+	const statusGate = new Promise((resolve) => {
+		releaseStatus = resolve;
+	});
+	const summaryGate = new Promise((resolve) => {
+		releaseSummary = resolve;
+	});
+	let heldStatus = false;
+	let heldSummary = false;
+	await page.route(`**/projects/${PROJECT_ID}/orchestrator/status`, async (route) => {
+		if (scenario.project.current_revision === 9 && !heldStatus) {
+			heldStatus = true;
+			await statusGate;
+			return route.fulfill({ json: oldStatus });
+		}
+		return route.fulfill({ json: scenario.status });
+	});
+	await page.route("**/workspace/summary?*", async (route) => {
+		if (scenario.project.current_revision === 9 && !heldSummary) {
+			heldSummary = true;
+			await summaryGate;
+			return route.fulfill({ json: oldSummary }).catch(() => {});
+		}
+		return route.fulfill({ json: workspaceForScenario(scenario) });
+	});
+	await page.route(`**/projects/${PROJECT_ID}/requirements/reviews`, (route) => {
+		expect(route.request().postDataJSON().reviews).toHaveLength(2);
+		approveScenarioRequirements(scenario);
+		return route.fulfill({ json: scenario.project });
+	});
+	await seedAuthenticatedSession(page);
+	await page.goto(buildProjectPath(PROJECT_ID, "requirements"));
+	await page.getByRole("button", { name: "Approve non-rejected", exact: true }).click();
+	await expect.poll(() => heldStatus && heldSummary).toBe(true);
+	await page.getByRole("link", { name: "Home", exact: true }).click();
+	await page.getByRole("region", { name: "Continue working" }).getByRole("link", { name: "Open Test Cases", exact: true }).click();
+	await expect(page.getByRole("button", { name: "Start analysis", exact: true })).toBeVisible();
+	const oldResponse = page.waitForResponse((response) => response.url().endsWith("/orchestrator/status"));
+	releaseStatus();
+	releaseSummary();
+	await oldResponse;
+	await page.getByRole("link", { name: "Overview", exact: true }).click();
+	await expect(page.getByLabel("Contextual task").getByRole("heading", { name: "Analyze Impact" })).toBeVisible();
+	await expect(page.getByRole("heading", { name: "Review Requirements", exact: true })).toHaveCount(0);
+});
+
+test("older revision responses fail visibly while committed requirement approvals survive", async ({ page }) => {
+	const scenario = reviewScenario();
+	const oldStatus = structuredClone(scenario.status);
+	const oldSummary = workspaceForScenario(scenario);
+	let stale = true;
+	await installApi(page, scenario);
+	await page.route(`**/projects/${PROJECT_ID}/orchestrator/status`, (route) =>
+		route.fulfill({ json: stale ? oldStatus : scenario.status })
+	);
+	await page.route("**/workspace/summary?*", (route) => route.fulfill({ json: stale ? oldSummary : workspaceForScenario(scenario) }));
+	await page.route(`**/projects/${PROJECT_ID}/requirements/reviews`, (route) => {
+		approveScenarioRequirements(scenario);
+		return route.fulfill({ json: scenario.project });
+	});
+	await seedAuthenticatedSession(page);
+	await page.goto(buildProjectPath(PROJECT_ID, "requirements"));
+	await page.getByRole("button", { name: "Approve non-rejected", exact: true }).click();
+	await expect(page.getByLabel("Review status for REQ-001", { exact: true })).toHaveValue("Approved");
+	await page.getByRole("link", { name: "Overview", exact: true }).click();
+	await expect(
+		page.getByText("Workflow guidance is out of date. Reload the latest project before continuing.", { exact: true })
+	).toBeVisible();
+	await expect(page.getByLabel("Contextual task").getByRole("button", { name: "Open Requirements" })).toHaveCount(0);
+	stale = false;
+	await page.getByRole("link", { name: "Home", exact: true }).click();
+	await expect(page.getByRole("region", { name: "Continue working" }).getByRole("link", { name: "Open Test Cases" })).toBeVisible();
+});

--- a/frontend/e2e/orchestrator-lifecycle.spec.js
+++ b/frontend/e2e/orchestrator-lifecycle.spec.js
@@ -19,6 +19,8 @@ function requirement(index, changed = false) {
 	const id = `REQ-${String(index).padStart(3, "0")}`;
 	return {
 		id,
+		requirement_uid: `lifecycle-${id}`,
+		quality_flags: [],
 		text: changed
 			? `${id} changed payment retry and approval behavior shall be validated.`
 			: `${id} baseline checkout behavior shall be validated.`,
@@ -494,7 +496,35 @@ function statusForPhase(phase) {
 async function mockLifecycleApi(page) {
 	let phase = "empty";
 	let parseCount = 0;
-	const projects = () => (phase === "none" ? [] : [projectSummary(projectForPhase(phase))]);
+	let pendingImport = null;
+	let reviewPending = false;
+	let reviewRevisions = 0;
+	const currentProject = () => {
+		const project = projectForPhase(phase);
+		project.current_revision += reviewRevisions;
+		if (reviewPending) {
+			project.stage_state.requirements.approved = false;
+			for (const row of project.current_snapshots.requirements.payload.requirements) {
+				if (phase === "requirements" || ["REQ-003", "REQ-010"].includes(row.id)) row.review_status = "Needs Review";
+			}
+		}
+		return project;
+	};
+	const currentStatus = () => {
+		const status = statusForPhase(phase);
+		status.project_revision = currentProject().current_revision;
+		if (reviewPending) {
+			status.current_stage = "requirements";
+			status.stages.requirements.approved = false;
+			status.stages.requirements.status = "attention_required";
+			status.next_actions = [
+				action("approve", "Review Requirements", "requirements", { primary: true }),
+				...(phase === "stale" ? [action("analyze_impact", "Analyze Impact", "impact_analysis", { secondary: true })] : []),
+			];
+		}
+		return status;
+	};
+	const projects = () => (phase === "none" ? [] : [projectSummary(currentProject())]);
 
 	await page.route("**/*", async (route) => {
 		const url = new URL(route.request().url());
@@ -535,27 +565,62 @@ async function mockLifecycleApi(page) {
 		}
 		if (url.pathname === "/projects" && method === "POST") {
 			phase = "empty";
-			return jsonResponse(route, projectForPhase(phase));
+			return jsonResponse(route, currentProject());
 		}
 		if (url.pathname === `/projects/${PROJECT_ID}` && method === "GET") {
-			return jsonResponse(route, projectForPhase(phase));
+			return jsonResponse(route, currentProject());
 		}
 		if (url.pathname === `/projects/${PROJECT_ID}/orchestrator/status`) {
-			return jsonResponse(route, statusForPhase(phase));
+			return jsonResponse(route, currentStatus());
 		}
-		if (url.pathname === "/requirements/parse") {
-			parseCount += 1;
-			phase = parseCount === 1 ? "requirements" : "stale";
-			const changed = parseCount > 1;
+		if (url.pathname === "/workspace/summary") {
 			return jsonResponse(route, {
-				raw_text: "Synthetic lifecycle requirements.",
-				requirements: requirements(changed),
-				review: review(),
-				coverage_metrics: { total_requirements: 10, approved_count: 10, shall_format_ratio: 1.0 },
-				workflow_diagnostics: null,
-				workflow_settings: null,
-				iteration_history: [],
+				projects: [{ ...projectSummary(currentProject()), project_revision: currentProject().current_revision }],
+				work_items: [],
+				recent_runs: [],
+				recent_reports: [],
 			});
+		}
+		if (url.pathname === `/projects/${PROJECT_ID}/requirement-imports`) {
+			return jsonResponse(route, pendingImport ? [pendingImport] : []);
+		}
+		if (url.pathname.endsWith("/requirement-imports/lifecycle-import/apply")) {
+			phase = parseCount === 1 ? "requirements" : "stale";
+			reviewPending = true;
+			pendingImport = null;
+			return jsonResponse(route, currentProject());
+		}
+		if (url.pathname === `/projects/${PROJECT_ID}/requirements/reviews`) {
+			reviewPending = false;
+			reviewRevisions++;
+			return jsonResponse(route, currentProject());
+		}
+		if (url.pathname === "/requirements/parse" || url.pathname === "/requirements/refine") {
+			parseCount++;
+			const changed = parseCount > 1;
+			pendingImport = {
+				import_id: "lifecycle-import",
+				project_id: PROJECT_ID,
+				base_project_revision: currentProject().current_revision,
+				source_name: "Lifecycle requirements",
+				recovery_snapshot_ids: [],
+				operation: "requirements.parse",
+				status: "pending",
+				created_at: "2026-09-12T12:00:00Z",
+				current_requirements: changed ? requirements() : [],
+				suggested_update_scope: [],
+				counts: {},
+				warnings: [],
+				candidates: requirements(changed).map((row) => ({
+					candidate_id: row.id,
+					requirement: row,
+					classification: !changed ? "new" : ["REQ-003", "REQ-010"].includes(row.id) ? "updated" : "unchanged",
+					target_requirement_uid: changed ? row.requirement_uid : null,
+					reason: "Compare lifecycle requirement text.",
+					suggestions: [],
+				})),
+			};
+			return jsonResponse(route, pendingImport);
 		}
 		if (url.pathname === "/testcases/generate") {
 			phase = "suite";
@@ -576,11 +641,11 @@ async function mockLifecycleApi(page) {
 		}
 		if (url.pathname === `/projects/${PROJECT_ID}/impact-analysis`) {
 			phase = "analysis";
-			return jsonResponse(route, projectForPhase(phase));
+			return jsonResponse(route, currentProject());
 		}
 		if (url.pathname === `/projects/${PROJECT_ID}/impact-update/apply`) {
 			phase = "applied";
-			return jsonResponse(route, projectForPhase(phase));
+			return jsonResponse(route, currentProject());
 		}
 		if (url.pathname === "/automation/execution/preview") {
 			return jsonResponse(route, {
@@ -661,11 +726,10 @@ test.describe("Orchestrator lifecycle validation", () => {
 
 		await page.locator('input[type="file"]').setInputFiles(sampleRequirementsFile);
 		await page.getByRole("button", { name: /^Parse Requirements$/ }).click();
-		await expect(page.getByLabel("Review status for REQ-001")).toHaveValue("Approved");
-		const approveButton = page.getByRole("button", { name: /approve non-rejected/i });
-		if (await approveButton.isVisible().catch(() => false)) {
-			await approveButton.click();
-		}
+		await page.getByRole("button", { name: "Apply reviewed changes", exact: true }).click();
+		await expect(page.getByLabel("Review status for REQ-001", { exact: true })).toHaveValue("Needs Review");
+		await page.getByRole("button", { name: /approve non-rejected/i }).click();
+		await expect(page.getByLabel("Review status for REQ-001", { exact: true })).toHaveValue("Approved");
 
 		await page
 			.getByRole("navigation", { name: "Project navigation" })
@@ -688,6 +752,10 @@ test.describe("Orchestrator lifecycle validation", () => {
 			.getByPlaceholder(/Enter your feedback here/i)
 			.fill("Change REQ-003 and REQ-010 to include payment retry and approval behavior.");
 		await page.getByRole("button", { name: /Implement Changes/i }).click();
+		await page.getByRole("button", { name: "Apply reviewed changes", exact: true }).click();
+		await expect(page.getByLabel("Contextual task").getByRole("heading", { name: "Review Requirements" })).toBeVisible();
+		await page.getByRole("button", { name: /approve non-rejected/i }).click();
+		await expect(page.getByLabel("Review status for REQ-003", { exact: true })).toHaveValue("Approved");
 
 		await page
 			.getByRole("navigation", { name: "Project navigation" })
@@ -730,7 +798,7 @@ test.describe("Orchestrator lifecycle validation", () => {
 			.getByRole("link", { name: /^Overview$/i })
 			.click();
 		task = page.getByLabel("Contextual task");
-		await task.getByRole("button", { name: /^Open workbench$/i }).click();
+		await task.getByRole("button", { name: /^Open (Requirements|Use Cases|Test Cases|Automation|Reports)$/i }).click();
 		await expect(page.getByRole("heading", { name: /^Export Test Cases$/ })).toBeVisible();
 		await page.getByRole("button", { name: /JSON/i }).click();
 		await expect(page.getByText(/Exported to JSON successfully/i)).toBeVisible();

--- a/frontend/e2e/report-evidence.spec.js
+++ b/frontend/e2e/report-evidence.spec.js
@@ -255,7 +255,7 @@ test.describe("Report evidence", () => {
 
 		const task = page.getByLabel("Contextual task");
 		await expect(task.getByRole("heading", { name: /^Regenerate Evidence Report$/ })).toBeVisible();
-		await expect(task.getByRole("button", { name: /^Open workbench$/ })).toBeVisible();
+		await expect(task.getByRole("button", { name: /^Open (Requirements|Use Cases|Test Cases|Automation|Reports)$/ })).toBeVisible();
 
 		await expect(page.getByLabel("Project information rail")).toHaveCount(0);
 		await expect(page.getByRole("button", { name: "Open QA project menu" })).toContainText("Report Evidence QA");

--- a/frontend/e2e/requirement-import-review.spec.js
+++ b/frontend/e2e/requirement-import-review.spec.js
@@ -70,7 +70,37 @@ async function setup(page, { candidates = incoming, revision = 7, failedApply = 
 	};
 	let pending = pendingOnLoad ? [preview] : [];
 	const applies = [];
+	const guidanceReads = [];
+	const summaryReads = [];
 	await installWorkspaceApi(page, { summary: workspaceSummaryFixture({ projects: [summary] }), projectDetails: { [ID]: project } });
+	await page.route(`**/projects/${ID}/orchestrator/status`, (route) => {
+		guidanceReads.push(project.current_revision);
+		const pending = project.current_snapshots.requirements.payload.requirements.some((r) => r.review_status !== "Approved");
+		return route.fulfill({
+			json: {
+				project_id: ID,
+				project_revision: project.current_revision,
+				stages: {},
+				next_actions: pending
+					? [
+							{
+								action: "approve",
+								stage: "requirements",
+								label: "Review Requirements",
+								primary: true,
+								enabled: true,
+								reason: "Review incoming requirements before applying changes.",
+							},
+						]
+					: [],
+			},
+		});
+	});
+	await page.route("**/workspace/summary?*", (route) => {
+		summaryReads.push(project.current_revision);
+		return route.fulfill({ json: workspaceSummaryFixture({ projects: [{ ...summary, project_revision: project.current_revision }] }) });
+	});
+
 	await page.route(`**/projects/${ID}`, (route) => route.fulfill({ json: project }));
 	await page.route(`**/projects/${ID}/requirement-imports`, (route) => route.fulfill({ json: pending }));
 	await page.route("**/requirements/parse", (route) => {
@@ -129,7 +159,15 @@ async function setup(page, { candidates = incoming, revision = 7, failedApply = 
 		project = {
 			...project,
 			current_revision: 8,
-			stage_state: { ...project.stage_state, test_cases: { ...project.stage_state.test_cases, stale: true } },
+			stage_state: {
+				...project.stage_state,
+				requirements: {
+					...project.stage_state.requirements,
+					current_snapshot_id: "combined",
+					approved: rows.every((r) => r.review_status === "Approved"),
+				},
+				test_cases: { ...project.stage_state.test_cases, stale: true },
+			},
 			current_snapshots: {
 				...project.current_snapshots,
 				requirements: { snapshot_id: "combined", payload: { requirements: rows, retired_requirements: retired, import_changes: counts } },
@@ -140,7 +178,7 @@ async function setup(page, { candidates = incoming, revision = 7, failedApply = 
 	});
 	await page.goto(`/projects/${ID}/requirements`);
 	await expect(page.getByRole("heading", { name: "Requirement Review Workbench" })).toBeVisible();
-	return { applies, preview, getProject: () => project };
+	return { applies, preview, guidanceReads, summaryReads, getProject: () => project };
 }
 
 async function stage(page) {
@@ -164,6 +202,11 @@ test("stages eight plus two, applies ten, and retains IDs and approvals after re
 	expect(state.applies[0].update_scope).toEqual([]);
 	expect(state.getProject().stage_state.test_cases.stale).toBeTruthy();
 	expect(state.getProject().current_snapshots.test_cases.payload.test_cases).toHaveLength(1);
+	await expect.poll(() => state.guidanceReads.includes(8) && state.summaryReads.includes(8)).toBe(true);
+	await page.getByRole("link", { name: "Overview", exact: true }).click();
+	await expect(page.getByLabel("Contextual task").getByRole("heading", { name: "Review Requirements" })).toBeVisible();
+	await page.getByRole("button", { name: "Open Requirements", exact: true }).click();
+
 	await page.reload();
 	await expect(workbench(page).getByRole("row")).toHaveCount(11);
 });

--- a/frontend/e2e/responsive-reflow.spec.js
+++ b/frontend/e2e/responsive-reflow.spec.js
@@ -252,7 +252,9 @@ test.describe("Responsive project shell", () => {
 
 			await expect(heading).toHaveText("Overview");
 			await expect(page.locator(".project-page-header")).toContainText(PROJECT_NAME);
-			await expect(page.getByLabel("Contextual task").getByRole("button", { name: /^Open workbench$/i })).toBeVisible();
+			await expect(
+				page.getByLabel("Contextual task").getByRole("button", { name: /^Open (Requirements|Use Cases|Test Cases|Automation|Reports)$/i })
+			).toBeVisible();
 			await expect(page.getByLabel("Project information rail")).toHaveCount(0);
 			await expectExactlyOneCurrent(globalNavigation);
 			await expectExactlyOneCurrent(projectNavigation);
@@ -272,7 +274,12 @@ test.describe("Responsive project shell", () => {
 
 			if ([390, 760].includes(viewport.width)) {
 				await expectWithinInitialViewport(heading, page);
-				await expectWithinInitialViewport(page.getByLabel("Contextual task").getByRole("button", { name: /^Open workbench$/i }), page);
+				await expectWithinInitialViewport(
+					page
+						.getByLabel("Contextual task")
+						.getByRole("button", { name: /^Open (Requirements|Use Cases|Test Cases|Automation|Reports)$/i }),
+					page
+				);
 			}
 
 			await expectNoDocumentOverflow(page, `${viewport.width}px project overview`);

--- a/frontend/e2e/review-inbox.spec.js
+++ b/frontend/e2e/review-inbox.spec.js
@@ -236,7 +236,7 @@ test.describe("Global Review Inbox", () => {
 		await expect(
 			useCaseRow.getByRole("heading", {
 				level: 3,
-				name: new RegExp(`${USE_CASE_PROJECT.name}.*Use Cases.*Review approvals`, "i"),
+				name: new RegExp(`${USE_CASE_PROJECT.name}.*Use Cases.*Review Use Cases`, "i"),
 			})
 		).toBeVisible();
 		await expect(useCaseRow.getByRole("link", { name: new RegExp(`Open .* for ${USE_CASE_PROJECT.name}`, "i") })).toHaveAttribute(

--- a/frontend/e2e/use-case-review.spec.js
+++ b/frontend/e2e/use-case-review.spec.js
@@ -168,8 +168,8 @@ test.describe("Use Cases review workbench", () => {
 		await page.goto(buildProjectPath(USE_CASE_PROJECT_ID));
 
 		const task = page.getByLabel("Contextual task");
-		await expect(task.getByRole("heading", { name: /^Approve Use Cases$/i })).toBeVisible({ timeout: 30_000 });
-		await task.getByRole("button", { name: /^Open workbench$/i }).click();
+		await expect(task.getByRole("heading", { name: /^Review Use Cases$/i })).toBeVisible({ timeout: 30_000 });
+		await task.getByRole("button", { name: /^Open Use Cases$/i }).click();
 
 		await expect(page).toHaveURL(buildProjectPath(USE_CASE_PROJECT_ID, "use-cases"));
 		await expect(reviewMain(page)).toBeVisible();
@@ -201,7 +201,7 @@ test.describe("Use Cases review workbench", () => {
 		await expect(
 			page.getByRole("navigation", { name: "Project navigation" }).getByRole("link", { name: /^Use Cases, Awaiting review$/i })
 		).toBeVisible();
-		await expect(page.getByLabel("Contextual task").getByRole("heading", { name: /^Approve Use Cases$/i })).toBeVisible();
+		await expect(page.getByLabel("Contextual task").getByRole("heading", { name: /^Review Use Cases$/i })).toBeVisible();
 		await page
 			.getByRole("navigation", { name: "Project navigation" })
 			.getByRole("link", { name: /^Requirements,/i })

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -244,6 +244,8 @@ export default function App() {
 	const projectRouteRequestRef = useRef(0);
 	const projectCreateRequestRef = useRef(0);
 	const projectListRequestRef = useRef(0);
+	const orchestratorRequestRef = useRef(0);
+	const projectRevisionsRef = useRef({ identity: "", projects: new Map() });
 	const projectOperationScopeRef = useRef({ projectId: "", userId: "", generation: 0 });
 	const projectOperationUserRef = useRef("");
 	const workflowMainRef = useRef(null);
@@ -521,6 +523,16 @@ export default function App() {
 	const currentProjectId = currentProject?.project_id || "";
 	const currentProjectRevision = Number.isInteger(currentProject?.current_revision) ? currentProject.current_revision : null;
 	projectOperationUserRef.current = currentUser?.sub || "";
+	if (projectRevisionsRef.current.identity !== projectOperationUserRef.current) {
+		projectRevisionsRef.current = { identity: projectOperationUserRef.current, projects: new Map() };
+	}
+	const recordProjectRevision = (projectId, revision) => {
+		if (projectId && Number.isInteger(revision)) {
+			projectRevisionsRef.current.projects.set(projectId, Math.max(revision, projectRevisionsRef.current.projects.get(projectId) || 0));
+		}
+	};
+	const isLatestProjectRevision = (projectId, revision) => revision >= (projectRevisionsRef.current.projects.get(projectId) || 0);
+	recordProjectRevision(currentProjectId, currentProjectRevision);
 	const syncProjectOperationScope = () => {
 		const browserRoute = typeof window === "undefined" ? route : parseWorkflowRoute(window.location.pathname);
 		const browserProjectId = browserRoute.kind === "project" ? browserRoute.projectId : "";
@@ -822,9 +834,12 @@ export default function App() {
 			const project = await res.json();
 			if (!isProjectOperationCurrent(operationScope)) return;
 			requirementReviewAttempt.current = null;
+			if (!isLatestProjectRevision(project.project_id, project.current_revision)) return;
+			recordProjectRevision(project.project_id, project.current_revision);
 			setCurrentProject(project);
 			hydrateProjectWorkflow(project);
 			setStatus("Requirement review saved.");
+			await refreshRequirementGuidance(project, operationScope);
 		} catch (error) {
 			if (isProjectOperationCurrent(operationScope)) setStatus(error.message);
 		} finally {
@@ -1397,6 +1412,7 @@ export default function App() {
 		isRefreshing: isWorkspaceSummaryRefreshing,
 		refresh: refreshWorkspaceSummary,
 		retry: retryWorkspaceSummary,
+		invalidateProject: invalidateWorkspaceProject,
 	} = useWorkspaceSummary({
 		request: apiRequest,
 		enabled: isAuthenticated && !isVerifyingSession,
@@ -1590,6 +1606,12 @@ export default function App() {
 	};
 
 	const loadProjectOrchestrator = async (projectId, { silent = false, routeRequestId = null, operationScope = null } = {}) => {
+		const requestId = ++orchestratorRequestRef.current;
+		const requestUserId = projectOperationUserRef.current;
+		const requestIsCurrent = () =>
+			requestId === orchestratorRequestRef.current &&
+			requestUserId === projectOperationUserRef.current &&
+			isProjectRequestCurrent(projectId, { routeRequestId, operationScope });
 		if (!projectId || !isAuthenticated) {
 			setOrchestratorStatus(null);
 			setOrchestratorError("");
@@ -1605,14 +1627,18 @@ export default function App() {
 				throw new Error(errorMessage);
 			}
 			const statusPayload = await statusRes.json();
-			if (!isProjectRequestCurrent(projectId, { routeRequestId, operationScope })) {
+			if (!requestIsCurrent() || statusPayload?.project_id !== projectId) {
 				return null;
 			}
+			if (!isLatestProjectRevision(projectId, statusPayload.project_revision)) {
+				throw new Error("Workflow guidance is out of date. Reload the latest project before continuing.");
+			}
+			recordProjectRevision(projectId, statusPayload.project_revision);
 			setOrchestratorStatus(statusPayload || null);
 			setOrchestratorError("");
 			return { status: statusPayload || null };
 		} catch (error) {
-			if (!isProjectRequestCurrent(projectId, { routeRequestId, operationScope })) {
+			if (!requestIsCurrent()) {
 				return null;
 			}
 			setOrchestratorStatus(null);
@@ -1622,9 +1648,18 @@ export default function App() {
 			}
 			return null;
 		} finally {
-			if (!silent && isProjectRequestCurrent(projectId, { routeRequestId, operationScope })) {
+			if (requestIsCurrent()) {
 				setIsLoadingOrchestrator(false);
 			}
+		}
+	};
+
+	const refreshRequirementGuidance = async (project, operationScope) => {
+		setOrchestratorStatus(null);
+		invalidateWorkspaceProject(project.project_id, project.current_revision);
+		const results = await Promise.all([loadProjectOrchestrator(project.project_id, { operationScope }), refreshWorkspaceSummary()]);
+		if (isProjectOperationCurrent(operationScope) && results.some((result) => !result)) {
+			setStatus("Requirements saved. Workflow guidance could not be refreshed; reload the latest project before continuing.");
 		}
 	};
 
@@ -1702,6 +1737,10 @@ export default function App() {
 			if (!data?.project_id || data.project_id !== projectId) {
 				throw new Error("The project response did not match the requested project.");
 			}
+			if (!isLatestProjectRevision(projectId, data.current_revision)) {
+				throw new Error("The project response is out of date. Reload the latest project before continuing.");
+			}
+			recordProjectRevision(projectId, data.current_revision);
 			setCurrentProject(data || null);
 			if (hydrate && data) {
 				hydrateProjectWorkflow(data);
@@ -1755,7 +1794,10 @@ export default function App() {
 		if (!operationScope || operationScope.projectId !== projectId || !isProjectOperationCurrent(operationScope)) {
 			return null;
 		}
+		if (committedStatus && !isLatestProjectRevision(projectId, committedStatus.project_revision)) committedStatus = null;
 		if (committedStatus) {
+			recordProjectRevision(projectId, committedStatus.project_revision);
+			invalidateWorkspaceProject(projectId, committedStatus.project_revision);
 			setOrchestratorStatus(committedStatus);
 		}
 		const requestIsCurrent = () => isProjectOperationCurrent(operationScope);
@@ -1775,7 +1817,7 @@ export default function App() {
 			!workspaceSummary ? "Home and review inbox" : null,
 		].filter(Boolean);
 		if (failedRefreshes.length) {
-			if (committedStatus) {
+			if (committedStatus && isLatestProjectRevision(projectId, committedStatus.project_revision)) {
 				setOrchestratorStatus(committedStatus);
 			}
 			const prefix = committedStatus ? "Decision saved, but" : "Reload incomplete:";
@@ -2508,7 +2550,14 @@ export default function App() {
 		currentProjectId,
 		isAuthenticated && !isVerifyingSession,
 		async (project, didApply = true) => {
-			if (project.project_id !== currentProjectId) return;
+			const operationScope = captureProjectOperationScope();
+			if (
+				project.project_id !== currentProjectId ||
+				operationScope?.projectId !== project.project_id ||
+				!isLatestProjectRevision(project.project_id, project.current_revision)
+			)
+				return;
+			recordProjectRevision(project.project_id, project.current_revision);
 			setCurrentProject(project);
 			hydrateProjectWorkflow(project);
 			rememberGeneration("requirements", project.current_snapshots?.requirements?.payload || {});
@@ -2517,7 +2566,7 @@ export default function App() {
 					? "Reviewed requirements applied. Existing downstream artifacts are retained; review their impact before regenerating."
 					: "Comparison refreshed against the current project. Review the new decisions before applying."
 			);
-			await refreshCurrentProject({ hydrate: false });
+			await refreshRequirementGuidance(project, operationScope);
 		}
 	);
 

--- a/frontend/src/app/workflowRoutes.js
+++ b/frontend/src/app/workflowRoutes.js
@@ -266,8 +266,33 @@ export function resolveOrchestratorDestination(recommendation) {
 	}
 
 	const action = normalizeKey(recommendation.action);
-	if (action === "approve" || action === "refine") {
+	if (["approve", "refine", "review"].includes(action)) {
 		return getDestinationForStage(recommendation.stage) || null;
 	}
 	return ACTION_DESTINATION[action] || getDestinationForStage(recommendation.stage) || null;
+}
+
+export function getWorkbenchNavigationLabel(recommendation) {
+	const destination = resolveOrchestratorDestination(recommendation);
+	const label = PROJECT_NAV_ITEMS.find((item) => item.id === destination)?.label;
+	return label ? `Open ${label}` : "Open Overview";
+}
+
+export function getReviewActionTitle(recommendation) {
+	const stage = normalizeKey(recommendation?.stage);
+	const action = normalizeKey(recommendation?.action);
+	if (action === "review" && ["requirements", "use_cases"].includes(stage)) {
+		return stage === "requirements" ? "Review Requirements" : "Review Use Cases";
+	}
+	if (action === "refine") {
+		return { requirements: "Refine Requirements", use_cases: "Refine Use Cases", test_cases: "Refresh Use Cases" }[stage];
+	}
+	if (action === "approve") {
+		return {
+			requirements: "Review Requirements",
+			use_cases: "Review Use Cases",
+			test_cases: "Review and Approve Test Cases",
+		}[stage];
+	}
+	return null;
 }

--- a/frontend/src/components/projects/ContextualTaskCard.jsx
+++ b/frontend/src/components/projects/ContextualTaskCard.jsx
@@ -5,10 +5,9 @@ import { List, ListItem } from "../ui/collections";
 import { useEffect, useRef, useState } from "react";
 
 import { formatTaskLabel, formatTaskProvenance, getTaskProvenance } from "./contextualTask";
+import { getWorkbenchNavigationLabel, getReviewActionTitle } from "../../app/workflowRoutes";
 
 const ACTION_CTA_LABELS = Object.freeze({
-	refine: "Open workbench",
-	approve: "Open workbench",
 	generate: "Start generation",
 	analyze_impact: "Start analysis",
 	apply_update: "Apply accepted changes",
@@ -21,7 +20,7 @@ const ACTION_CTA_LABELS = Object.freeze({
 const normalizeList = (value) => (Array.isArray(value) ? value : []);
 
 function actionLabel(action) {
-	return action?.label || formatTaskLabel(action?.action) || "Continue workflow";
+	return getReviewActionTitle(action) || action?.label || formatTaskLabel(action?.action) || "Continue workflow";
 }
 
 function firstBlocker(action) {
@@ -29,8 +28,8 @@ function firstBlocker(action) {
 }
 
 function actionCtaLabel(action, navigationOnly = false) {
-	if (navigationOnly) {
-		return "Open workbench";
+	if (navigationOnly || ["approve", "refine"].includes(action?.action)) {
+		return getWorkbenchNavigationLabel(action);
 	}
 	return ACTION_CTA_LABELS[action?.action] || "Continue";
 }

--- a/frontend/src/components/reviews/ReviewInbox.jsx
+++ b/frontend/src/components/reviews/ReviewInbox.jsx
@@ -15,6 +15,7 @@ import {
 	normalizeWorkspaceList,
 } from "../workspace/workspacePresentation";
 import { ProjectOpenLink } from "../workspace/WorkspacePrimitives";
+import { getWorkbenchNavigationLabel } from "../../app/workflowRoutes";
 
 const COMPLETED_STATUSES = new Set(["approved", "completed", "passed"]);
 const STAGE_ORDER = Object.freeze([
@@ -131,7 +132,7 @@ function ReviewInboxRow({ item, onOpenProject }) {
 				className="workspace-open-link review-inbox-open-link"
 				ariaLabel={`Open ${taskTitle} for ${item.project_name || "project"}`}
 			>
-				Open workbench
+				{getWorkbenchNavigationLabel(item)}
 			</ProjectOpenLink>
 		</ListItem>
 	);

--- a/frontend/src/components/workspace/HomeWorkspaceSections.jsx
+++ b/frontend/src/components/workspace/HomeWorkspaceSections.jsx
@@ -1,6 +1,7 @@
 import { List, ListItem, CollectionState } from "../ui/collections";
 import { Button } from "../ui/controls";
 import { useState } from "react";
+import { getWorkbenchNavigationLabel } from "../../app/workflowRoutes";
 import { Activity, ClipboardCheck, FileText, FolderKanban, PlayCircle } from "lucide-react";
 
 import { PROJECT_DESTINATIONS } from "../../app/workflowRoutes";
@@ -49,7 +50,7 @@ export function ContinueWorkingSection({
 						onOpenProject={onOpenProject}
 						className="workspace-open-link workspace-primary-link"
 					>
-						Continue
+						{getWorkbenchNavigationLabel(item)}
 					</ProjectOpenLink>
 				</div>
 			) : (
@@ -121,7 +122,7 @@ export function MyWorkSection({
 												{formatWorkItemCount(item) ? <span className="workspace-count">{formatWorkItemCount(item)}</span> : null}
 											</div>
 											<ProjectOpenLink projectId={item.project_id} destination={getWorkItemDestination(item)} onOpenProject={onOpenProject}>
-												Open
+												{getWorkbenchNavigationLabel(item)}
 											</ProjectOpenLink>
 										</ListItem>
 									))}

--- a/frontend/src/components/workspace/workspacePresentation.js
+++ b/frontend/src/components/workspace/workspacePresentation.js
@@ -1,4 +1,10 @@
-import { PROJECT_DESTINATIONS, buildProjectPath, getDestinationForStage, resolveOrchestratorDestination } from "../../app/workflowRoutes";
+import {
+	PROJECT_DESTINATIONS,
+	buildProjectPath,
+	getDestinationForStage,
+	resolveOrchestratorDestination,
+	getReviewActionTitle,
+} from "../../app/workflowRoutes";
 
 const STATUS_LABELS = Object.freeze({
 	not_started: "Not started",
@@ -82,6 +88,8 @@ export const getWorkItemDestination = (item) =>
 export const getProjectDestination = (project) => getDestinationForStage(project?.current_stage) || PROJECT_DESTINATIONS.OVERVIEW;
 
 export const getWorkItemTitle = (item) => {
+	const reviewTitle = getReviewActionTitle(item);
+	if (reviewTitle) return reviewTitle;
 	if (item?.action && ACTION_LABELS[item.action]) return ACTION_LABELS[item.action];
 	if (item?.kind === "review") return `Review ${formatWorkspaceLabel(item.stage, "project work").toLowerCase()}`;
 	return `${formatWorkspaceLabel(item?.stage, "Project work")} needs attention`;

--- a/frontend/src/hooks/useWorkspaceSummary.js
+++ b/frontend/src/hooks/useWorkspaceSummary.js
@@ -14,6 +14,8 @@ const isAbortError = (error) => error?.name === "AbortError";
 export default function useWorkspaceSummary({ request, enabled = true, identity = "" } = {}) {
 	const requestRef = useRef(request);
 	const activeRequestRef = useRef({ controller: null, sequence: 0 });
+	const revisionsRef = useRef({ identity, projects: new Map() });
+	if (revisionsRef.current.identity !== identity) revisionsRef.current = { identity, projects: new Map() };
 	const [state, setState] = useState(INITIAL_STATE);
 	requestRef.current = request;
 
@@ -38,6 +40,18 @@ export default function useWorkspaceSummary({ request, enabled = true, identity 
 			if (activeRequestRef.current.sequence !== sequence || controller.signal.aborted) {
 				return null;
 			}
+			const rows = [...summary.projects, ...summary.work_items, ...(summary.continue_working ? [summary.continue_working] : [])];
+			if (rows.some((row) => row.project_revision < (revisionsRef.current.projects.get(row.project_id) || 0))) {
+				throw new Error("Workflow guidance is out of date. Refresh to load the latest project reviews.");
+			}
+			for (const row of rows) {
+				if (Number.isInteger(row.project_revision)) {
+					revisionsRef.current.projects.set(
+						row.project_id,
+						Math.max(row.project_revision, revisionsRef.current.projects.get(row.project_id) || 0)
+					);
+				}
+			}
 			setState({ identity, summary, status: "success", error: "" });
 			return summary;
 		} catch (error) {
@@ -53,6 +67,13 @@ export default function useWorkspaceSummary({ request, enabled = true, identity 
 			return null;
 		}
 	}, [enabled, identity]);
+
+	const invalidateProject = useCallback((projectId, revision) => {
+		revisionsRef.current.projects.set(projectId, Math.max(revision, revisionsRef.current.projects.get(projectId) || 0));
+		activeRequestRef.current.controller?.abort();
+		activeRequestRef.current.sequence++;
+		setState(INITIAL_STATE);
+	}, []);
 
 	const clear = useCallback(() => {
 		activeRequestRef.current.controller?.abort();
@@ -85,5 +106,6 @@ export default function useWorkspaceSummary({ request, enabled = true, identity 
 		refresh,
 		retry: refresh,
 		clear,
+		invalidateProject,
 	};
 }

--- a/frontend/src/pages/ReviewsPage.jsx
+++ b/frontend/src/pages/ReviewsPage.jsx
@@ -1,6 +1,6 @@
 import { Button } from "../components/ui/controls";
 import { RefreshCw } from "lucide-react";
-import { useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import ReviewInbox from "../components/reviews/ReviewInbox";
 import { formatWorkspaceDate } from "../components/workspace/workspacePresentation";
@@ -9,6 +9,13 @@ import { WorkspaceErrorState, WorkspaceLoadingState } from "../components/worksp
 export default function ReviewsPage({ summary, isLoading = false, isRefreshing = false, error = "", onRetry, onRefresh, onOpenProject }) {
 	const headingRef = useRef(null);
 	const refreshButtonRef = useRef(null);
+	const [restoreRefreshFocus, setRestoreRefreshFocus] = useState(false);
+	useEffect(() => {
+		if (restoreRefreshFocus && !isLoading && !isRefreshing) {
+			refreshButtonRef.current?.focus();
+			setRestoreRefreshFocus(false);
+		}
+	}, [restoreRefreshFocus, isLoading, isRefreshing]);
 
 	const retryAndRestoreFocus = async () => {
 		await onRetry?.();
@@ -16,7 +23,7 @@ export default function ReviewsPage({ summary, isLoading = false, isRefreshing =
 	};
 	const refreshAndRestoreFocus = async () => {
 		await onRefresh?.();
-		window.requestAnimationFrame(() => refreshButtonRef.current?.focus());
+		setRestoreRefreshFocus(true);
 	};
 	const errorMessage = error && summary ? `${error} Refresh failed; showing the last available review queue.` : error;
 


### PR DESCRIPTION
Closes #296. Follows #294; this PR is based on PR #295 and must merge after it.

Projects with a baseline suite could recommend Analyze Impact even when requirements needed review, sending Open workbench to Test Cases. Required requirement reviews now take priority, followed by current use-case reviews. Stale use cases follow refresh/impact guidance; analysis remains optional and existing mutation approval gates stay intact.

Overview, Home and Reviews use explicit destination labels and the shared action/stage resolver. Review and import commits refresh guidance, and project revision/request guards reject obsolete responses. Overview navigation performs no workflow action. Review-inbox refresh restores keyboard focus after the control is re-enabled.

Validation:
- Backend unittest suite: 454 passed (repo-local venv; local ADK guidance disabled for deterministic tests).
- Strict offline requirements, generation and orchestrator benchmarks: passed.
- OpenAPI export, generated frontend API type check, Ruff lint/format, frontend lint/format and build: passed.
- Required Home/workflow browser gate: 211 passed; adjacent orchestrator, impact and report regressions: 5 passed. The lifecycle fixture now exercises staged imports and explicit requirement reviews.
- Live local project: Overview shows Review Requirements and Open Requirements reaches both pending reviews; project remains revision 7.

The existing frontend bundle-size advisory remains. No API schema or persistence migration is needed. Both required CI checks passed on ac9026b: Backend tests and offline benchmarks; Frontend build and focused E2E. [CI run](https://github.com/lumensparkxy/agentic_test_case_generator/actions/runs/34693139730).
